### PR TITLE
Allow multiple modals

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -1,10 +1,13 @@
 (function($) {
+    var _stack = 0,
+    _lastID = 0,
+    _generateID = function() {
+      _lastID++;
+      return 'materialize-lean-overlay-' + _lastID;
+    };
+
   $.fn.extend({
     openModal: function(options) {
-      var modal = this;
-      var overlay = $('<div id="lean-overlay"></div>');
-      $("body").append(overlay);
-
       var defaults = {
         opacity: 0.5,
         in_duration: 350,
@@ -12,40 +15,50 @@
         ready: undefined,
         complete: undefined,
         dismissible: true
-      }
+      },
+      overlayID = _generateID(),
+      $modal = $(this),
+      $overlay = $('<div class="lean-overlay"></div>'),
+      lStack = (++_stack);
+
+      // Store a reference of the overlay
+      $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
+      $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
+
+      $("body").append($overlay);
 
       // Override defaults
       options = $.extend(defaults, options);
 
       if (options.dismissible) {
-        $("#lean-overlay").click(function() {
-          $(modal).closeModal(options);
+        $overlay.click(function() {
+          $modal.closeModal(options);
         });
         // Return on ESC
-        $(document).on('keyup.leanModal', function(e) {
+        $(document).on('keyup.leanModal' + overlayID, function(e) {
           if (e.keyCode === 27) {   // ESC key
-            $(modal).closeModal(options);
+            $modal.closeModal(options);
           }
         });
       }
 
-      $(modal).find(".modal-close").click(function(e) {
-        $(modal).closeModal(options);
+      $modal.find(".modal-close").click(function(e) {
+        $modal.closeModal(options);
       });
 
-      $("#lean-overlay").css({ display : "block", opacity : 0 });
+      $overlay.css({ display : "block", opacity : 0 });
 
-      $(modal).css({
+      $modal.css({
         display : "block",
         opacity: 0
       });
 
-      $("#lean-overlay").velocity({opacity: options.opacity}, {duration: options.in_duration, queue: false, ease: "easeOutCubic"});
-
+      $overlay.velocity({opacity: options.opacity}, {duration: options.in_duration, queue: false, ease: "easeOutCubic"});
+      $modal.data('associated-overlay', $overlay[0]);
 
       // Define Bottom Sheet animation
-      if ($(modal).hasClass('bottom-sheet')) {
-        $(modal).velocity({bottom: "0", opacity: 1}, {
+      if ($modal.hasClass('bottom-sheet')) {
+        $modal.velocity({bottom: "0", opacity: 1}, {
           duration: options.in_duration,
           queue: false,
           ease: "easeOutCubic",
@@ -58,8 +71,8 @@
         });
       }
       else {
-        $(modal).css({ top: "4%" });
-        $(modal).velocity({top: "10%", opacity: 1}, {
+        $modal.css({ top: "4%" });
+        $modal.velocity({top: "10%", opacity: 1}, {
           duration: options.in_duration,
           queue: false,
           ease: "easeOutCubic",
@@ -81,43 +94,48 @@
       var defaults = {
         out_duration: 250,
         complete: undefined
-      }
-      var options = $.extend(defaults, options);
+      },
+      options = $.extend(defaults, options),
+      $modal = $(this),
+      overlayID = $modal.data('overlay-id'),
+      $overlay = $('#' + overlayID);
 
-      $('.modal-close').off();
-      $(document).off('keyup.leanModal');
+      $modal.find('.modal-close').off();
+      $(document).off('keyup.leanModal' + overlayID);
 
-      $("#lean-overlay").velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
+      $overlay.velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
 
 
       // Define Bottom Sheet animation
-      if ($(this).hasClass('bottom-sheet')) {
-        $(this).velocity({bottom: "-100%", opacity: 0}, {
+      if ($modal.hasClass('bottom-sheet')) {
+        $modal.velocity({bottom: "-100%", opacity: 0}, {
           duration: options.out_duration,
           queue: false,
           ease: "easeOutCubic",
           // Handle modal ready callback
           complete: function() {
-            $("#lean-overlay").css({display:"none"});
+            $overlay.css({display:"none"});
 
             // Call complete callback
             if (typeof(options.complete) === "function") {
               options.complete();
             }
-            $('#lean-overlay').remove();
+            $overlay.remove();
+            _stack--;
           }
         });
       }
       else {
-        $(this).fadeOut(options.out_duration, function() {
-          $(this).css({ top: 0});
-          $("#lean-overlay").css({display:"none"});
+        $modal.fadeOut(options.out_duration, function() {
+          $modal.css({ top: 0});
+          $overlay.css({display:"none"});
 
           // Call complete callback
           if (typeof(options.complete) === "function") {
             options.complete();
           }
-          $('#lean-overlay').remove();
+          $overlay.remove();
+          _stack--;
         });
       }
 

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -11,7 +11,6 @@
   width: 55%;
   margin: auto;
   overflow-y: auto;
-  z-index: 1000;
 
   border-radius: 2px;
   @include transform(translate(0));
@@ -42,9 +41,8 @@
     }
   }
 }
-#lean-overlay {
+.lean-overlay {
     position: fixed;
-    z-index:999;
     top: 0;
     left: 0;
     bottom: 0;

--- a/sass/components/_tooltip.scss
+++ b/sass/components/_tooltip.scss
@@ -1,7 +1,7 @@
 .material-tooltip {
     padding: 10px 8px;
     font-size: 1rem;
-    z-index: 1000;
+    z-index: 2000;
     background-color: transparent;
     border-radius: 2px;
     color: #fff;


### PR DESCRIPTION
This change allows multiple modals to be opened at the same time.

How it has been done:
 - Don't use a static ID for the overlay. Use a class instead
 - Store references to the associated overlay element so each modal
   can reference its own overlay. We're generating an ID to store the reference
   so we only need to have a string as a reference instead of a whole jQuery
   object
 - Populate the z-index CSS property in JavaScript, so we can increase it for
   each new stacked modal

Also, reuse jQuery objects instead of querying the DOM each time.

fixes #1021