### PR TITLE
Un-initialized variable causing issues

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1,4 +1,4 @@
-Materialize = {};
+window.Materialize = {};
 
 // Unique ID
 Materialize.guid = (function() {


### PR DESCRIPTION
Un-initialized Materialize variable causing issues when using browserify. Assumign due to strict mode?

This should fix the one issue i've seen