### PR TITLE
Added manualHide on dropdown (and docs)

### DIFF
--- a/jade/page-contents/dropdown_content.html
+++ b/jade/page-contents/dropdown_content.html
@@ -62,6 +62,9 @@
               <td>beloworigin</td>
               <td>If true, the dropdown will show below the activator. Default: false</td>
             </tr>
+            <tr>
+              <td>manualHide</td>
+              <td>If set to a function, the dropdown will not be hidden by the plugin. It will call the function with the event of the click and a callback function to hide the dropdown</td>
           </tbody>
         </table>
         <p>To use these inline you have to add them as data attributes. If you want more dynamic control, you can define them using the jQuery plugin below. </p>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -12,9 +12,11 @@
       inDuration: 300,
       outDuration: 225,
       constrain_width: true, // Constrains width of dropdown to the activator
-      hover: false,
+      hover: true,
+      alignment: 'left',
       gutter: 0, // Spacing from edge
-      belowOrigin: false
+      belowOrigin: false,
+      manualHide: null,
     }
 
     options = $.extend(defaults, options);
@@ -25,18 +27,22 @@
     var activates = $("#"+ origin.attr('data-activates'));
 
     function updateOptions() {
-      if (origin.data('induration') != undefined)
+      if (origin.data('inDuration') != undefined)
         options.inDuration = origin.data('inDuration');
-      if (origin.data('outduration') != undefined)
+      if (origin.data('outDuration') != undefined)
         options.outDuration = origin.data('outDuration');
       if (origin.data('constrainwidth') != undefined)
         options.constrain_width = origin.data('constrainwidth');
       if (origin.data('hover') != undefined)
         options.hover = origin.data('hover');
+      if (origin.data('alignment') != undefined)
+        options.alignment = origin.data('alignment');
       if (origin.data('gutter') != undefined)
         options.gutter = origin.data('gutter');
       if (origin.data('beloworigin') != undefined)
         options.belowOrigin = origin.data('beloworigin');
+      if (origin.manualHide != undefined)
+        options.manualHide = origin.data('manualHide');
     }
 
     updateOptions();
@@ -64,14 +70,10 @@
       if (options.belowOrigin == true) {
         offset = origin.height();
       }
-
       // Handle edge alignment
-      var offsetLeft = origin.offset().left;
-
       var width_difference = 0;
       var gutter_spacing = options.gutter;
-
-      if (offsetLeft + activates.innerWidth() > $(window).width()) {
+      if (options.alignment == 'right') {
         width_difference = origin.innerWidth() - activates.innerWidth();
         gutter_spacing = gutter_spacing * -1;
       }
@@ -162,8 +164,15 @@
 
         $(document).bind('click.'+ activates.attr('id'), function (e) {
           if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length > 0) ) {
-            hideDropdown();
-            $(document).unbind('click.' + activates.attr('id'));
+            var fn = function() {
+              hideDropdown();
+              $(document).unbind('click.' + activates.attr('id'));
+            }
+
+            if (options.manualHide) 
+              options.manualHide(e, fn);
+            else
+              fn();
           }
         });
       });
@@ -177,8 +186,4 @@
 
    });
   }; // End dropdown plugin
-
-  $(document).ready(function(){
-    $('.dropdown-button').dropdown();
-  });
 }( jQuery ));


### PR DESCRIPTION
Added the option `manualHide` to the dropdown plugin.

This is useful in cases where you're integrating with a framework that depends on the element being available (in my case, react).

Usage:

``` javascript
$(element).dropdown({manualHide: function(evt, hideCallback) {
   // evt is the event object
  // hideCallback is the function to hide the element
});
```
