### PR TITLE
Fix undesired color in buttons or collections inside cards

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -26,13 +26,13 @@
     }
   }
 
-  a {
-    color: color("orange", "accent-2");
+  a:not(.btn):not(.collection-item) {
+    color: $card-link-color;
     margin-right: $card-padding;
     @include transition(color .3s ease);
     text-transform: uppercase;
 
-    &:hover { color: lighten(color("orange", "accent-2"), 20%); }
+    &:hover { color: lighten($card-link-color, 20%); }
   }
 
   // Card Sizes

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -26,6 +26,7 @@ $button-line-height: 36px !default;
 /*** Cards ***/
 $card-padding: 20px !default;
 $card-bg-color: #fff !default;
+$card-link-color: color("orange", "accent-2") !default;
 
 /*** Collapsible ***/
 $collapsible-height: 3rem !default;


### PR DESCRIPTION
Placing a button or a collection with links in a card cause it to inherit the card link color, which is undesired. Also, card link color was exported to a variable.