### PR TITLE
Hide border for <button> with .btn class

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -6041,6 +6041,7 @@ ul.tabs li.tab {
   background-clip: padding-box;
   line-height: 36px;
   text-transform: uppercase;
+  border: none;
 }
 
 .btn.disabled, .disabled.btn-large, .btn-floating.disabled, .btn-large.disabled {


### PR DESCRIPTION
If you use the .btn class at a <button>, you can still see the border of the <button> because of the standard style of it. By doing border:none at the class you basically get rid of that border.
