### PR TITLE
bugfix  issue #1618

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -2725,7 +2725,7 @@ $(document).ready(function(){
       // Tear down structure if Select needs to be rebuilt
       var lastID = $select.data('select-id');
       if (lastID) {
-        $select.parent().find('i').remove();
+        $select.parent().find('span').remove();
         $select.parent().find('input').remove();
 
         $select.unwrap();


### PR DESCRIPTION
in the last update 0.96.1 -> 0.97 you change the `dropdownIcon` from `<i>` to `<span>` but forget to change the `$select.parent().find('i').remove();` on `$select.parent().find('span').remove();`