### PR TITLE
Fix vertical alignment of pagination

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -142,6 +142,7 @@ video.responsive-video {
     margin: 0 10px;
     border-radius: 2px;
     text-align: center;
+    line-height: 30px;
 
     a { color: #444; }
 
@@ -153,7 +154,6 @@ video.responsive-video {
 
     i {
       font-size: 2rem;
-      line-height: 1.8rem;
     }
   }
 }


### PR DESCRIPTION
The list items of the pagination already have a defined height, so using the line-height property (equal to the height of the item) you can get a proper vertical alignment.