### PR TITLE
Added caret deletion on material_select destroy and redraw

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -279,6 +279,7 @@
       if (lastID) {
         $select.parent().find('i').remove();
         $select.parent().find('input').remove();
+        $select.parent().find('.caret').remove();
 
         $select.unwrap();
         $('ul#select-options-'+lastID).remove();


### PR DESCRIPTION
I was trying your latest release and upon close inspection I found out that the select's on destroy and redraw were leaving behind the caret, this line is just to remove it.