### PR TITLE
Allow jquery 1.x to be used

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -61,6 +61,6 @@
 
   ],
   "dependencies": {
-        "jquery": ">=2.1.1"
+        "jquery": ">=1.11.1"
     }
 }


### PR DESCRIPTION
The existing version is over-specific. jquery `>= 1.11.x` (`1.11.1` for example) works just fine