### PR TITLE
.collapsible-header height changed to auto

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -6082,7 +6082,7 @@ a.waves-effect .waves-ripple {
 .collapsible-header {
   display: block;
   cursor: pointer;
-  height: 3rem;
+  height: auto;
   line-height: 3rem;
   padding: 0 1rem;
   background-color: #fff;


### PR DESCRIPTION
Causing an issue for the collapsible component (especially on mobile devices).

Text was spilling over into the row below. 
Rows weren't able to flexibly change height to accommodate the text:
![image](https://cloud.githubusercontent.com/assets/10707415/8394534/2595b476-1d34-11e5-9acb-da5d1298cbca.png)

Removing the 'height:3rem' means it can accommodate the text as the viewport shrinks:
![image](https://cloud.githubusercontent.com/assets/10707415/8394536/5454969c-1d34-11e5-8b13-47a4b0a9a65d.png)

Thanks!

