### PR TITLE
scrollSpy bugfix

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -181,7 +181,7 @@
 		    var offset = $(this.hash).offset().top + 1;
 
 //            offset-60 to handle floating fixed tab bar
-				if ($('.tabs-wrapper').length) {
+				if ($('.nav-wrapper').length) {
 			    $('html, body').animate({ scrollTop: offset-60 }, {duration: 400, easing: 'easeOutCubic'});
 				}
 				else {


### PR DESCRIPTION
Updated scrollSpy to use the correct selector when applying scrollTop
animation.

This fixes the issue where scrolling to an element while using a fixed navbar, results in the element being obscured behind the nav.