### PR TITLE
fix(sidenav): Sets right percentage to negative on small screens

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -6729,7 +6729,7 @@ ul.side-nav.fixed {
   ul.side-nav.fixed {
     left: -105%; }
     ul.side-nav.fixed.right-aligned {
-      right: 105%;
+      right: -105%;
       left: auto; }
  }
 

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -6729,7 +6729,7 @@ ul.side-nav.fixed {
   ul.side-nav.fixed {
     left: -105%; }
     ul.side-nav.fixed.right-aligned {
-      right: 105%;
+      right: -105%;
       left: auto; }
  }
 

--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -74,7 +74,7 @@ ul.side-nav.fixed {
     left: -105%;
 
     &.right-aligned {
-      right: 105%;
+      right: -105%;
       left: auto;
     }
   }


### PR DESCRIPTION
To reproduce: 

* On side-nav.html
* Sets the sidenav edge to right
* Resize the screen until the menu appears
* Click on the hamburger

Then the menu will slide from left to right. This only happens the first time.