### PR TITLE
Remove left floating of col from small screen

### DIFF
--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -48,7 +48,6 @@
   }
 
   .col {
-    float: left;
     @include box-sizing(border-box);
     padding: 0 $gutter-width / 2;
 
@@ -71,7 +70,7 @@
     }
 
     @media #{$medium-and-up} {
-
+      float: left;
       $i: 1;
       @while $i <= $num-cols {
         $perc: unquote((100 / ($num-cols / $i)) + "%");


### PR DESCRIPTION
The left floating for the .col does not play well in small screens. I guess float:left should be used in .col only when medium and up.