### PR TITLE
sass/global: badge: fix positioning (Dogfalo/materialize#1298)

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -520,8 +520,9 @@ span.badge {
   font-size: 1rem;
   line-height: inherit;
   color: color('grey', 'darken-1');
-  position: absolute;
-  right: 15px;
+  position: relative;
+  float: right;
+  display: inline-block;
   @include box-sizing(border-box);
 
   &.new {


### PR DESCRIPTION
Not all points in Dogfalo/materialize#1298 are addressed -- the "new"
text is still hard-coded and cannot easily be replaced for translation
purposes.

This also resolves positioning issues when badges are used on
`.collapsible-header` containers, though line height will need to be
addressed separately before that working completely.
