### PR TITLE
fix events are removed in collapsible

### DIFF
--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -15,10 +15,6 @@
 
       var collapsible_type = $this.data("collapsible");
 
-      // Turn off any existing event handlers
-       $this.off();
-       $this.children().off();
-
 
        /****************
        Helper Functions


### PR DESCRIPTION
I'm not sure why those lines was there but they disallow events inside a collapsible.