### PR TITLE
Fixed navbar link darkening (scrollspy)

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5284,7 +5284,7 @@ nav {
       transition: background-color .3s;
       float: left;
       padding: 0; }
-      nav ul li:hover, nav ul li.active {
+      nav ul li:hover, nav ul li.active, nav ul a.active {
         background-color: rgba(0, 0, 0, 0.1); }
     nav ul a {
       font-size: 1rem;


### PR DESCRIPTION
Previously, the active links on the navbar would not be highlighted as the link was active rather than the div containing it. This tweak fixed this problem.
