### PR TITLE
fix(jQuery): add missing jQuery wrapper on global.js

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -28,9 +28,11 @@ Materialize.elementOrParentIsFixed = function(element) {
 
 // Velocity has conflicts when loaded with jQuery, this will check for it
 var Vel;
-if ($) {
-  Vel = $.Velocity;
-}
-else {
-  Vel = Velocity;
-}
+(function ($) {
+    if ($) {
+        Vel = $.Velocity;
+    }
+    else {
+        Vel = Velocity;
+    }
+}( jQuery ));


### PR DESCRIPTION
I propose to add the jQuery wrapper on global.js because if it's not present, Jquery with no $ alias doesn't work fine.
![capture_d ecran_2015-06-23_a_02_15_32](https://cloud.githubusercontent.com/assets/1308977/8296316/6b03bc8a-194f-11e5-8e39-3e17d0c383c3.png)