### PR TITLE
Update _materialbox.scss

### DIFF
--- a/sass/components/_materialbox.scss
+++ b/sass/components/_materialbox.scss
@@ -13,6 +13,7 @@
 
 .materialboxed.active {
   cursor: zoom-out;
+  max-width: none;
 }
 
 #materialbox-overlay {


### PR DESCRIPTION
Added max-width:none to prevent cropping of zoomed images when used in columns.
