### PR TITLE
Update/clearfix

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -4807,10 +4807,13 @@ span.badge {
 .row {
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: 20px; }
-  .row:after {
-    content: "";
+  margin-bottom: 20px;
+  *zoom: 1; }
+  .row:before, .row:after {
     display: table;
+    content: "";
+    line-height: 0; }
+  .row:after {
     clear: both; }
   .row .col {
     float: left;

--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5062,8 +5062,15 @@ nav {
   nav a {
     color: #fff; }
   nav .nav-wrapper {
+    *zoom: 1;
     position: relative;
     height: 100%; }
+    nav .nav-wrapper:before, nav .nav-wrapper:after {
+      display: table;
+      content: "";
+      line-height: 0; }
+    nav .nav-wrapper:after {
+      clear: both; }
     nav .nav-wrapper i {
       font-size: 2rem; }
   @media only screen and (min-width : 993px) {

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -4807,10 +4807,13 @@ span.badge {
 .row {
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: 20px; }
-  .row:after {
-    content: "";
+  margin-bottom: 20px;
+  *zoom: 1; }
+  .row:before, .row:after {
     display: table;
+    content: "";
+    line-height: 0; }
+  .row:after {
     clear: both; }
   .row .col {
     float: left;

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5062,8 +5062,15 @@ nav {
   nav a {
     color: #fff; }
   nav .nav-wrapper {
+    *zoom: 1;
     position: relative;
     height: 100%; }
+    nav .nav-wrapper:before, nav .nav-wrapper:after {
+      display: table;
+      content: "";
+      line-height: 0; }
+    nav .nav-wrapper:after {
+      clear: both; }
     nav .nav-wrapper i {
       font-size: 2rem; }
   @media only screen and (min-width : 993px) {

--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -41,11 +41,7 @@
   margin-bottom: 20px;
 
   // Clear floating children
-  &:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
+  @include clearfix;
 
   .col {
     float: left;

--- a/sass/components/_mixins.scss
+++ b/sass/components/_mixins.scss
@@ -3,3 +3,18 @@
     -moz-box-shadow: $args1, $args2;
     box-shadow: $args1, $args2;
 }
+
+@mixin clearfix {
+  *zoom: 1;
+
+  &:before,
+  &:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+
+  &:after {
+    clear: both;
+  }
+}

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -10,6 +10,9 @@ nav {
   a { color: #fff; }
 
   .nav-wrapper {
+    // Fix floating content
+    @include clearfix;
+
     position: relative;
     height: 100%;
 


### PR DESCRIPTION
Mixin added 'clearfix' to resolve issues with elements containing float elements having no height.

Clearfix added on .nav-wrapper to resolve brand-logo position when centred and .nav-wrapper only containing float elements
