### PR TITLE
Load grid before other components

### DIFF
--- a/sass/materialize.scss
+++ b/sass/materialize.scss
@@ -8,10 +8,10 @@
 @import "components/normalize";
 
 // components
+@import "components/grid";
 @import "components/color";
 @import "components/global";
 @import "components/icons-material-design";
-@import "components/grid";
 @import "components/navbar";
 @import "components/roboto";
 @import "components/typography";


### PR DESCRIPTION
The grid was being loaded after other components and as a result some things were not working.
For example `right-align` when added to a column was not working because grid floads were being applied afterwards.
