### PR TITLE
Allow the user to fling the sidenav away

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -126,7 +126,7 @@
         var menuOut = false;
 
         $('.drag-target').hammer({
-          prevent_default: false
+          prevent_default: true
         }).bind('tap', function(e) {
           // capture overlay click on drag target
           // if (menuOut && !panning) {
@@ -191,9 +191,9 @@
           if (e.gesture.pointerType === "touch") {
             var velocityX = e.gesture.velocityX;
             panning = false;
-
             if (options.edge === 'left') {
-              if (menuOut || velocityX < -0.5) {
+              // If velocityX <= 0.3 then the user is flinging the menu closed so ignore menuOut
+              if ((menuOut && velocityX <= 0.3) || velocityX < -0.5) {
                 menu_id.velocity({left: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
                 $('#sidenav-overlay').velocity({opacity: 1 }, {duration: 50, queue: false, easing: 'easeOutQuad'});
                 $('.drag-target').css({width: '50%', right: 0, left: ''});
@@ -208,7 +208,7 @@
               }
             }
             else {
-              if (menuOut || velocityX > 0.5) {
+              if ((menuOut && velocityX >= -0.3) || velocityX > 0.5) {
                 menu_id.velocity({right: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
                 $('#sidenav-overlay').velocity({opacity: 1 }, {duration: 50, queue: false, easing: 'easeOutQuad'});
                 $('.drag-target').css({width: '50%', right: '', left: 0});
@@ -237,6 +237,7 @@
               // disable_scroll();
 
               if (options.edge === 'left') {
+                console.log('showing');
                 $('.drag-target').css({width: '50%', right: 0, left: ''});
                 menu_id.velocity({left: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
               }

--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -126,7 +126,7 @@
         var menuOut = false;
 
         $('.drag-target').hammer({
-          prevent_default: true
+          prevent_default: false
         }).bind('tap', function(e) {
           // capture overlay click on drag target
           // if (menuOut && !panning) {
@@ -237,7 +237,6 @@
               // disable_scroll();
 
               if (options.edge === 'left') {
-                console.log('showing');
                 $('.drag-target').css({width: '50%', right: 0, left: ''});
                 menu_id.velocity({left: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
               }


### PR DESCRIPTION
The ability to fling the sidenav away regressed. This fixes it again.

To test:
1) open any materialize page with a sidenav on a touch enabled device
2) attempt to quickly 'swipe' the sidenav away

Expected behaviour: the sidenav swipes away with your momentum
Actual behaviour: the sidenav bounces back

This change causes the expected behaviour to work, which seems to have regressed.