### PR TITLE
Support for non-dismissable modals

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -10,15 +10,18 @@
         in_duration: 300,
         out_duration: 200,
         ready: undefined,
-        complete: undefined
+        complete: undefined,
+        dismissable: true
       }
 
       // Override defaults
       options = $.extend(defaults, options);
 
-      $("#lean-overlay").click(function() {
-        $(modal).closeModal(options);
-      });
+      if (options.dismissable) {
+        $("#lean-overlay").click(function() {
+          $(modal).closeModal(options);
+        });
+      }
 
       $(modal).find(".modal-close").click(function(e) {
         e.preventDefault();


### PR DESCRIPTION
Hi there!

A couple days ago, I realized that I needed a modal to prompt users for acceptance on the privacy policy of my webpage, for example, to allow installation of third-party cookies.

The problem is that many users simply dismiss these kind of modals, by pressing `esc` or clicking outside the modal (in the `#lean-overlay`).

In order to disable this behaviour, a simple option can be passed to the modal, by doing:

``` javascript
$('.modal-trigger').leanModal({
  dismissable: false
});
```

... or if it was to be opened programmatically:

``` javascript
$('#cookie-policy-modal').openModal({
  dismissable: false
});
```

Along with a minimum modification on the `leanModal.js` file:

``` javascript
if (options.dismissable) {
  $("#lean-overlay").click(function() {
    $(modal).closeModal(options);
  });
}
```

By default, the `dismissable` option is set to `true`, so no previous behaviour changes at all.

I thought this could be helpful for anyone out there! (this is actually my first _open_ pull request... forgive me if the intended workflow is not this one!)

Kind regards!
