### PR TITLE
Using correct mixin to init flexbox for .tabs

### DIFF
--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -1,5 +1,5 @@
 .tabs {
-  @include flex();
+  @include flexbox();
   position: relative;
   height: 48px;
   background-color: $tabs-bg-color;


### PR DESCRIPTION
@include flex() was incorrect because we would need to pass values, instead doing this, use mixin flexbox