### PR TITLE
Change font to RobotoDraft + inherit color

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -6417,7 +6417,7 @@ ul.collapsible {
 input {
   background-color: transparent;
   border: none;
-  border-bottom: 1px solid #bdbdbd;
+  border-bottom: 1px solid #757575;
   outline: none;
   height: 3em;
   width: 100%;
@@ -6438,10 +6438,10 @@ input {
 }
 
 input:focus {
-  border-bottom: 1px solid #00BCD4;
-  -webkit-box-shadow: 0 1px 0 0 #00BCD4;
-  -moz-box-shadow: 0 1px 0 0 #00BCD4;
-  box-shadow: 0 1px 0 0 #00BCD4;
+  border-bottom: 1px solid #4059a9;
+  -webkit-box-shadow: 0 1px 0 0 #4059a9;
+  -moz-box-shadow: 0 1px 0 0 #4059a9;
+  box-shadow: 0 1px 0 0 #4059a9;
 }
 
 /***************


### PR DESCRIPTION
The new font which is used in Material Design is called "RobotoDraft". You are currently using the old font called "Roboto". You can add RobotoDraft font by adding this to your page (or copy the contents of this file to your own .css file):
    <link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&lang=en' rel='stylesheet' type='text/css'>

Also, whenever you use the h1 tag for example, you were restricted to 1 color (#212121) unless you overwrite that. The html tag uses #212121 too, so you could use inherit the color instead.
