### PR TITLE
Fixes issue where comment created invalid top-level expression

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -1834,7 +1834,8 @@ button, select {
  * 3. Improve usability and consistency of cursor style between image-type
  *    `input` and others.
  */
-button, html input[type="button"], input[type="reset"], input[type="submit"] {
+/* 1 */
+html input[type="button"], button, input[type="reset"], input[type="submit"] {
   -webkit-appearance: button;
   /* 2 */
   cursor: pointer;

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -1834,7 +1834,8 @@ button, select {
  * 3. Improve usability and consistency of cursor style between image-type
  *    `input` and others.
  */
-button, html input[type="button"], input[type="reset"], input[type="submit"] {
+/* 1 */
+html input[type="button"], button, input[type="reset"], input[type="submit"] {
   -webkit-appearance: button;
   /* 2 */
   cursor: pointer;

--- a/sass/components/_normalize.scss
+++ b/sass/components/_normalize.scss
@@ -287,8 +287,8 @@ select {
  *    `input` and others.
  */
 
+/* 1 */ html input[type="button"],
 button,
-html input[type="button"], /* 1 */
 input[type="reset"],
 input[type="submit"] {
   -webkit-appearance: button; /* 2 */


### PR DESCRIPTION
When the _normalize.scss file is run through a SASS processor with linting, the statement on line 290 fails because the top level expression is interrupted by a comment block.

```scss
button,
html input[type="button"], /* 1 */ 
input[type="reset"],
input[type="submit"] {
  -webkit-appearance: button; /* 2 */
  cursor: pointer; /* 3 */
}
```

Attempting to retain the comment yet remove linting errors due to invalid syntax, I have opted to move the button input selector for Android 4.0 as the first in the selector list and moved the comment to the start of the line.