### PR TITLE
sass: $sidenav-width to _variables and dynamic sideNav width in js

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -52,7 +52,7 @@
       $(this).each(function(){
         var $this = $(this);
         var menu_id = $("#"+ $this.attr('data-activates'));
-        var menuWidth = 240;
+        var menuWidth = - (parseInt($(menu_id).css(options.edge)) - 10);
 
         // Add alignment
         if (options.edge != 'left') {

--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -1,4 +1,3 @@
-$sidenav-width: 240px;
 @media #{$medium-and-down} {
   ul.side-nav {
     position: fixed;

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -86,6 +86,7 @@ $navbar-height-mobile: 56px !default;
 
 
 /*** SideNav ***/
+$sidenav-width: 240px !default;
 
 
 


### PR DESCRIPTION
Shouldn't the variable $sidenav-width be defined in _variables.scss, and preferably as !default?
And: dynamically getting the sideNav width in the JS.
