### PR TITLE
correct medium-and-up and large-and-up media queries

### DIFF
--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -82,8 +82,8 @@ $small-screen: 600px !default;
 $medium-screen: 992px !default;
 $large-screen: 1200px !default;
 
-$medium-and-up: "only screen and (min-width : #{$small-screen-up})" !default;
-$large-and-up: "only screen and (min-width : #{$medium-screen-up})" !default;
+$medium-and-up: "only screen and (min-width : #{$medium-screen-up})" !default;
+$large-and-up: "only screen and (min-width : #{$large-screen-up})" !default;
 $small-and-down: "only screen and (max-width : #{$small-screen})" !default;
 $medium-and-down: "only screen and (max-width : #{$medium-screen})" !default;
 $medium-only: "only screen and (min-width : #{$small-screen-up}) and (max-width : #{$medium-screen})" !default;


### PR DESCRIPTION
I might be mistaken here, but it seems like the media query breakpoints `$large-and-up` and `$medium-and-up` are using the wrong breakpoints.

They're currently defined in _variables.scss as:
```
$medium-and-up: "only screen and (min-width : #{$small-screen-up})" !default;
$large-and-up: "only screen and (min-width : #{$medium-screen-up})" !default;
```
but I believe they should be:
```
$medium-and-up: "only screen and (min-width : #{$medium-screen-up})" !default;
$large-and-up: "only screen and (min-width : #{$large-screen-up})" !default;
```