### PR TITLE
Not removing existing tooltips when we re-initialize. 

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -13,7 +13,16 @@
       options = $.extend(defaults, options);
 
       //Remove previously created html
-      $('.material-tooltip').remove();
+      var that = this;
+      $('.material-tooltip').each(function (index, element) {
+        var origin = $(element).data("origin");
+        // Checking if the element is still attached to the dom. http://stackoverflow.com/questions/3086068/how-do-i-check-whether-a-jquery-element-is-in-the-dom#answer-3086084
+        if (!jQuery.contains(document, origin[0])) {
+          $(element).remove(); // The origin is detached, so no need for the material-tooltip.
+        } else if (that.filter(origin).length) {
+          $(element).remove(); // We are about to reinitialize this one, so we remove it.
+        }
+      });
 
       return this.each(function(){
         var origin = $(this);


### PR DESCRIPTION
Currently, when you initialize a tooltip, all the previously initialized tooltips are removed. 

So when you add a tooltip dynamically, like we do here: krescruz/angular-materialize#34, you have to initialize all the tooltips again. 
This is also dicussed a bit here: #1386

With this change, a tooltip is only removed if its anchor is detached, or we are about to re-initialize it. 

The last part keeps backwards-compatibility with people that re-initialize everything when a new tooltip is added.  