### PR TITLE
Open modal without trigger of a button

### DIFF
--- a/jade/javascript/javascript_content.html
+++ b/jade/javascript/javascript_content.html
@@ -93,14 +93,14 @@
         <h3 class="header">Modals</h3>
         <div class="row">
           <div class="col s12">
-            <p>Use a modal for dialog boxes, confirmation messages, or other content that can be called up. In order for the modal to work you have to add the Modal ID to the link of the trigger. To add a close button, just add the class <code class="language-css">.modal_close</code> to your button.</p>
+            <p>Use a modal for dialog boxes, confirmation messages, or other content that can be called up. In order for the modal to work you have to add the Modal ID to the link of the trigger. To add a close button, just add the class <code class="language-css">.modal-close</code> to your button.</p>
             <a class="waves-effect waves-light btn modal-trigger" href="#modal1">Modal</a>
           </div>
         </div>
         <div id="modal1" class="modal">
           <h4>Modal Header</h4>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
-          <a href="#" class="waves-effect btn-flat modal-action modal_close">Agree</a>
+          <a href="#" class="waves-effect btn-flat modal-action modal-close">Agree</a>
         </div>
 
         <div class="row">
@@ -114,7 +114,7 @@
   &lt;div id="modal1" class="modal">
     &lt;h4>Modal Header&lt;/h4>
     &lt;p>A bunch of text&lt;/p>
-    &lt;a href="#" class="waves-effect btn-flat modal_close">Agree&lt;/a>
+    &lt;a href="#" class="waves-effect btn-flat modal-close">Agree&lt;/a>
   &lt;/div>
             </code></pre>
           </div>

--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -2,7 +2,7 @@
   $.fn.extend({
     openModal: function(options) {
       var modal = this;
-      var overlay = $("<div id='lean_overlay'></div>");
+      var overlay = $('<div id="lean-overlay"></div>');
       $("body").append(overlay);
 
       var defaults = {
@@ -16,17 +16,17 @@
       // Override defaults
       options = $.extend(defaults, options);
 
-      $("#lean_overlay").click(function() {
+      $("#lean-overlay").click(function() {
         closeModal(modal);
       });
 
-      $(modal).find(".modal_close").click(function(e) {
+      $(modal).find(".modal-close").click(function(e) {
         e.preventDefault();
         closeModal(modal);
       });
 
 
-      $("#lean_overlay").css({ display : "block", opacity : 0 });
+      $("#lean-overlay").css({ display : "block", opacity : 0 });
 
       $(modal).css({
         display : "block",
@@ -34,7 +34,7 @@
         opacity: 0
       });
 
-      $("#lean_overlay").velocity({opacity: options.opacity}, {duration: options.in_duration, queue: false, ease: "easeOutCubic"});
+      $("#lean-overlay").velocity({opacity: options.opacity}, {duration: options.in_duration, queue: false, ease: "easeOutCubic"});
 
       $(modal).velocity({top: "10%", opacity: 1}, {
         duration: options.in_duration,
@@ -49,10 +49,10 @@
       });
 
       function closeModal(modal_id) {
-        $("#lean_overlay").velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
+        $("#lean-overlay").velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
         $(modal_id).fadeOut(options.out_duration, function() {
           $(modal_id).css({ top: 0});
-          $("#lean_overlay").css({display:"none"});
+          $("#lean-overlay").css({display:"none"});
 
           // Call complete callback
           if (typeof(options.complete) === "function") {

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -25,7 +25,7 @@
     margin-top: 0;
   }
 }
-#lean_overlay {
+#lean-overlay {
     position: fixed;
     z-index:999;
     top: 0px;


### PR DESCRIPTION
This completes Dogfalo/materialize#187

I extracted the process of opening a new modal to a new function called `openModal()`
Now developers can do something like:

``` javascript
$(document).ready(function() {
  $("#modalToOpen").openModal();
});
```

to open the modal within Javascript.

Binding to click event is still as is.

Updated the documentation as well.
