### PR TITLE
Mixin keyframe fix

### DIFF
--- a/sass/components/_prefixer.scss
+++ b/sass/components/_prefixer.scss
@@ -117,13 +117,13 @@
 
 // Keyframes
 @mixin keyframes($animation-name) {
-  @-webkit-keyframes $animation-name {
+  @-webkit-keyframes #{$animation-name} {
     @content;
   }
-  @-moz-keyframes $animation-name {
+  @-moz-keyframes #{$animation-name} {
     @content;
   }
-  @keyframes $animation-name {
+  @keyframes #{$animation-name} {
     @content;
   }
 }
@@ -414,4 +414,3 @@
     -ms-transition-timing-function: $function;
     transition-timing-function: $function;
 }
-


### PR DESCRIPTION
This fixes the mixin @keyframes issue and allowing grunt to
successfully build this when integrated with a grunt file.