### PR TITLE
Add a css attr to limit the max height of the dropdown by the availab…

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -75,11 +75,19 @@
         gutter_spacing = gutter_spacing * -1;
       }
 
+      // Get and set max height
+      var maxHeight = activates.css('maxHeight').replace(/[^-\d\.]/g, '');
+
+      if (maxHeight > $(document).height() - origin.offset().top){
+        maxHeight = $(document).height() - origin.offset().top;
+      }
+
       // Position dropdown
       activates.css({
         position: 'absolute',
         top: origin.position().top + offset,
-        left: origin.position().left + width_difference + gutter_spacing
+        left: origin.position().left + width_difference + gutter_spacing,
+        maxHeight: maxHeight
       });
 
 


### PR DESCRIPTION
Add a css attr to limit the max height of the dropdown by the available space in the document. This avoid the dropdown to break the rest of the layout in some cases. If this value is higher than the default max height set in the css, then it preserve the default.