### PR TITLE
Add latest releases to CHANGELOG+ headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,87 +1,114 @@
-- v0.95.2 (Feb 10, 2015)
-  - Switches added
-  - Transition animation functions added
-  - ScrollFire Plugin added (fires functions dependent on scroll position)
-  - Responsive Video tag added
-  - Custom File Input Button added
-  - Modals has a fixed footer option
-  - SideNav implementation changed (needs 2 UL menus)
-  - Slider Responsive Fixes
+## v0.96.0 (April 1, 2015)
+- Toasts, transitions, scrollfire added under Materialize namespace
+- Dropdown is now created as a child of its parent
+- Collapsibles supports nesting
+- Modal Bottom Sheet added
+- Indeterminate Checkboxes added
+- New Checkbox Style added
+- Text Inputs supports placeholder/readonly
+- Google Inbox-like Collapsible added
+- Text Character Counter added
+- Waves no longer breaks on SVGs
 
-- v0.95.1 (Jan 26, 2015)
-  - Sidenav Fixes
-  - Dropdown alignment/gutter options added
-  - Parallax fixes
-  - JavaScript Initialization no longer needed for many components
-  - HTML options through data-attributes
-  - Site colors can be defined through Primary and Secondary color in Sass
-  - Tables no longer resonsive by default
-
-- v0.95.0 (Jan 17, 2015)
-  - Drag Out Menu fixed with Touch Interactions
-  - Toasts minor bugfix
-  - OL element has default styling
-  - Fullscreen Slider added
-  - Footer requires page-footer class
-  - Progress Bars added
-  - Form autofill support added
-  - Responsive Tables support added
-  - Scrollspy Plugin released
-  - Waves events are now delegated / behavior enhanced
-
-- v0.94.0 (Dec 30, 2014)
-  - Sidenav supports right edge positioning
-  - Responsive Embeds
-  - Image Vertical align classes
-  - border-box added
-  - Variable file created
-  - Pushpin added
-  - Tooltips support all directions
-  - Layout helper classes added
-  - Materialbox Fixes
-  - Form Element Enhancements
-  - Navbar supports search bar
-  - Waves fixes
-  - Materialbox Captions
-  - Image Slider Fixes
-
-- v0.93.1 (Dec 20, 2014)
-  - Flexbox Sticky Footer removed due to IE incompatibility
-
-- v0.93.0 (Dec 19, 2014)
-  - Card Reveal
-  - Image Slider
-  - Dynamically loaded forms work correctly
-  - Badges added
-  - Circular Image
-  - Waves Fixes
-  - Footer Added
-  - Toast support Custom HTML
-  - Modals support programmatic opening/closing
-  - Responsive Image support
-
-- v0.92.1 (Dec 14, 2014)
-  - Bower semver fix
-  - Added new radio button style
-
-- v0.92.0 (Dec 13, 2014)
-  - Clicking icon in dropdown in navbar no longer closes dropdown immediately
-  - Multiple select inputs now work properly
-  - Mobile navbar no longer extends past screen width
-  - Parallax improved
-  - Modal restructured / can be opened programmatically
-  - Callbacks added to modals
-  - Added dist folder to repo
-  - Cards restructured
+## v0.95.3 (Feb 25, 2015)
+- Parallax image loading / responsiveness fixes
+- Date picker supports month/year as dropdown
+- Dismissable collection items
+- Avatar collection items
+- Pagination Added
+- ScrollFire fixes
 
 
-- v0.91 (Dec 3, 2014)
-  - bug fixes to forms
-  - added waves color classes
-  - toast thickened to look better on mobile
-  - many other bug fixes
+## v0.95.2 (Feb 10, 2015)
+- Switches added
+- Transition animation functions added
+- ScrollFire Plugin added (fires functions dependent on scroll position)
+- Responsive Video tag added
+- Custom File Input Button added
+- Modals has a fixed footer option
+- SideNav implementation changed (needs 2 UL menus)
+- Slider Responsive Fixes
 
 
-- v0.9 (Nov 30, 2014)
-  - Touch interactions added
-  - tons more...
+## v0.95.1 (Jan 26, 2015)
+- Sidenav Fixes
+- Dropdown alignment/gutter options added
+- Parallax fixes
+- JavaScript Initialization no longer needed for many components
+- HTML options through data-attributes
+- Site colors can be defined through Primary and Secondary color in Sass
+- Tables no longer resonsive by default
+
+
+## v0.95.0 (Jan 17, 2015)
+- Drag Out Menu fixed with Touch Interactions
+- Toasts minor bugfix
+- OL element has default styling
+- Fullscreen Slider added
+- Footer requires page-footer class
+- Progress Bars added
+- Form autofill support added
+- Responsive Tables support added
+- Scrollspy Plugin released
+- Waves events are now delegated / behavior enhanced
+
+
+## v0.94.0 (Dec 30, 2014)
+- Sidenav supports right edge positioning
+- Responsive Embeds
+- Image Vertical align classes
+- border-box added
+- Variable file created
+- Pushpin added
+- Tooltips support all directions
+- Layout helper classes added
+- Materialbox Fixes
+- Form Element Enhancements
+- Navbar supports search bar
+- Waves fixes
+- Materialbox Captions
+- Image Slider Fixes
+
+
+## v0.93.1 (Dec 20, 2014)
+- Flexbox Sticky Footer removed due to IE incompatibility
+
+
+## v0.93.0 (Dec 19, 2014)
+- Card Reveal
+- Image Slider
+- Dynamically loaded forms work correctly
+- Badges added
+- Circular Image
+- Waves Fixes
+- Footer Added
+- Toast support Custom HTML
+- Modals support programmatic opening/closing
+- Responsive Image support
+
+
+## v0.92.1 (Dec 14, 2014)
+- Bower semver fix
+- Added new radio button style
+
+
+## v0.92.0 (Dec 13, 2014)
+- Clicking icon in dropdown in navbar no longer closes dropdown immediately
+- Multiple select inputs now work properly
+- Mobile navbar no longer extends past screen width
+- Parallax improved
+- Modal restructured / can be opened programmatically
+- Callbacks added to modals
+- Added dist folder to repo
+- Cards restructured
+
+## v0.91 (Dec 3, 2014)
+- bug fixes to forms
+- added waves color classes
+- toast thickened to look better on mobile
+- many other bug fixes
+
+
+## v0.9 (Nov 30, 2014)
+- Touch interactions added
+- tons more...


### PR DESCRIPTION
I've added the latest [releases](https://github.com/Dogfalo/materialize/releases) to the changelog.

Also, I've made each version a heading, which will generate a Markdown anchor, so that it becomes possible to link to it on GitHub.

Thanks for making this awesome Bootstrap alternative!