### PR TITLE
Official Meteor integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -411,6 +411,7 @@ module.exports = function(grunt) {
         src: [
           'bower.json',
           'package.json',
+          'package.js',
           'jade/**/*.html'
         ],
         overwrite: true,

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Materialize, a CSS Framework based on material design
 ## Sass Requirements:
 - Ruby Sass 3.3+, LibSass 0.6+
 
-##Supported Browsers:
+## Supported Browsers:
 Chrome 35+, Firefox 31+, Safari 7+, IE 10+
 
-##Contributing
+## Contributing
 - Issues
   - If you have an issue please make sure you document the problems in depth. One line issues with no explanations will be closed.
 - Feature Requests
   - We like feature requests but make sure that it can be seen within the goals of the project and not just something you need individually. Also you should try and give as much examples and details about the new feature as possible.
 
-##Changelog
+## Changelog
 
 - v0.95.1 (Jan 26, 2015)
   - Sidenav Fixes
@@ -60,5 +60,3 @@ Chrome 35+, Firefox 31+, Safari 7+, IE 10+
   - Sidebar bug fixes
   - Checkbox cross-browser fixes
   - Modal supports ESC closing
-
-

--- a/getting-started.html
+++ b/getting-started.html
@@ -214,7 +214,7 @@
           </code></pre>
           <p class="promo-caption">Meteor Package</p>
           <pre><code class="language-bash">
-  meteor add d0minikk:materialize-meteor
+  meteor add materialize:materialize
           </code></pre>
           <p class="promo-caption">Ember Package</p>
           <pre><code class="language-bash">
@@ -315,7 +315,7 @@
     <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
     <script>if (!window.jQuery) { document.write('<script src="bin/jquery-2.1.1.min.js"><\/script>'); }
     </script>
-    <script src="js/jquery.timeago.min.js"></script>  
+    <script src="js/jquery.timeago.min.js"></script>
     <script src="js/prism.js"></script>
     <script src="bin/materialize.js"></script>
     <script src="js/init.js"></script>

--- a/package.js
+++ b/package.js
@@ -1,0 +1,28 @@
+// package metadata file for Meteor.js
+
+Package.describe({
+  name: 'materialize:materialize',  // http://atmospherejs.com/materialize/materialize
+  summary: 'Materialize (official): A modern responsive front-end framework based on Material Design',
+  version: '0.95.1',
+  git: 'https://github.com/Dogfalo/materialize.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0');
+
+  api.use('jquery', 'client');
+
+  api.addFiles([
+    'font/material-design-icons/Material-Design-Icons.eot',
+    'font/material-design-icons/Material-Design-Icons.svg',
+    'font/material-design-icons/Material-Design-Icons.ttf',
+    'font/material-design-icons/Material-Design-Icons.woff',
+    'font/roboto/Roboto-Bold.ttf',
+    'font/roboto/Roboto-Light.ttf',
+    'font/roboto/Roboto-Medium.ttf',
+    'font/roboto/Roboto-Regular.ttf',
+    'font/roboto/Roboto-Thin.ttf',
+    'bin/materialize.css',
+    'bin/materialize.js',
+  ], 'client');
+});


### PR DESCRIPTION
Hello guys,

As you might know, the [Meteor](https://www.meteor.com/) community is loving Materialize. We have many different [wrapper packages](https://atmospherejs.com/?q=materialize) all doing the same thing but not all of them kept updated, so I'm submitting a PR that integrates Meteor packaging directly into your repository: at the end of this merge process, in case you'll find yourself comfortable with it, we'll get automated new Meteor package releases with every new release of Materialize.

I've made this PR as lean as possible so as not to take up too much space within your repository: basically it adds only a `package.js` file among the ones already present for other package managers.

All you have to do after accepting this PR would be:

1. Create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and we'll add you as a maintainer of the *materialize* organization (which has been already reserved to make things simpler for you).

2. Head to [autopublish.meteor.com](http://autopublish.meteor.com/), sign in with your GitHub account, locate this repository and enable it for autopublish by toggling the checkbox you'll find on the right side of the repository item. You can get an idea about how Meteor Autopublish works by having a quick look at [this page](http://autopublish.meteor.com/howitworks), but basically it creates a [web hook](https://help.github.com/articles/about-webhooks/) to let us know when you push new tags. When you'll release new versions, autopublish.meteor.com will automatically package the the new version of the library also for Meteor!

3. In case you're not comfortable with autopublish.meteor.com maintaining access rights to your repos, please head to [GitHub Application Settings](https://github.com/settings/applications) and revoke permissions for *Meteor Autopublish*.

Please note that you will not be able to toggle your repository until you'll have the `package.js` file on your master branch.

Please also note that we've not yet published the current version of the package on [Atmosphere](https://atmospherejs.com) (Meteor's package directory) under the new name `materialize:materialize` to wait for your approval. If you think another name would be a better fit, just let us know!

Thanks in advance for your availability and collaboration and congratulation for the awesome project!
Luca & the [Meteor Packaging Team](https://github.com/orgs/MeteorPackaging/people)