### PR TITLE
Add .active to label elements if input has been prepopulated

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -24,6 +24,15 @@
       }
     });
 
+    // Add active if input element has been pre-populated on document ready
+    $(document).ready(function() {
+      $(input_selector).each(function(index, element) {
+        if($(element).val().length > 0) {
+          $(this).siblings('label, i').addClass('active');
+        }
+      });
+    });
+
     // Add active when element has focus
     $(document).on('focus', input_selector, function () {
       $(this).siblings('label, i').addClass('active');


### PR DESCRIPTION
If an input value has been prepopulated (as in `<input type="text" name="etc" value="Prepopulated">`), the label will overlap on top of the field value. Screenshot:

![error](http://i.imgur.com/J3mooj9.png)

This fix checks if the input_selectors have value prepopulated on document ready, and adds class="active" to their labels accordingly.