### PR TITLE
Update _typography.scss

### DIFF
--- a/sass/components/_typography.scss
+++ b/sass/components/_typography.scss
@@ -39,6 +39,7 @@ em { font-style: italic; }
 strong { font-weight: 500; }
 small { font-size: 75%; }
 .light { font-weight: 300; }
+.thin { font-weight: 200; }
 
 .flow-text{
   font-weight: 300;


### PR DESCRIPTION
Why do we have a style for light (300) font-weight, but there is no style for the thinnest 200? Maybe I don't understand? I think this should be added. One or another way.