### PR TITLE
fix(_cards.scss): make card-reveal width 100% and make it scrollable

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -103,6 +103,8 @@
     padding: $card-padding;
     position: absolute;
     background-color: #FFF;
+    width: 100%;
+    overflow-y: auto;
     top: 100%;
     height: 100%;
 


### PR DESCRIPTION
When card's width is bigger, card-reveal gets broken(https://www.dropbox.com/s/csitt1eicr4uzfp/Screenshot%202015-01-11%2001.36.01.png?dl=0). It's `width` should be `100%` and it should be made `scrollable` since text doesn't have any chars limit.

Here is the screenshot for the issue: https://www.dropbox.com/s/csitt1eicr4uzfp/Screenshot%202015-01-11%2001.36.01.png?dl=0
Here is the screenshot after the changes are done: https://www.dropbox.com/s/zzm1k92guz5yvya/Screenshot%202015-01-11%2001.39.20.png?dl=0