### PR TITLE
Remove closing input tag from docs

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -575,7 +575,7 @@
         <h2 class="header">Date Picker</h2>
         <p>We use a modified version of pickadate.js to create a materialized date picker. Test it out below! </p>
         <label for="birthdate">Birthdate</label>
-        <input id="birthdate" type="text" class="datepicker"></input>
+        <input id="birthdate" type="text" class="datepicker">
         <pre><code class="language-markup">
   &lt;input type="date" class="datepicker">
         </code></pre>


### PR DESCRIPTION
Was reusing the code and had Meteor throw a major hissyfit, don't need that closing input tag.