### PR TITLE
Fix 0 width for empty elements.

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5052,6 +5052,7 @@ span.badge {
     clear: both; }
   .row .col {
     float: left;
+    min-height: 1px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
If an empty element has class ".col .sx", then the element will have no width. With a 1px min-height, the width applied by the responsive classes .col .sx will be applied.