### PR TITLE
rebuilt select caret, on update select structure

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -284,9 +284,7 @@
       // Tear down structure if Select needs to be rebuilt
       var lastID = $select.data('select-id');
       if (lastID) {
-        $select.parent().find('span.caret').remove();
-        $select.parent().find('input').remove();
-
+        $select.parent().find('input, i, .caret').remove();
         $select.unwrap();
         $('ul#select-options-'+lastID).remove();
       }


### PR DESCRIPTION
Hello, I notice when not added a new <option> element, only refresh seleted item, the caret will repeated. example to replicate bug:

``` javascript
$inputSelect.find(':selected').text('rename text');
$inputSelect.material_select();
```
