### PR TITLE
Fix for Issue #947.  By checking if any of the parent elements are disab...

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -260,7 +260,7 @@
 
         while (target.parentElement !== null) {
             if (!(target instanceof SVGElement) && target.className.indexOf('waves-effect') !== -1) {
-                if (target.attributes.hasOwnProperty('disabled')) {
+                if (target.attributes.hasOwnProperty('disabled') || target.className.indexOf('disabled') !== -1 ) {
                     return null;
                 }
                 element = target;

--- a/js/waves.js
+++ b/js/waves.js
@@ -260,6 +260,9 @@
 
         while (target.parentElement !== null) {
             if (!(target instanceof SVGElement) && target.className.indexOf('waves-effect') !== -1) {
+                if (target.attributes.hasOwnProperty('disabled')) {
+                    return null;
+                }
                 element = target;
                 break;
             } else if (target.classList.contains('waves-effect')) {


### PR DESCRIPTION
...led, we can disable the delegation for the icon click.

The wave-effect delegation wasn't taking into account if any of its parents were disabled.  So even if the button was disabled, a child <i> icon element would still trigger the waves-effect.

Code used to recreate issue:

```html

  <!DOCTYPE html>
  <html>
    <head>
      <!-- Compiled and minified CSS -->
      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.95.3/css/materialize.min.css">

      <!--Let browser know website is optimized for mobile-->
      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
    </head>

    <body>
    <div class="input-field right-align right">
          <button id="submitLoginForm" class="btn waves-effect waves-light blue darken-4">Login
                  <i class="mdi-content-send right"></i>
        </button>
    </div>

      <!--Import jQuery before materialize.js-->
      <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>

      <!-- Compiled and minified JavaScript -->
      <script src="assets/materialize/bin/materialize.js"></script>
          <script>
            $(document).ready(function() {
                $("#submitLoginForm").prop("disabled",true);
            });
          </script>
    </body>
  </html>
        

```