### PR TITLE
Fixed navbar Mobile Collapse not giving correct example

### DIFF
--- a/jade/page-contents/navbar_content.html
+++ b/jade/page-contents/navbar_content.html
@@ -326,7 +326,7 @@ $(".dropdown-button").dropdown();
   &lt;nav>
     &lt;div class="nav-wrapper">
       &lt;a href="#!" class="brand-logo">Logo&lt;/a>
-      &lt;a href="#" data-activates="mobile-demo" class="button-collapse">&lt;i class="material-icons">menu</i>&lt;/i>&lt;/a>
+      &lt;a href="#" data-activates="mobile-demo" class="button-collapse">&lt;i class="mdi-navigation-menu"></i>&lt;/i>&lt;/a>
       &lt;ul class="right hide-on-med-and-down">
         &lt;li>&lt;a href="sass.html">Sass&lt;/a>&lt;/li>
         &lt;li>&lt;a href="badges.html">Components&lt;/a>&lt;/li>

--- a/navbar.html
+++ b/navbar.html
@@ -429,7 +429,7 @@ $(".dropdown-button").dropdown();
   &lt;nav>
     &lt;div class="nav-wrapper">
       &lt;a href="#!" class="brand-logo">Logo&lt;/a>
-      &lt;a href="#" data-activates="mobile-demo" class="button-collapse">&lt;i class="material-icons">menu</i>&lt;/i>&lt;/a>
+      &lt;a href="#" data-activates="mobile-demo" class="button-collapse">&lt;i class="mdi-navigation-menu"></i>&lt;/i>&lt;/a>
       &lt;ul class="right hide-on-med-and-down">
         &lt;li>&lt;a href="sass.html">Sass&lt;/a>&lt;/li>
         &lt;li>&lt;a href="badges.html">Components&lt;/a>&lt;/li>


### PR DESCRIPTION
The example on the NavBar page, at Mobile Collapse, doesn't give the right example. It's saying you need to add

```html
<i class="material-icons">menu</i>
```

But it should be

```html
<i class="mdi-navigation-menu"></i>
```

Like how it is on the SideNav page under JavaScript.

This commit fixed that.