### PR TITLE
Remove css specificity in grid classes such as .col and .s1

### DIFF
--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -19,8 +19,8 @@
 }
 
 .section {
-	padding-top: 1rem;
-	padding-bottom: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 
   &.no-pad {
     padding: 0;
@@ -45,73 +45,72 @@
     display: table;
     clear: both;
   }
+}
 
-  .col {
-    float: left;
-    @include box-sizing(border-box);
-    padding: 0 $gutter-width / 2;
+.col {
+  float: left;
+  @include box-sizing(border-box);
+  padding: 0 $gutter-width / 2;
+}
 
-    $i: 1;
-    @while $i <= $num-cols {
-      $perc: unquote((100 / ($num-cols / $i)) + "%");
-      &.s#{$i} {
-        width: $perc;
-        margin-left: 0;
-      }
-      $i: $i + 1;
-    }
-    $i: 1;
-    @while $i <= $num-cols {
-      $perc: unquote((100 / ($num-cols / $i)) + "%");
-      &.offset-s#{$i} {
-        margin-left: $perc;
-      }
-      $i: $i + 1;
-    }
-
-    @media #{$medium-and-up} {
-
-      $i: 1;
-      @while $i <= $num-cols {
-        $perc: unquote((100 / ($num-cols / $i)) + "%");
-        &.m#{$i} {
-          width: $perc;
-          margin-left: 0;
-        }
-        $i: $i + 1;
-      }
-      $i: 1;
-      @while $i <= $num-cols {
-        $perc: unquote((100 / ($num-cols / $i)) + "%");
-        &.offset-m#{$i} {
-          margin-left: $perc;
-        }
-        $i: $i + 1;
-      }
-
-    }
-
-    @media #{$large-and-up} {
-
-      $i: 1;
-      @while $i <= $num-cols {
-        $perc: unquote((100 / ($num-cols / $i)) + "%");
-        &.l#{$i} {
-          width: $perc;
-          margin-left: 0;
-        }
-        $i: $i + 1;
-      }
-      $i: 1;
-      @while $i <= $num-cols {
-        $perc: unquote((100 / ($num-cols / $i)) + "%");
-        &.offset-l#{$i} {
-          margin-left: $perc;
-        }
-        $i: $i + 1;
-      }
-
-    }
-
+$i: 1;
+@while $i <= $num-cols {
+  $perc: unquote((100 / ($num-cols / $i)) + "%");
+  .s#{$i} {
+    width: $perc;
+    margin-left: 0;
   }
+  $i: $i + 1;
+}
+$i: 1;
+@while $i <= $num-cols {
+  $perc: unquote((100 / ($num-cols / $i)) + "%");
+  .offset-s#{$i} {
+    margin-left: $perc;
+  }
+  $i: $i + 1;
+}
+
+@media #{$medium-and-up} {
+
+  $i: 1;
+  @while $i <= $num-cols {
+    $perc: unquote((100 / ($num-cols / $i)) + "%");
+    .m#{$i} {
+      width: $perc;
+      margin-left: 0;
+    }
+    $i: $i + 1;
+  }
+  $i: 1;
+  @while $i <= $num-cols {
+    $perc: unquote((100 / ($num-cols / $i)) + "%");
+    .offset-m#{$i} {
+      margin-left: $perc;
+    }
+    $i: $i + 1;
+  }
+
+}
+
+@media #{$large-and-up} {
+
+  $i: 1;
+  @while $i <= $num-cols {
+    $perc: unquote((100 / ($num-cols / $i)) + "%");
+    .l#{$i} {
+      width: $perc;
+      margin-left: 0;
+    }
+    $i: $i + 1;
+  }
+  $i: 1;
+  @while $i <= $num-cols {
+    $perc: unquote((100 / ($num-cols / $i)) + "%");
+    .offset-l#{$i} {
+      margin-left: $perc;
+    }
+    $i: $i + 1;
+  }
+
 }


### PR DESCRIPTION
I haven't found a reason for the specificity of .col and column sizes. I needed to remove padding on some columns.
