### PR TITLE
Update waves.js

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -259,7 +259,7 @@
         var target = e.target || e.srcElement;
 
         while (target.parentElement !== null) {
-            if (target.className.indexOf('waves-effect') !== -1) {
+            if (target.className.indexOf && target.className.indexOf('waves-effect') !== -1) {
                 element = target;
                 break;
             }


### PR DESCRIPTION
Fixing waves effect so it will be able not to throw errors when user taps/clicks on SVG elements.

Original issue - I am using C3 graphs and when I click on legend to switch graph series errors are thorn into console. Errors are present due to className check performed in code. There are no 'indexOf' method for SVG className property.

So I am basically checking if we could use this property.