### PR TITLE
Update materialize.css

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -6637,6 +6637,8 @@ select {
     .side-nav li:hover, .side-nav li.active {
       background-color: #ddd; }
   .side-nav a {
+     display: block;
+    padding: 0 15px;
     color: #444; }
 
 .drag-target {


### PR DESCRIPTION
without this the slide-in sidenav (not fixed) has a href only for the textsize, so its very uncomfortable.