### PR TITLE
Wait for document to be ready before calling `displayEffect()`

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -260,6 +260,9 @@
     };
 
     window.Waves = Waves;
-    Waves.displayEffect();
+
+    $(document).ready(function() {
+      Waves.displayEffect();
+    });
 
 })(window);


### PR DESCRIPTION
Fixes https://github.com/Dogfalo/materialize/issues/133.
