### PR TITLE
Fix build with valid JS syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ html/
 node_modules/
 .sass-cache/
 bin/jquery-2.1.1.min.js
+/.idea/
+

--- a/js/animation.js
+++ b/js/animation.js
@@ -5,4 +5,4 @@ jQuery.extend( jQuery.easing,
 		if ((t/=d/2) < 1) return c/2*t*t + b;
 		return c/4*((t-=2)*t*t + 2) + b;
 	}
-}
+});


### PR DESCRIPTION
Fixes js syntax, so `grunt release` doesn't break.