### PR TITLE
Removing active class from form labels on 'reset' trigger.

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -37,6 +37,7 @@
     $(document).on('reset', function(e) {
       if ($(e.target).is('form')) {
         $(this).find(input_selector).removeClass('valid').removeClass('invalid');
+        $(this).find(input_selector).siblings('label, i').removeClass('active');
 
         // Reset select
         $(this).find('select.initialized').each(function () {


### PR DESCRIPTION
When the reset trigger is sent to the form, it should also remove the
“active” class from any form labels.