### PR TITLE
Fix #1503 - Textarea not resizing automatically with dynamic content

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -142,7 +142,7 @@
       }
     });
 
-    $('body').on('keyup keydown', text_area_selector, function () {
+    $('body').on('keyup keydown focus', text_area_selector, function () {
       textareaAutoResize($(this));
     });
 


### PR DESCRIPTION
Added a focus event on textarea resize.

https://github.com/Dogfalo/materialize/issues/1503
