### PR TITLE
dropdown onClick bind fix

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -151,7 +151,8 @@
       var open = false;
 
       // Click handler to show dropdown
-      origin.click( function(e){ // Click
+      origin.unbind('click.' + origin.attr('id'));
+      origin.bind('click.'+origin.attr('id'), function(e){ // Click
         e.preventDefault(); // Prevents button click from moving window
         e.stopPropagation(); // Allows clicking on icon
         placeDropdown();


### PR DESCRIPTION
When dom data is loaded async and the dropdown functionality needs to be re-initiated via the same selector (e.g. `$('.dropdown-button').dropdown({})`)  previously bound buttons will fail to work. This fixes the problem.

But maybe a check for pre-existing binds is better?