### PR TITLE
Fix for #692

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -24,7 +24,7 @@
       // Create tooltip
       var newTooltip = $('<div></div>');
       newTooltip.addClass('material-tooltip').append(tooltip_text);
-      newTooltip.appendTo($('body'));
+      newTooltip.appendTo($(this).parent());
 
       var backdrop = $('<div></div>').addClass('backdrop');
       backdrop.appendTo(newTooltip);

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -13,7 +13,9 @@
       options = $.extend(defaults, options);
 
       //Remove previously created html
-      $('.material-tooltip').remove();
+      $('.material-tooltip').remove(); // this should be removed if used in a MVC framework
+                                       // since every template will call tooltip() on his own elements
+                                       // so there is no need to destroy preiovus created tooltips
 
       return this.each(function(){
         var origin = $(this);


### PR DESCRIPTION
This fixes <a href="https://github.com/Dogfalo/materialize/issues/692">#692</a>

I suggest if possible to use the same behaviour for all components with shadow markup; appending to the parent conteainer instead of appending to 'body' allow MVC frameworks like Ember, Angular or Meteor to remove the shadow markup when the template is removed from the DOM