### PR TITLE
Added cursor pointer to card action

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -125,6 +125,7 @@
       margin-right: $card-padding;
       @include transition(color .3s ease);
       text-transform: uppercase;
+      cursor: pointer;
 
       &:hover { color: $card-link-color-light; }
     }


### PR DESCRIPTION
When the anchor tag doesn't have an href, there's no pointer cursor. This commit makes sure there's always a pointer cursor.
