### PR TITLE
Tooltips automatically remove the previous existing tooltip.

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -25,6 +25,10 @@
       return this.each(function(){
         var tooltipId = Materialize.guid();
         var origin = $(this);
+        var previousTooltipId = origin.attr('data-tooltip-id');
+        if (previousTooltipId) {
+          $('#' + previousTooltipId).remove();
+        }
         origin.attr('data-tooltip-id', tooltipId);
 
         // Create Text span


### PR DESCRIPTION
When you initialize a tooltip on an element, that already has a tooltip. The current behaviour is that mouseEnter and mouseLeave events are unbound, but the .material-tooltip div is left in the DOM. 

With this little commit, that .material-tooltip div is also removed. 
