### PR TITLE
move sidenav-width to variables.scss

### DIFF
--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -1,4 +1,3 @@
-$sidenav-width: 240px;
 @media #{$medium-and-down} {
   ul.side-nav {
     position: fixed;

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -86,7 +86,7 @@ $navbar-height-mobile: 56px !default;
 
 
 /*** SideNav ***/
-
+$sidenav-width: 240px !default;
 
 
 /*** Tabs ***/


### PR DESCRIPTION
Shouldn't the variable $sidenav-width be defined in _variables.scss, and preferably as !default?