### PR TITLE
Use grunt-sass instead of grunt-contrib-sass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,94 +1,101 @@
 module.exports = function(grunt) {
- 
-  // configure the tasks
+  // tasks configuration
   grunt.initConfig({
-//  Copy
+    // copy files
     copy: {
       dist: { cwd: 'font', src: [ '**' ], dest: 'dist/font', expand: true },
     },
-    
-//  Sass
-    sass: {                              // Task
-      expanded: {                            // Target
-        options: {                       // Target options
-          style: 'expanded',
-          sourcemap: 'none'
+
+    // sass operations
+    sass: { // grunt-sass
+      expanded: {
+        options: {
+          outputStyle: 'expanded',
+          sourcemap: false,
         },
-        files: {                         
-          'dist/css/materialize.css': 'sass/materialize.scss',
+        dist: {
+          files: {
+            'dist/css/materialize.css': 'sass/materialize.scss',
+          }
         }
       },
-      
       min: {
         options: {
-          style: 'compressed',
-          sourcemap: 'none'
+          outputStyle: 'compressed',
+          sourcemap: false,
         },
-        files: {                         
-          'dist/css/materialize.min.css': 'sass/materialize.scss',
+        dist: {
+          files: {
+            'dist/css/materialize.min.css': 'sass/materialize.scss',
+          }
         }
       },
-      
-      // Compile ghpages css
+
+      // Compile ghpages CSS
       gh: {
         options: {
           style: 'compressed',
-          sourcemap: 'none'
+          sourcemap: false
         },
-        files: {
-          'css/ghpages-materialize.css': 'sass/ghpages-materialize.scss',
+        dist: {
+          files: {
+            'css/ghpages-materialize.css': 'sass/ghpages-materialize.scss',
+          }
         }
       },
-      
+
       // Compile ghpages css
       bin: {
         options: {
           style: 'expanded',
-          sourcemap: 'none'
+          sourcemap: false
         },
-        files: {
-          'bin/materialize.css': 'sass/materialize.scss',
+        dist: {
+          files: {
+            'bin/materialize.css': 'sass/materialize.scss',
+          }
         }
       }
     },
-    
-//  Concat
+
+    // Concat
     concat: {
       options: {
         separator: ';'
       },
       dist: {
         // the files to concatenate
-        src: ["js/jquery.easing.1.3.js",
-             "js/velocity.min.js",
-              "js/hammer.min.js",
-              "js/jquery.hammer.js",
-              "js/collapsible.js",
-              "js/dropdown.js",
-              "js/leanModal.js",
-              "js/materialbox.js",
-              "js/parallax.js",
-              "js/tabs.js",
-              "js/tooltip.js",
-              "js/waves.js",
-              "js/toasts.js",
-              "js/sideNav.js",
-              "js/scrollspy.js",
-              "js/forms.js",
-              "js/date_picker/picker.js",
-              "js/date_picker/picker.date.js",
-             ],
+        src: [
+        "js/jquery.easing.1.3.js",
+        "js/velocity.min.js",
+        "js/hammer.min.js",
+        "js/jquery.hammer.js",
+        "js/collapsible.js",
+        "js/dropdown.js",
+        "js/leanModal.js",
+        "js/materialbox.js",
+        "js/parallax.js",
+        "js/tabs.js",
+        "js/tooltip.js",
+        "js/waves.js",
+        "js/toasts.js",
+        "js/sideNav.js",
+        "js/scrollspy.js",
+        "js/forms.js",
+        "js/date_picker/picker.js",
+        "js/date_picker/picker.date.js",
+        ],
         // the location of the resulting JS file
         dest: 'dist/js/materialize.js'
       }
     },
 
-//  Uglify
+    //  Uglify
     uglify: {
       options: {
-              
+
         // the banner is inserted at the top of the output
-//        banner: '/*! <%= pkg.name %> <%= grunt.template.today("dd-mm-yyyy") %> */\n'
+        //        banner: '/*! <%= pkg.name %> <%= grunt.template.today("dd-mm-yyyy") %> */\n'
       },
       dist: {
         files: {
@@ -102,8 +109,7 @@ module.exports = function(grunt) {
       }
     },
 
-
-//  Compress
+    // Compress
     compress: {
       main: {
         options: {
@@ -115,18 +121,21 @@ module.exports = function(grunt) {
           { expand: true, cwd: './', src: ['LICENSE', 'README.md'], dest: 'materialize/'},
         ]
       },
-                   
       src: {
         options: {
           archive: 'bin/materialize-src.zip',
           level: 6
         },
-        files:[
+        files: [
           {expand: true, cwd: 'font/', src: ['**/*'], dest: 'materialize-src/font/'},
           {expand: true, cwd: 'sass/', src: ['materialize.scss'], dest: 'materialize-src/sass/'},
           {expand: true, cwd: 'sass/', src: ['components/**/*'], dest: 'materialize-src/sass/'},
-          {expand: true, cwd: 'js/', src: ["jquery.easing.1.3.js",
-             "velocity.min.js",
+          {
+            expand: true,
+            cwd: 'js/',
+            src: [
+              "jquery.easing.1.3.js",
+              "velocity.min.js",
               "hammer.min.js",
               "jquery.hammer.js",
               "collapsible.js",
@@ -143,23 +152,22 @@ module.exports = function(grunt) {
               "forms.js",
               "date_picker/picker.js",
               "date_picker/picker.date.js",
-             ], dest: 'materialize-src/js/'},
-        {expand: true, cwd: 'dist/js/', src: ['**/*'], dest: 'materialize-src/js/bin/'},
-        {expand: true, cwd: './', src: ['LICENSE', 'README.md'], dest: 'materialize-src/'}
-        
+            ],
+            dest: 'materialize-src/js/'
+          },
+          {expand: true, cwd: 'dist/js/', src: ['**/*'], dest: 'materialize-src/js/bin/'},
+          {expand: true, cwd: './', src: ['LICENSE', 'README.md'], dest: 'materialize-src/'}
         ]
       }
     },
-                   
-    
-//  Clean
-//    clean: {
-//      build: {
-//        src: [ 'dist/' ]
-//      },
-//    },
+    // Clean
+    // clean: {
+    //   build: {
+    //     src: [ 'dist/' ]
+    //   },
+    // },
 
-//  Jade
+    // Jade
     jade: {
       compile: {
         options: {
@@ -177,12 +185,11 @@ module.exports = function(grunt) {
           "javascript.html": "jade/javascript.jade",
           "mobile.html": "jade/mobile.jade",
           "parallax.html": "jade/parallax.jade"
-
         }
       }
-    },               
-                   
-//  Watch Files
+    },
+
+    // watchers
     watch: {
       jade: {
         files: ['jade/**/*'],
@@ -192,46 +199,45 @@ module.exports = function(grunt) {
           spawn: false,
         },
       },
-                   
+
       js: {
         files: [ "js/jquery.easing.1.3.js",
-                 "js/velocity.min.js",
-                 "js/hammer.min.js",
-                 "js/jquery.hammer.js",
-                 "js/collapsible.js",
-                 "js/dropdown.js",
-                 "js/leanModal.js",
-                 "js/materialbox.js",
-                 "js/parallax.js",
-                 "js/tabs.js",
-                 "js/tooltip.js",
-                 "js/waves.js",
-                 "js/toasts.js",
-                 "js/sideNav.js",
-                 "js/scrollspy.js",
-                 "js/forms.js",
-                 "js/date_picker/picker.js",
-                 "js/date_picker/picker.date.js",
-             ],
+        "js/velocity.min.js",
+        "js/hammer.min.js",
+        "js/jquery.hammer.js",
+        "js/collapsible.js",
+        "js/dropdown.js",
+        "js/leanModal.js",
+        "js/materialbox.js",
+        "js/parallax.js",
+        "js/tabs.js",
+        "js/tooltip.js",
+        "js/waves.js",
+        "js/toasts.js",
+        "js/sideNav.js",
+        "js/scrollspy.js",
+        "js/forms.js",
+        "js/date_picker/picker.js",
+        "js/date_picker/picker.date.js",
+        ],
         tasks: ['js_compile'],
         options: {
           interrupt: false,
           spawn: false,
         },
       },
-      
+
       sass: {
         files: ['sass/**/*'],
         tasks: ['sass_compile'],
         options: {
           interrupt: false,
           spawn: false,
-        },           
+        },
       }
     },
-                   
-                   
-//  Concurrent
+
+    // Concurrent
     concurrent: {
       options: {
         logConcurrentOutput: true
@@ -240,9 +246,9 @@ module.exports = function(grunt) {
         tasks: ["watch:jade", "watch:js", "watch:sass", "notify:watching", 'connect:server', 'notify:server']
       },
     },
-                   
-                
-//  Notifications
+
+
+    // Notifications
     notify: {
       watching: {
         options: {
@@ -253,7 +259,7 @@ module.exports = function(grunt) {
           duration: 1 // the duration of notification in seconds, for `notify-send only
         }
       },
-                   
+
       sass_compile: {
         options: {
           enabled: true,
@@ -263,7 +269,7 @@ module.exports = function(grunt) {
           duration: 2 // the duration of notification in seconds, for `notify-send only
         }
       },
-                   
+
       js_compile: {
         options: {
           enabled: true,
@@ -273,7 +279,7 @@ module.exports = function(grunt) {
           duration: 2 // the duration of notification in seconds, for `notify-send only
         }
       },
-                   
+
       jade_compile: {
         options: {
           enabled: true,
@@ -282,8 +288,8 @@ module.exports = function(grunt) {
           success: true, // whether successful grunt executions should be notified automatically
           duration: 2 // the duration of notification in seconds, for `notify-send only
         }
-      },       
-      
+      },
+
       server: {
         options: {
           enabled: true,
@@ -294,9 +300,8 @@ module.exports = function(grunt) {
         }
       }
     },
-                   
-              
-//  Server
+
+    //  Server
     connect: {
       server: {
         options: {
@@ -307,18 +312,17 @@ module.exports = function(grunt) {
         }
       }
     }
-
   });
- 
+
   // load the tasks
-//  grunt.loadNpmTasks('grunt-gitinfo');
+  // grunt.loadNpmTasks('grunt-gitinfo');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-compress');
-//  grunt.loadNpmTasks('grunt-contrib-clean');
+  // grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-jade');
   grunt.loadNpmTasks('grunt-concurrent');
   grunt.loadNpmTasks('grunt-notify');
@@ -326,11 +330,9 @@ module.exports = function(grunt) {
 
   // define the tasks
   grunt.registerTask('default', ['copy', 'sass:expanded', 'sass:min', 'concat', 'uglify:dist', 'compress:main', 'compress:src']);
-  
   grunt.registerTask('jade_compile', ['jade', 'notify:jade_compile']);
   grunt.registerTask('js_compile', ['concat:dist', 'uglify:bin', 'notify:js_compile']);
   grunt.registerTask('sass_compile', ['sass:gh', 'sass:bin', 'notify:sass_compile']);
   grunt.registerTask('start_server', ['connect:server', 'notify:server']);
-  
   grunt.registerTask("monitor", ["concurrent:monitor"]);
 };

--- a/package.json
+++ b/package.json
@@ -2,27 +2,25 @@
   "name": "Materialize-dist-build",
   "description": "Builds Materialize distribution packages",
   "author": "Alvin Wang, Alan Chang",
-  "url" : "http://materializecss.com/",
+  "url": "http://materializecss.com/",
   "version": "0.92.1",
-  
   "dependencies": {
     "grunt": "0.x.x",
     "grunt-contrib-clean": "0.5.x",
-    "grunt-contrib-connect": "0.4.x",
+    "grunt-contrib-connect": "^0.4.2",
     "grunt-contrib-copy": "0.4.x",
     "grunt-contrib-cssmin": "0.6.x",
     "grunt-contrib-jade": "0.8.x",
     "grunt-contrib-uglify": "0.2.x",
-    "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-compress": "^0.12.0",
     "grunt-contrib-watch": "^0.5.3",
     "grunt-concurrent": "^1.0.0",
-    "grunt-notify": "^0.4.1",
-    "grunt-contrib-connect": "^0.4.2"
+    "grunt-notify": "^0.4.1"
   },
   "engine": "node >= 0.10",
   "devDependencies": {
-    "grunt-gitinfo": "^0.1.7"
+    "grunt-gitinfo": "^0.1.7",
+    "grunt-sass": "^0.17.0"
   }
 }


### PR DESCRIPTION
`grunt-sass` is a lot faster than `grunt-sass-contrib` that this project is using. It's built on top of a C/C++ implementation of SASS compiler. It lacks support for SASS style, but I don't think we're using that syntax at all in this project, so it should be fine (correct me if I'm wrong!).

run `npm install` then `grunt`

From `grunt-sass` repo:

> This task uses libsass which is an experimental Sass compiler in C++. In contrast to the original Ruby compiler, this one is much faster, but is missing some features, though improving quickly. It also doesn't support Compass. Check out grunt-contrib-sass if you prefer something more stable, but slower.
