### PR TITLE
fixed bug of sideNav not working on right side

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -34,9 +34,22 @@
 
         // If fixed sidenav, bring menu out
         if (menu_id.hasClass('fixed')) {
-            if (window.innerWidth > 992) {
-              menu_id.css('left', 0);
+          if (window.innerWidth > 992) {
+            // Close menu if window is resized bigger than 992 and user has fixed sidenav
+            if ($('#sidenav-overlay').css('opacity') !== 0 && menuOut) {
+              removeMenu(true);
             }
+            else {
+              menu_id.removeAttr('style');
+              menu_id.css('width', options.menuWidth);
+            }
+          }
+          else if (menuOut === false){
+            if (options.edge === 'left')
+              menu_id.css('left', -1 * (options.menuWidth + 10));
+            else
+              menu_id.css('right', -1 * (options.menuWidth + 10));
+          }
           }
 
         // Window resize to reset on large screens fixed


### PR DESCRIPTION
As discussed/mentioned in issue #1488.

As you can clearly see in sideNav.js the code executed on pageLoad is different from the one executed if window is resized. As everything works as expected if you resize the window you just need to use the same code on pageLoad and everything works perfectly fine.

This causes the issue:

``` js
// If fixed sidenav, bring menu out
if (menu_id.hasClass('fixed')) {
    if (window.innerWidth > 992) {
        menu_id.css('left', 0);
    }
}
```

If page is resized the following code is in charge:

``` js
 // Window resize to reset on large screens fixed
if (menu_id.hasClass('fixed')) {
    $(window).resize( function() {
        if (window.innerWidth > 992) {
            // Close menu if window is resized bigger than 992 and user has fixed sidenav
            if ($('#sidenav-overlay').css('opacity') !== 0 && menuOut) {
                removeMenu(true);
            }
            else {
                menu_id.removeAttr('style');
                menu_id.css('width', options.menuWidth);
            }
        }
        else if (menuOut === false){
            if (options.edge === 'left')
                menu_id.css('left', -1 * (options.menuWidth + 10));
            else
                menu_id.css('right', -1 * (options.menuWidth + 10));
        }
    });
}
```

Used the same code as if you would resize the window and everything worked as expected:

``` js
// If fixed sidenav, bring menu out
if (menu_id.hasClass('fixed')) {
    if (window.innerWidth > 992) {
        // Close menu if window is resized bigger than 992 and user has fixed sidenav
        if ($('#sidenav-overlay').css('opacity') !== 0 && menuOut) {
            removeMenu(true);
        }
        else {
            menu_id.removeAttr('style');
            menu_id.css('width', options.menuWidth);
        }
    }
    else if (menuOut === false){
        if (options.edge === 'left')
            menu_id.css('left', -1 * (options.menuWidth + 10));
        else
            menu_id.css('right', -1 * (options.menuWidth + 10));
    }
}
```
