### PR TITLE
Option to display dropdown below origin

### DIFF
--- a/dropdown.html
+++ b/dropdown.html
@@ -141,7 +141,8 @@
       constrain_width: false, // Does not change width of dropdown to that of the activator
       hover: false, // Activate on click
       alignment: 'left', // Aligns dropdown to left or right edge (works with constrain_width)
-      gutter: 0 // Spacing from edge
+      gutter: 0, // Spacing from edge
+      belowOrigin: false // Displays dropdown below the button
     }
   );
         </code></pre>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -7,7 +7,8 @@
       constrain_width: true, // Constrains width of dropdown to the activator
       hover: true,
       alignment: 'left',
-      gutter: 0 // Spacing from edge
+      gutter: 0, // Spacing from edge
+      belowOrigin: false
     }
 
     options = $.extend(defaults, options);
@@ -30,6 +31,8 @@
         options.alignment = origin.data('alignment');
       if (origin.data('gutter') != undefined)
         options.gutter = origin.data('gutter');
+      if (origin.data('beloworigin') != undefined)
+        options.belowOrigin = origin.data('beloworigin');
     }
 
     updateOptions();
@@ -52,6 +55,10 @@
       if (options.constrain_width == true) {
         activates.css('width', origin.outerWidth());
       }
+      var offset = 0;
+      if (options.belowOrigin == true) {
+        offset = origin.height();
+      }
       // Handle edge alignment
       var width_difference = 0;
       var gutter_spacing = options.gutter;
@@ -64,14 +71,14 @@
           display: 'block',
           position: 'fixed',
           height: 0,
-          top: origin.offset().top - $(window).scrollTop(),
+          top: origin.offset().top - $(window).scrollTop() + offset,
           left: origin.offset().left + width_difference + gutter_spacing
         });
       }
       else {
         activates.css({
           display: 'block',
-          top: origin.offset().top,
+          top: origin.offset().top + offset,
           left: origin.offset().left + width_difference + gutter_spacing,
           height: 0
         });


### PR DESCRIPTION
#533

Usage :
```javascript
$(".dropdown-button").dropdown({
      inDuration: 300,
      outDuration: 225,
      constrain_width: false, // Does not change width of dropdown to that of the activator
      hover: false, // Activate on click
      alignment: "left", // Aligns dropdown to left or right edge (works with constrain_width)
      gutter: 0, // Spacing from edge
      belowOrigin: true,
    }
``` 
or
```html
 data-beloworigin="true"
``` 

Hope this helps !