### PR TITLE
Double Quotes on href

### DIFF
--- a/jade/page-contents/cards_content.html
+++ b/jade/page-contents/cards_content.html
@@ -17,7 +17,7 @@
               </div>
               <div class="card-action">
                 <a href="#">This is a link</a>
-                <a href='#'>This is a link</a>
+                <a href="#">This is a link</a>
               </div>
             </div>
           </div>
@@ -35,7 +35,7 @@
             &lt;/div>
             &lt;div class="card-action">
               &lt;a href="#">This is a link&lt;/a>
-              &lt;a href='#'>This is a link&lt;/a>
+              &lt;a href="#">This is a link&lt;/a>
             &lt;/div>
           &lt;/div>
         &lt;/div>
@@ -60,7 +60,7 @@
                 <p>I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.</p>
               </div>
               <div class="card-action">
-                <a href='#'>This is a link</a>
+                <a href="#">This is a link</a>
               </div>
             </div>
           </div>
@@ -86,7 +86,7 @@
             &lt;/div>
             &lt;div class="card-action">
               &lt;a href="#">This is a link&lt;/a>
-              &lt;a href='#'>This is a link&lt;/a>
+              &lt;a href="#">This is a link&lt;/a>
             &lt;/div>
           &lt;/div>
         &lt;/div>
@@ -172,7 +172,7 @@
               </div>
               <div class="card-action">
                 <a href="#">This is a link</a>
-                <a href='#'>This is a link</a>
+                <a href="#">This is a link</a>
               </div>
             </div>
           </div>
@@ -197,7 +197,7 @@
               </div>
               <div class="card-action">
                 <a href="#">This is a link</a>
-                <a href='#'>This is a link</a>
+                <a href="#">This is a link</a>
               </div>
             </div>
           </div>
@@ -222,7 +222,7 @@
               </div>
               <div class="card-action">
                 <a href="#">This is a link</a>
-                <a href='#'>This is a link</a>
+                <a href="#">This is a link</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
XHTML technically requires double quotes on hrefs, also, was kind of weird having both types one line after the other. Changed just to be normalized at least. Was throwing errors with HTMLint