### PR TITLE
fixed dropdowns misbehaving because of relocating dom

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -41,8 +41,6 @@
 
     updateOptions();
 
-    // Attach dropdown to its activator
-    origin.after(activates);
 
     /*
       Helper function to position and resize dropdown.
@@ -78,8 +76,8 @@
       // Position dropdown
       activates.css({
         position: 'absolute',
-        top: origin.position().top + offset,
-        left: origin.position().left + width_difference + gutter_spacing
+        top: origin.offset().top + offset,
+        left: origin.offset().left + width_difference + gutter_spacing
       });
 
 


### PR DESCRIPTION
The issue is dropdowns are relocated in the dom to be right next to the element that is triggering the dropdown. If the surrounding dom has CSS elements that negatively affect the dropdown (like position: relative, or overflow: hidden), then the dropdown appears strange.

This fix gets the offset of the origin in relation to the entire page, and then it absolutely positions the dropdown from that.
