### PR TITLE
Fix small typo in example code

### DIFF
--- a/jade/page-contents/badges_content.html
+++ b/jade/page-contents/badges_content.html
@@ -21,7 +21,7 @@
   &lt;div class="collection">
     &lt;a href="#!" class="collection-item">Alan&lt;span class="badge">1&lt;/span>&lt;/a>
     &lt;a href="#!" class="collection-item">Alan&lt;span class="new badge">4&lt;/span>&lt;/a>
-    &lt;a href="#!" class="collection-item">Alan&lt;/li>
+    &lt;a href="#!" class="collection-item">Alan&lt;/a>
     &lt;a href="#!" class="collection-item">Alan&lt;span class="badge">14&lt;/span>&lt;/a>
   &lt;/div>
             </code></pre>


### PR DESCRIPTION
A closing `</li>` tag was used instead of `</a>`