### PR TITLE
Fix for brand-logo.center when using an image.

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5063,22 +5063,20 @@ nav {
     font-size: 2.1rem;
     padding: 0; }
     nav .brand-logo.center {
-      top: 50%;
       left: 50%;
-      -webkit-transform: translate(-50%, -50%);
-      -moz-transform: translate(-50%, -50%);
-      -ms-transform: translate(-50%, -50%);
-      -o-transform: translate(-50%, -50%);
-      transform: translate(-50%, -50%); }
+      -webkit-transform: translateX(-50%);
+      -moz-transform: translateX(-50%);
+      -ms-transform: translateX(-50%);
+      -o-transform: translateX(-50%);
+      transform: translateX(-50%); }
     @media only screen and (max-width : 992px) {
       nav .brand-logo {
-        top: 50%;
         left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        -moz-transform: translate(-50%, -50%);
-        -ms-transform: translate(-50%, -50%);
-        -o-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%); } }
+        -webkit-transform: translateX(-50%);
+        -moz-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+        -o-transform: translateX(-50%);
+        transform: translateX(-50%); }
     nav .brand-logo.right {
       right: 0.5rem;
       padding: 0; }

--- a/dist/css/materialize.css
+++ b/dist/css/materialize.css
@@ -5089,22 +5089,20 @@ nav {
     font-size: 2.1rem;
     padding: 0; }
     nav .brand-logo.center {
-      top: 50%;
       left: 50%;
-      -webkit-transform: translate(-50%, -50%);
-      -moz-transform: translate(-50%, -50%);
-      -ms-transform: translate(-50%, -50%);
-      -o-transform: translate(-50%, -50%);
-      transform: translate(-50%, -50%); }
+      -webkit-transform: translateX(-50%);
+      -moz-transform: translateX(-50%);
+      -ms-transform: translateX(-50%);
+      -o-transform: translateX(-50%);
+      transform: translateX(-50%); }
     @media only screen and (max-width : 992px) {
       nav .brand-logo {
-        top: 50%;
         left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        -moz-transform: translate(-50%, -50%);
-        -ms-transform: translate(-50%, -50%);
-        -o-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%); } }
+        -webkit-transform: translateX(-50%);
+        -moz-transform: translateX(-50%);
+        -ms-transform: translateX(-50%);
+        -o-transform: translateX(-50%);
+        transform: translateX(-50%); }
     nav .brand-logo.right {
       right: 0.5rem;
       padding: 0; }

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -47,15 +47,13 @@ nav {
     padding: 0;
 
     &.center {
-      top: 50%;
       left: 50%;
-      @include transform(translate(-50%, -50%));
+      @include transform(translateX(-50%));
     }
 
     @media #{$medium-and-down} {
-      top: 50%;
       left: 50%;
-      @include transform(translate(-50%, -50%));
+      @include transform(translateX(-50%));
     }
 
     &.right {


### PR DESCRIPTION
Added a fix for horizontal centering which exhibited issues when centering an image under a brand-logo.center condition.  The vertical centering (which was unnecessary) resulted in an improperly centered image which was cut off by the top of the navigation bar boundary.

The problem would occur when embedding an image under the a#logo-container entry.  When the page width shrunk to activate the 992px media query (which caused the logo to center), the logo would be chopped off at the top.  The logo image in this case used dimensions 278x64.

Here is a test case which exposes the issue: 
```
  <nav role="navigation">
    <div class="nav-wrapper container">
      <a id="logo-container" href="#" class="brand-logo"><img class="todo-shrink-navlogo" src="Home-Logo-278x64.png"/></a>
      <ul class="right hide-on-med-and-down">
        <li><a href="#">Page 1</a></li>
      </ul>

      <ul id="nav-mobile" class="side-nav">
        <li><a href="#">Page 1</a></li>
      </ul>
    </div>
  </nav>
```