### PR TITLE
Fix documentation typos on getting_started_content.html

### DIFF
--- a/jade/getting_started/getting_started_content.html
+++ b/jade/getting_started/getting_started_content.html
@@ -24,7 +24,7 @@
     <div class="section col s12 m9 l10">
       <div id="download" class="row scrollspy">
           <h2 class="col s12 header">Download</h2>
-        <p class="caption col s12">Materialize comes in two different forms. You can select which version you want depending on your preference and expertise. To start using Materialize, all you have to is download one of the options below.</p>
+        <p class="caption col s12">Materialize comes in two different forms. You can select which version you want depending on your preference and expertise. To start using Materialize, all you have to do is download one of the options below.</p>
 
         <div class="col s12 m6">
           <p class="promo-caption">Materialize</p>
@@ -51,7 +51,7 @@
         <div class="col s12">
           <br>
           <p class="promo-caption">NPM</p>
-          <p>You can also get the latest release using NPM. this release contains source files as well as the compiled CSS and JavaScript files.</p>
+          <p>You can also get the latest release using NPM. This release contains source files as well as the compiled CSS and JavaScript files.</p>
           <pre><code class="language-bash">
   npm install materialize-css
           </code></pre>
@@ -59,7 +59,7 @@
         <div class="col s12">
           <br>
           <p class="promo-caption">Bower</p>
-          <p>You can also get the latest release using bower. this release contains source files as well as the compiled CSS and JavaScript files.</p>
+          <p>You can also get the latest release using bower. This release contains source files as well as the compiled CSS and JavaScript files.</p>
           <pre><code class="language-bash">
   bower install materialize
           </code></pre>


### PR DESCRIPTION
In jade/getting_started/getting_started_content.html, I updated line 27 from '...all you have to is...' to '...all you have to do is...,' and capitalized the word 'this' in lines 54 and 62.