### PR TITLE
Add border-radius mixin into prefixer.scss

### DIFF
--- a/sass/components/_prefixer.scss
+++ b/sass/components/_prefixer.scss
@@ -156,6 +156,13 @@
     @include box-sizing(content-box);
 }
 
+// Border Radius
+
+@mixin border-radius($args) {
+    -webkit-border-radius: $args;
+    -moz-border-radius: $args;
+    border-radius: $args;
+}
 
 // Columns
 


### PR DESCRIPTION
Add mixin border-radius, that exist in the docs http://materializecss.com/sass.html , but missed in the _prefixer.scss