### PR TITLE
Fix textarea auto resize

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -69,8 +69,8 @@
 
 
     // Textarea Auto Resize
-    var hiddenDiv;
-    if ($('.hiddendiv').length === 0) {
+    var hiddenDiv = $('.hiddendiv').first();
+    if (!hiddenDiv.length) {
       hiddenDiv = $('<div class="hiddendiv common"></div>');
       $('body').append(hiddenDiv);
     }

--- a/js/forms.js
+++ b/js/forms.js
@@ -69,30 +69,31 @@
 
 
     // Textarea Auto Resize
+    var hiddenDiv;
     if ($('.hiddendiv').length === 0) {
-      var hiddenDiv = $('<div class="hiddendiv common"></div>'),
-        content = null;
-        $('body').append(hiddenDiv);
+      hiddenDiv = $('<div class="hiddendiv common"></div>');
+      $('body').append(hiddenDiv);
     }
     var text_area_selector = '.materialize-textarea';
-    $('.hiddendiv').css('width', $(text_area_selector).width());
+
+    function textareaAutoResize($textarea) {
+      hiddenDiv.text($textarea.val() + '\n');
+      var content = hiddenDiv.html().replace(/\n/g, '<br>');
+      hiddenDiv.html(content);
+      hiddenDiv.css('width', $(this).width());
+      hiddenDiv.html(hiddenDiv.html()).html(content + '<br>');
+      $textarea.css('height', hiddenDiv.height());
+    }
 
     $(text_area_selector).each(function () {
-      if ($(this).val().length) {
-        content = $(this).val();
-        content = content.replace(/\n/g, '<br>');
-        hiddenDiv.html(content + '<br>');
-        $(this).css('height', hiddenDiv.height());
+      var $textarea = $(this);
+      if ($textarea.val().length) {
+        textareaAutoResize($textarea);
       }
     });
-      $('body').on('keyup keydown',text_area_selector , function () {
-        // console.log($(this).val());
-        content = $(this).val();
-        content = content.replace(/\n/g, '<br>');
-        hiddenDiv.html(content + '<br>');
-        // console.log(hiddenDiv.html());
-        $(this).css('height', hiddenDiv.height());
-      });
+    $('body').on('keyup keydown', text_area_selector, function () {
+      textareaAutoResize($(this));
+    });
 
 
     // File Input Path


### PR DESCRIPTION
Ensure that textareas of different widths (including those initially
hidden) are resized correctly.

Ensure textareas containing html within their content are escaped
correctly when calculating the width.

Fixes #684