### PR TITLE
fix for fixed footer modals in ie10+11. fixes #604

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -6031,14 +6031,14 @@ a.waves-effect .waves-ripple {
   padding: 0;
   height: 70%; }
   .modal.modal-fixed-footer .modal-content {
-    position: fixed;
+    position: absolute;
+    height: calc(100% - 56px);
     max-height: 100%;
-    padding-bottom: 64px;
     width: 100%;
     overflow-y: auto; }
   .modal.modal-fixed-footer .modal-footer {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    position: fixed;
+    position: absolute;
     bottom: 0; }
 
 .modal.bottom-sheet {

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -6031,14 +6031,14 @@ a.waves-effect .waves-ripple {
   padding: 0;
   height: 70%; }
   .modal.modal-fixed-footer .modal-content {
-    position: fixed;
+    position: absolute;
+    height: calc(100% - 56px);
     max-height: 100%;
-    padding-bottom: 64px;
     width: 100%;
     overflow-y: auto; }
   .modal.modal-fixed-footer .modal-footer {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    position: fixed;
+    position: absolute;
     bottom: 0; }
 
 .modal.bottom-sheet {

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -64,16 +64,16 @@
   height: 70%;
 
   .modal-content {
-    position: fixed;
+    position: absolute;
+    height: calc(100% - 56px);
     max-height: 100%;
-    padding-bottom: 64px;
     width: 100%;
     overflow-y: auto;
   }
 
   .modal-footer {
     border-top: 1px solid rgba(0,0,0,.1);
-    position: fixed;
+    position: absolute;
     bottom: 0;
   }
 }


### PR DESCRIPTION
Fix for #604 

It's a bit hackie, but it seems to work.

This seems to be working for me. I'm not sure if it breaks anything else. I tested it in Chrome/safari on yosemite, ios, android; on ie10 on win7+8, and ie11 on win8.