### PR TITLE
0.5em padding added to .brand-logo

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -4993,7 +4993,7 @@ nav {
     color: #fff;
     display: inline-block;
     font-size: 2.1rem;
-    padding: 0; }
+    padding: 0 0 0 0.5; }
     @media only screen and (max-width : 992px) {
       nav .brand-logo {
         left: 0;


### PR DESCRIPTION
Best responsive values 0.2em and 0.5em to give logos proper padding. 

Reason: Each new setup the logo is currently dead on left:0; requiring everyone to add/override there own logo padding each init setup per deploy.