### PR TITLE
Adding colors to documentation

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -1606,6 +1606,12 @@
 .white-text {
   color: #FFFFFF !important; }
 
+.transparent {
+  background-color: transparent !important; }
+
+.transparent-text {
+  color: transparent !important; }
+
 /*** Colors ***/
 /*** Badges ***/
 /*** Buttons ***/

--- a/color.html
+++ b/color.html
@@ -453,6 +453,13 @@
             <div class="blue-grey darken-3"></div>
             <div class="blue-grey darken-4"></div>
           </div>
+          <div class="col s12 m6 l4">
+            <div class="section">
+                <div class="white">#ffffff white</div>
+                <div class="black white-text">#000000 black</div>
+                <div class="transparent">transparent transparent</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/jade/page-contents/color_content.html
+++ b/jade/page-contents/color_content.html
@@ -352,6 +352,11 @@
             <div class="blue-grey darken-3"></div>
             <div class="blue-grey darken-4"></div>
           </div>
+          <div class="col s12 m6 l4">
+            <div class="black"></div>
+            <div class="white"></div>
+            <div class="transparent"></div>
+          </div>          
         </div>
       </div>
     </div>

--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -332,8 +332,9 @@ $grey: (
 );
 
 $shades: (
-  "black":      #000000,
-  "white":      #FFFFFF
+  "black":        #000000,
+  "white":        #FFFFFF,
+  "transparent":  transparent
 );
 
 $colors: (


### PR DESCRIPTION
This adds an example of the black and white color classes to the colors documentation.  Also, this adds a transparent class to the documentation and CSS.  The transparent class can be used in the same way as any other color class.  For consistency with the other color classes the transparent-text class is included but this is far less likely to be used.

This commit is related to comment: https://github.com/Dogfalo/materialize/issues/1038

If the changes need to be added or moved to another file please let me know and I will update them appropriately. 