### PR TITLE
Added generic .divider class that can be used with any list-item

### DIFF
--- a/jade/components/components_content.html
+++ b/jade/components/components_content.html
@@ -727,6 +727,7 @@
         <ul id="dropdown1" class="dropdown-content">
           <li><a href="#!">one</a></li>
           <li><a href="#!">two</a></li>
+          <li class="divider"></li>
           <li><a href="#!">three</a></li>
         </ul>
         <nav>
@@ -749,6 +750,7 @@
   &lt;ul id="dropdown1" class="dropdown-content">
     &lt;li>&lt;a href="#!">one&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">two&lt;/a>&lt;/li>
+    &lt;li class="divider">&lt;/li>
     &lt;li>&lt;a href="#!">three&lt;/a>&lt;/li>
   &lt;/ul>
   &lt;nav>

--- a/jade/javascript/javascript_content.html
+++ b/jade/javascript/javascript_content.html
@@ -164,6 +164,7 @@
             <ul id='dropdown1' class='dropdown-content'>
               <li><a href="#!">one</a></li>
               <li><a href="#!">two</a></li>
+              <li class="divider"></li>
               <li><a href="#!">three</a></li>
             </ul>
             <pre><code class="language-markup">
@@ -174,6 +175,7 @@
   &lt;ul id='dropdown1' class='dropdown-content'>
     &lt;li>&lt;a href="#!">one&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">two&lt;/a>&lt;/li>
+    &lt;li class="divider">&lt;/li>
     &lt;li>&lt;a href="#!">three&lt;/a>&lt;/li>
   &lt;/ul>
             </code></pre>

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -1,3 +1,8 @@
+li.divider {
+  height: 1px;
+  overflow: hidden;
+  background-color: color("grey", "lighten-3");
+}
 .dropdown-content {
   display:none;
   @extend .z-depth-1;


### PR DESCRIPTION
#265

Usage:

``` html
<ul id='dropdown1' class='dropdown-content'>
  <li><a href="#!">one</a></li>
  <li><a href="#!">two</a></li>
  <li class="divider"></li>
  <li><a href="#!">three</a></li>
</ul>
```

How it looks like:
![Demo](http://i.imgur.com/Uib8zaV.png?1)

Updated the documentation to show how to use `.divider` too!
