### PR TITLE
Fix SideNav button toggling behavior

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -109,6 +109,7 @@
           }
 
           // enable_scroll();
+          menu_id.removeClass('active');
         }
 
 
@@ -227,6 +228,7 @@
             }
             else {
               // disable_scroll();
+              menu_id.addClass('active');
 
               if (options.edge === 'left') {
                 $('.drag-target').css({width: '50%', right: 0, left: ''});
@@ -265,9 +267,18 @@
 
     },
     show : function() {
+      var menu_id = $("#"+ this.attr('data-activates'));
+      if (menu_id.hasClass('active')) {
+      	return;
+      }
+
       this.trigger('click');
     },
     hide : function() {
+      if ($('#sidenav-overlay').length == 0) {
+      	return;
+      }
+
       $('#sidenav-overlay').trigger('click');
     }
   };


### PR DESCRIPTION
Old behavior being fixed:
1- SideNav is not out
2- Press button to slide out
3- Press button again
=> the pane is going out with a second [third, fourth...] overlay (and with same id)

You can also call "show" several time creating the same behavior.

Note: the code looks for whether "menu_id" has CSS class "active", but class is never set nor removed.

New behavior post fix:
- SideNav is not out
- Press button to slide out
- Press button again
  => the pane is removed and overlay is removed. The button is effectively toggling.

The fix offers to add the CSS class "active" to "menu_id" when the show action is acted, and to remove the class in "removeMenu".

The fix also modifies "show" and "hide" only when the menu is in the desirable state.

Note: you probably need to regenerate your complete file + mimified versionif you accept this change
