### PR TITLE
Generalized button seletors

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -7,12 +7,12 @@
     $(document).on('mouseenter.fixedActionBtn', '.fixed-action-btn', function(e) {
       var $this = $(this);
 
-      $this.find('ul a.btn-floating').velocity(
+      $this.find('ul .btn-floating').velocity(
         { scaleY: ".4", scaleX: ".4", translateY: "40px"},
         { duration: 0 });
 
       var time = 0;
-      $this.find('ul a.btn-floating').reverse().each(function () {
+      $this.find('ul .btn-floating').reverse().each(function () {
         $(this).velocity(
           { opacity: "1", scaleX: "1", scaleY: "1", translateY: "0"},
           { duration: 80, delay: time });
@@ -25,8 +25,8 @@
       var $this = $(this);
 
       var time = 0;
-      $this.find('ul a.btn-floating').velocity("stop", true);
-      $this.find('ul a.btn-floating').velocity(
+      $this.find('ul .btn-floating').velocity("stop", true);
+      $this.find('ul .btn-floating').velocity(
         { opacity: "0", scaleX: ".4", scaleY: ".4", translateY: "40px"},
         { duration: 80 });
     });


### PR DESCRIPTION
`a.btn-floating` is too specific. It doesn't allow the use of `button` elements for example.