### PR TITLE
Nav element shadow fix

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -2463,6 +2463,7 @@ nav {
     line-height: 56px; } }
 @media only screen and (min-width: 480px) {
   nav {
+    z-index:1;
     height: 64px;
     line-height: 64px; } }
 @font-face {


### PR DESCRIPTION
This is not meant to actually be merged as the change needs to happen higher up in the SASS files.

Just wanted to point out that there appears to be a z-index issue with the shadow on the nav element. 

Simply shifting the z-index to 1, or a similar solution, will bring the shadow on top of that sub navigation div.
