### PR TITLE
Use `script.` instead of the deprecated version

### DIFF
--- a/jade/_head.jade
+++ b/jade/_head.jade
@@ -27,7 +27,7 @@ link(href='css/prism.css', rel='stylesheet')
 link(href='css/ghpages-materialize.css', type='text/css', rel='stylesheet', media='screen,projection')
 link(href='http://fonts.googleapis.com/css?family=Inconsolata', rel='stylesheet', type='text/css')
 
-script
+script.
   window.liveSettings = {
     api_key: "a0b49b34b93844c38eaee15690d86413",
     picker: "bottom-right",


### PR DESCRIPTION
Stop the grunt task from reporting
````
jade/_head.jade, line 31:
Implicit textOnly for `script` and `style` is deprecated.  Use `script.` or `style.` instead.
````