### PR TITLE
Modified the responsive table to retain header column height on empty header cells.

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -2207,6 +2207,8 @@ td, th {
       table.responsive-table thead tr {
         display: block;
         padding: 0 10px 0 0; }
+        table.responsive-table thead tr th::before {
+          content: "\00a0"; }
     table.responsive-table tbody {
       display: block;
       width: auto;

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -2207,6 +2207,8 @@ td, th {
       table.responsive-table thead tr {
         display: block;
         padding: 0 10px 0 0; }
+        table.responsive-table thead tr th::before {
+          content: "\00a0"; }
     table.responsive-table tbody {
       display: block;
       width: auto;

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -360,6 +360,10 @@ td, th{
       tr {
         display: block;
         padding: 0 10px 0 0;
+
+        th::before {
+          content: "\00a0";
+        }
       }
     }
     tbody {


### PR DESCRIPTION
When the responsive table hits the medium-and-down breakpoint, the
header cells stack vertically. This works well, except when a header
cell is empty, the stack of cells shift up, causing the header and body
to misalign.

![image](https://cloud.githubusercontent.com/assets/698316/6600732/ab31ee9e-c7e7-11e4-8b5e-d2352fb83065.png)

This fix adds a no-break space character to td::before within thead,
keeping the table sections properly aligned.

![image](https://cloud.githubusercontent.com/assets/698316/6600738/b9ddba72-c7e7-11e4-9351-cf0d17b0c186.png)
