### PR TITLE
Do not close menu when it should stay open.

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -80,6 +80,10 @@
             }
           }
 
+        if (window.innerWidth > 992) {
+          menuOut = true;
+        }
+
         // Window resize to reset on large screens fixed
         if (menu_id.hasClass('fixed')) {
           $(window).resize( function() {
@@ -106,7 +110,9 @@
         // if closeOnClick, then add close event for all a tags in side sideNav
         if (options.closeOnClick == true) {
           menu_id.on("click.itemclick", "a:not(.collapsible-header)", function(){
-            removeMenu();
+            if (menuOut === true) {
+              removeMenu();
+            }
           });
         }
 


### PR DESCRIPTION
Right now when the option `closeOnClick` is true for the `sideNav` it will also close when the sidenav is not collapsed. This PR will make sure it stays open when it should.
