### PR TITLE
Wroong padding-left: avatar collection with header

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -2256,7 +2256,7 @@ td, th {
     border-bottom: 1px solid #e0e0e0; }
     .collection .collection-item.avatar {
       height: 84px;
-      padding-left: 72px;
+      padding-left: 72px!important;
       position: relative; }
       .collection .collection-item.avatar .circle {
         position: absolute;


### PR DESCRIPTION
I'm sorry, this is my first time with materialize, I just had a problem and posting here how I fixed it. As long as I don't know the project, maybe this PR in not useful. 
When using a collection with header to show collection itens with avatars, there is a problem with the padding-left:

![screenshot from 2015-03-28 01 13 54](https://cloud.githubusercontent.com/assets/4960137/6879770/d2e63802-d4e7-11e4-9a8b-09e1976cd7b5.png)

The problem:
![screenshot from 2015-03-28 01 14 54](https://cloud.githubusercontent.com/assets/4960137/6879772/dfcad6a4-d4e7-11e4-8d6c-3e30471515b9.png)

So I just added !important here to use it with my project.