### PR TITLE
Fix bug in the dropdown in/out duration init

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -26,9 +26,9 @@
 
     function updateOptions() {
       if (origin.data('induration') !== undefined)
-        options.inDuration = origin.data('inDuration');
+        options.inDuration = origin.data('induration');
       if (origin.data('outduration') !== undefined)
-        options.outDuration = origin.data('outDuration');
+        options.outDuration = origin.data('outduration');
       if (origin.data('constrainwidth') !== undefined)
         options.constrain_width = origin.data('constrainwidth');
       if (origin.data('hover') !== undefined)


### PR DESCRIPTION
Neither inDuration nor outDuration were being properly set. This is due to what I presume to be a simple typo.