### PR TITLE
Fixed "lean-overlay" element bug (#1129)

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -48,11 +48,11 @@
 #lean-overlay {
     position: fixed;
     z-index:999;
-    top: 0;
+    top: -100px;
     left: 0;
     bottom: 0;
     right: 0;
-    height: 115%;
+    height: 125%;
     width: 100%;
     background: #000;
     display: none;


### PR DESCRIPTION
The "lean-overlay" element (used when a dialog is opened) doesn't overlay the top part of the screen when the address bar is moved upwards on Chrome for Android.
This pull request fixes this by changing the top and height styles of #lean-overlay.

Fixes #1129