### PR TITLE
Add missing build dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "grunt-concurrent": "^1.0.0",
     "grunt-notify": "^0.4.1",
     "grunt-text-replace": "^0.4.0",
-    "grunt-rename": "^0.1.4"
+    "grunt-rename": "^0.1.4",
+    "grunt-remove-logging": "^0.2.0"
   },
   "engine": "node >= 0.10",
   "devDependencies": {


### PR DESCRIPTION
    $ grunt release
    >> Local Npm module "grunt-remove-logging" not found. Is it installed?
    Warning: Task "removelogging:source" not found. Use --force to continue.
    
    Aborted due to warnings.
