### PR TITLE
Destroy select

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -227,6 +227,12 @@
         $('ul#select-options-'+lastID).remove();
       }
 
+      // If destroying the select, remove the selelct-id and reset it to it's uninitialized state.
+      if(callback === 'destroy') {
+          $select.data('select-id', null).removeClass('initialized');
+          return;
+      }
+
       var uniqueID = Materialize.guid();
       $select.data('select-id', uniqueID);
       var wrapper = $('<div class="select-wrapper"></div>');


### PR DESCRIPTION
When calling `material_select('destroy')` will remove the `ul` created for the itens, and revert the select back to its uninitialized state.

I didn't know if I had to commit the `bin/materialize.js` file or not, so I didn't.

fixes #819