### PR TITLE
Fixed duplicate leanModal overlays

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -4,7 +4,8 @@
     _generateID = function() {
       _lastID++;
       return 'materialize-lean-overlay-' + _lastID;
-    };
+    },
+    _stackModals = [];
 
   $.fn.extend({
     openModal: function(options) {
@@ -25,11 +26,23 @@
       $overlay = $('<div class="lean-overlay"></div>'),
       lStack = (++_stack);
 
-      // Store a reference of the overlay
-      $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
-      $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
+      //check if modal has been opened
+      //if the modal is not opened then add a new overlay
+      if( _stackModals.indexOf($modal.selector) === -1 ) {
+          // Store a reference of the modal
+          _stackModals.push($modal.selector);
 
-      $("body").append($overlay);
+        // Store a reference of the overlay
+        $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
+
+        $("body").append($overlay);
+      } else {
+          //if the modal has been opened already
+          //retrieve overlayID
+          overlayID = $modal.data('overlay-id');
+      }
+
+      $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
 
       // Override defaults
       options = $.extend(defaults, options);

--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -4,8 +4,7 @@
     _generateID = function() {
       _lastID++;
       return 'materialize-lean-overlay-' + _lastID;
-    },
-    _stackModals = [];
+    };
 
   $.fn.extend({
     openModal: function(options) {
@@ -26,23 +25,11 @@
       $overlay = $('<div class="lean-overlay"></div>'),
       lStack = (++_stack);
 
-      //check if modal has been opened
-      //if the modal is not opened then add a new overlay
-      if( _stackModals.indexOf($modal.selector) === -1 ) {
-          // Store a reference of the modal
-          _stackModals.push($modal.selector);
-
-        // Store a reference of the overlay
-        $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
-
-        $("body").append($overlay);
-      } else {
-          //if the modal has been opened already
-          //retrieve overlayID
-          overlayID = $modal.data('overlay-id');
-      }
-
+      // Store a reference of the overlay
+      $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
       $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
+
+      $("body").append($overlay);
 
       // Override defaults
       options = $.extend(defaults, options);


### PR DESCRIPTION
The bug is by re-opening opened modals will generate duplicate leanModal overlays. Those overlays cannot be closed properly.

Fix:
Added a _stackModals array to store modal’s id. Every time opening a modal will check if the modal is opened against the array.

I created a plunk to illustrate the problem.
http://embed.plnkr.co/NMosr6KBPlR1NTyX3FLj/preview
(Codepen cannot run this properly) 