### PR TITLE
Fixed documentation for submit button. 

### DIFF
--- a/jade/page-contents/buttons_content.html
+++ b/jade/page-contents/buttons_content.html
@@ -74,7 +74,7 @@
         <button class="btn waves-effect waves-light" type="submit" name="action">Submit<i class="material-icons right">send</i></button>
         <pre><code class="language-markup">
   &lt;button class="btn waves-effect waves-light" type="submit" name="action">Submit
-    &lt;i class="material-icons">send</i>&lt;/i>
+    &lt;i class="material-icons right">send</i>&lt;/i>
   &lt;/button>
         </code></pre>
       </div>


### PR DESCRIPTION
In the 'Button' documentation, under the 'Submit Button' section (http://materializecss.com/buttons.html#submit), the example code is missing the 'right' class on the icon. If you use the code as shown, the button text is displayed incorrectly.

This fixes issue #1623 