### PR TITLE
Update ghpages-materialize.css

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5520,7 +5520,6 @@ small {
 
 .card {
   position: relative;
-  overflow: hidden;
   margin: 0.5rem 0 1rem 0;
   background-color: #fff;
   border-radius: 2px; }


### PR DESCRIPTION
Removed overflow:hidden from .card class since selects (formItem) are beeing cut when higher than .card