### PR TITLE
Tooltip javascript-defined position

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -8,7 +8,8 @@
 
       // Defaults
       var defaults = {
-        delay: 350
+        delay: 350,
+        position: 'bottom'
       };
       options = $.extend(defaults, options);
 
@@ -38,6 +39,8 @@
       mouseenter: function(e) {
         var tooltip_delay = origin.data("delay");
         tooltip_delay = (tooltip_delay === undefined || tooltip_delay === '') ? options.delay : tooltip_delay;
+        var tooltipPosition =  origin.data('position');
+        tooltipPosition = (tooltipPosition === undefined || tooltipPosition === '') ? options.position : tooltipPosition;
         counter = 0;
         counterInterval = setInterval(function(){
           counter += 10;
@@ -51,7 +54,6 @@
             // Tooltip positioning
             var originWidth = origin.outerWidth();
             var originHeight = origin.outerHeight();
-            var tooltipPosition =  origin.attr('data-position');
             var tooltipHeight = newTooltip.outerHeight();
             var tooltipWidth = newTooltip.outerWidth();
             var tooltipVerticalMovement = '0px';


### PR DESCRIPTION
Added default tooltip position and linked position to look at the javascript parameters when not defined in the attribute.

The general reason for this change is to reduce unnecessary bloat in the DOM when trying to use the Materialize tooltips.  Having to specify a class and at least 2 data-attributes makes an originally small button definition to need line wrapping in some IDEs and code styles.  This change makes the data-position attribute optional in the same fashion as the data-delay attribute to possibly reduce this clutter.