### PR TITLE
fix : initial dropdown height change when animation is in progress

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -40,6 +40,8 @@
       $('body').append(activates);
     }
 
+    var dropdownRealHeight = activates.height();
+
     /*
       Helper function to position and resize dropdown.
       Used in hover and click handler.
@@ -48,7 +50,6 @@
       // Check html data attributes
       updateOptions();
 
-      var dropdownRealHeight = activates.height();
       if (options.constrain_width == true) {
         activates.css('width', origin.outerWidth());
       }


### PR DESCRIPTION
if a dropdown is updated when animation is in progress the dropdownRealHeight var is set to "current height" as dropdownRealHeight was defined in the update function.
This patch set the dropdownRealHeight as object property instead.