### PR TITLE
Fix for waves effects triggered from code

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -282,12 +282,11 @@
             Effect.show(e, element);
 
             if ('ontouchstart' in window) {
-                element.addEventListener('touchend', Effect.hide, false);
-                element.addEventListener('touchcancel', Effect.hide, false);
+                $(element).on('touchend', Effect.hide);
+                $(element).on('touchcancel', Effect.hide);
             }
-
-            element.addEventListener('mouseup', Effect.hide, false);
-            element.addEventListener('mouseleave', Effect.hide, false);
+            $(element).on('mouseup', Effect.hide);
+            $(element).on('mouseleave', Effect.hide);
         }
     }
 
@@ -302,10 +301,9 @@
         Effect.wrapInput($$('.waves-effect'));
 
         if ('ontouchstart' in window) {
-            document.body.addEventListener('touchstart', showEffect, false);
+            $(document.body).on('touchstart', showEffect);
         }
-
-        document.body.addEventListener('mousedown', showEffect, false);
+        $(document.body).on('mousedown', showEffect);
     };
 
     /**
@@ -323,10 +321,10 @@
         }
 
         if ('ontouchstart' in window) {
-            element.addEventListener('touchstart', showEffect, false);
+            $(element).on('touchstart', showEffect);
         }
 
-        element.addEventListener('mousedown', showEffect, false);
+        $(element).on('mousedown', showEffect);
     };
 
     window.Waves = Waves;

--- a/js/waves.js
+++ b/js/waves.js
@@ -72,15 +72,22 @@
 
             // Get click coordinate and element witdh
             var pos         = offset(el);
-            var relativeY   = (e.pageY - pos.top);
-            var relativeX   = (e.pageX - pos.left);
-            var scale       = 'scale('+((el.clientWidth / 100) * 10)+')';
-
+            var relativeY = 0;
+            var relativeX = 0;
             // Support for touch devices
-            if ('touches' in e) {
-              relativeY   = (e.touches[0].pageY - pos.top);
-              relativeX   = (e.touches[0].pageX - pos.left);
+            if('touches' in e && e.touches.length) {
+                relativeY   = (e.touches[0].pageY - pos.top);
+                relativeX   = (e.touches[0].pageX - pos.left);
             }
+            //Normal case
+            else {
+                relativeY   = (e.pageY - pos.top);
+                relativeX   = (e.pageX - pos.left);
+            }
+            // Support for synthetic events
+            relativeX = relativeX >= 0 ? relativeX : 0;
+            relativeY = relativeY >= 0 ? relativeY : 0;
+            var scale       = 'scale('+((el.clientWidth / 100) * 10)+')';
 
             // Attach data to element
             ripple.setAttribute('data-hold', Date.now());


### PR DESCRIPTION
According to this documentation: 
https://developer.mozilla.org/en-US/docs/Web/API/UIEvent 
https://msdn.microsoft.com/en-us/library/ff974344%28v=vs.85%29.aspx#properties
We cant create MouseEvent with filled pageX, pageY properties. 
Example is https://jsfiddle.net/Tezd/3gp1u5pp/4/

Now if we will use JQuery (which is already should be present by stack of this project) to add listeners we can populate pageX, pageY. 
Example is https://jsfiddle.net/Tezd/g78qbmmp/2/

Note: Its still better to use JQuery mouse events cause we will be able to specify starting point of wave effect in our synthetic mouse event instead of using [0,0].
