### PR TITLE
Destroy cancel modal keypress event

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -22,7 +22,7 @@
           $(modal).closeModal(options);
         });
         // Return on ESC
-        $(document).keyup(function(e) {
+        $(document).on('keyup.leanModal', function(e) {
           if (e.keyCode === 27) {   // ESC key
             $(modal).closeModal(options);
           }
@@ -87,7 +87,7 @@
       var options = $.extend(defaults, options);
 
       $('.modal-close').off();
-      $(document).off('keyup');
+      $(document).off('keyup.leanModal');
 
       $("#lean-overlay").velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
 

--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -25,7 +25,6 @@
         $(document).keyup(function(e) {
           if (e.keyCode === 27) {   // ESC key
             $(modal).closeModal(options);
-            $(this).off();
           }
         });
       }
@@ -88,6 +87,7 @@
       var options = $.extend(defaults, options);
 
       $('.modal-close').off();
+      $(document).off('keyup');
 
       $("#lean-overlay").velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
 


### PR DESCRIPTION
Ensure modal "escape key" event handler is destroyed no matter how modal is closed