### PR TITLE
Missing angle brackets on closing tags (in docs)

### DIFF
--- a/jade/page-contents/table_content.html
+++ b/jade/page-contents/table_content.html
@@ -210,7 +210,7 @@
                     <th data-field="name">Item Name</th>
                     <th data-field="price">Item Price</th>
                 </tr>
-              </thead
+              </thead>
               <tbody>
                 <tr>
                   <td>Alvin</td>
@@ -251,7 +251,7 @@
                     <th data-field="name">Item Name</th>
                     <th data-field="price">Item Price</th>
                 </tr>
-              </thead
+              </thead>
               <tbody>
                 <tr>
                   <td>Alvin</td>


### PR DESCRIPTION
Just fixed two small HTML errors in the Tables page of the docs, were throwing errors when I tried using the code.