### PR TITLE
fix(_buttons): parent selector on a base-level rule

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -88,7 +88,7 @@
 }
 
 // Fixed Action Button
-&.fixed-action-btn {
+.fixed-action-btn {
   position: fixed;
   right: 23px;
   bottom: 23px;
@@ -136,5 +136,3 @@
     font-size: 1.6rem;
   }
 }
-
-


### PR DESCRIPTION
Removed useless parent selector. Also was crashing with compass