### PR TITLE
Clarify icon usage.

### DIFF
--- a/jade/page-contents/icons_content.html
+++ b/jade/page-contents/icons_content.html
@@ -8,7 +8,7 @@
             <p>To be able to use these icons, you must include this line in the <code class="language-markup">&lt;head></code>portion of your HTML code</p>
             <pre><code class="language-markup">
   &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"></code></pre>
-            <p>To use these icons, just place the name of the icon into the class of an i tag</p>
+            <p>To use these icons, use the material-icons class on an element and provide the ligature as the text content.</p>
             <pre><code class="language-markup">
       &lt;i class="material-icons">add&lt;/i>
             </code></pre>


### PR DESCRIPTION
This documentation update clarifies how to use the Material Design icons. Some [confusion exists](https://plus.google.com/u/0/115994601702879969997/posts/6XcHKNyrR13) (see comments) based on the current wording which does not work as it says.