### PR TITLE
Avoid fakepath in file fields

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -110,7 +110,7 @@
     $('.file-field').each(function() {
       var path_input = $(this).find('input.file-path');
       $(this).find('input[type="file"]').change(function () {
-        path_input.val($(this).val());
+        path_input.val($(this)[0].files[0].name);
         path_input.trigger('change');
       });
     });


### PR DESCRIPTION
Chrome browser substitutes filepath for fake value. So, let's show only filename.

![forms - materialize](https://cloud.githubusercontent.com/assets/282529/6553779/33389bb2-c676-11e4-873e-882146600745.png)
