### PR TITLE
Correct spacing for checkbox documentation

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -456,9 +456,9 @@
             <input type="checkbox" id="test7" checked="checked" disabled="disabled" />
             <label for="test7">Green</label>
           </p>
-            <p>
-              <input type="checkbox" id="test8" disabled="disabled" />
-              <label for="test8">Brown</label>
+          <p>
+            <input type="checkbox" id="test8" disabled="disabled" />
+            <label for="test8">Brown</label>
           </p>
         </form>
         <pre><code class="language-markup">


### PR DESCRIPTION
The spacing for the documentation is indented one tab out too far and not inline with other similar elements. This small change will hopefully improve code readability and visual appearance for those learning materialize or referencing the documents.