### PR TITLE
Replaced all mdi-* occurences in the documentation

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
   </head>
   <body>
     <header>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/badges.html
+++ b/badges.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Badges</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>
@@ -143,7 +143,7 @@
               <li><a href="#!">two<span class="new badge">1</span></a></li>
               <li><a href="#!">three</a></li>
             </ul>
-            <a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown<i class="mdi-navigation-arrow-drop-down right"></i></a>
+            <a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown<i class="material-icons right">arrow_drop_down</i></a>
 
             <pre><code class="language-markup">
   &lt;ul id="dropdown2" class="dropdown-content">
@@ -151,7 +151,7 @@
     &lt;li>&lt;a href="#!">two&lt;span class="new badge">1&lt;/span>&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">three&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown&lt;i class="mdi-navigation-arrow-drop-down right">&lt;/i>&lt;/a>
+  &lt;a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown&lt;i class="material-icons right">arrow_drop_down&lt;/i>&lt;/a>
             </code></pre>
 
           </div>

--- a/buttons.html
+++ b/buttons.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Buttons</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/cards.html
+++ b/cards.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Cards</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/chips.html
+++ b/chips.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Chips</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/collapsible.html
+++ b/collapsible.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Collapsible</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>
@@ -202,7 +202,7 @@
           </li>
         </ul>
         <pre><code class="language-markup">
-  &lt;div class="collapsible-header active">&lt;i class="mdi-maps-place">&lt;/i>Second&lt;/div>
+  &lt;div class="collapsible-header active">&lt;i class="material-icons">place&lt;/i>Second&lt;/div>
         </code></pre>
       </div>
 

--- a/collections.html
+++ b/collections.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Collections</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/color.html
+++ b/color.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Color</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/dialogs.html
+++ b/dialogs.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Dialogs</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/dropdown.html
+++ b/dropdown.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Dropdown</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/footer.html
+++ b/footer.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Footer</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/forms.html
+++ b/forms.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Forms</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/getting-started.html
+++ b/getting-started.html
@@ -32,7 +32,7 @@
   </head>
   <body>
     <header>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>
@@ -258,8 +258,8 @@
         <p class="promo-caption">Parallax Template</p>
         <a href="templates/parallax-template/preview.html"><img class="z-depth-1" style="width: 100%;" src="images/parallax-template.jpg"></a>
         <p>This is the simplest starter page with a Header, Call-to-Action, and Icon Features. </p>
-        <a class="btn waves-effect waves-light" href="templates/parallax-template/preview.html">Demo<i class="mdi-action-search right"></i></a>
-        <a class="btn waves-effect waves-light" href="templates/parallax-template.zip">Download<i class="mdi-file-file-download right"></i></a>
+        <a class="btn waves-effect waves-light" href="templates/parallax-template/preview.html">Demo<i class="material-icons right">search</i></a>
+        <a class="btn waves-effect waves-light" href="templates/parallax-template.zip">Download<i class="material-icons right">file_download</i></a>
       </div>
     </div>
 

--- a/grid.html
+++ b/grid.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Grid</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/helpers.html
+++ b/helpers.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Helpers</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/icons.html
+++ b/icons.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Icons</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   </head>
   <body>
     <header>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav waves-effect waves-light circle hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/jade/_navbar.jade
+++ b/jade/_navbar.jade
@@ -6,7 +6,7 @@ header
           a.page-title #{page}
   .container
     a.button-collapse.top-nav(href='#', data-activates='nav-mobile', class=(no_nav == false ? "full hide-on-large-only" : "" + "waves-effect waves-light circle hide-on-large-only"))
-      i.mdi-navigation-menu
+      i.material-icons menu
   ul#nav-mobile.side-nav.fixed
     li(class="logo")
       a#logo-container.brand-logo(href='http://materializecss.com/')

--- a/jade/getting_started/getting_started_content.html
+++ b/jade/getting_started/getting_started_content.html
@@ -160,8 +160,8 @@
         <p class="promo-caption">Parallax Template</p>
         <a href="templates/parallax-template/preview.html"><img class="z-depth-1" style="width: 100%;" src="images/parallax-template.jpg"></a>
         <p>This is the simplest starter page with a Header, Call-to-Action, and Icon Features. </p>
-        <a class="btn waves-effect waves-light" href="templates/parallax-template/preview.html">Demo<i class="mdi-action-search right"></i></a>
-        <a class="btn waves-effect waves-light" href="templates/parallax-template.zip">Download<i class="mdi-file-file-download right"></i></a>
+        <a class="btn waves-effect waves-light" href="templates/parallax-template/preview.html">Demo<i class="material-icons right">search</i></a>
+        <a class="btn waves-effect waves-light" href="templates/parallax-template.zip">Download<i class="material-icons right">file_download</i></a>
       </div>
     </div>
 

--- a/jade/page-contents/badges_content.html
+++ b/jade/page-contents/badges_content.html
@@ -40,7 +40,7 @@
               <li><a href="#!">two<span class="new badge">1</span></a></li>
               <li><a href="#!">three</a></li>
             </ul>
-            <a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown<i class="mdi-navigation-arrow-drop-down right"></i></a>
+            <a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown<i class="material-icons right">arrow_drop_down</i></a>
 
             <pre><code class="language-markup">
   &lt;ul id="dropdown2" class="dropdown-content">
@@ -48,7 +48,7 @@
     &lt;li>&lt;a href="#!">two&lt;span class="new badge">1&lt;/span>&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">three&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown&lt;i class="mdi-navigation-arrow-drop-down right">&lt;/i>&lt;/a>
+  &lt;a class="btn dropdown-button" href="#!" data-activates="dropdown2">Dropdown&lt;i class="material-icons right">arrow_drop_down&lt;/i>&lt;/a>
             </code></pre>
 
           </div>

--- a/jade/page-contents/collapsible_content.html
+++ b/jade/page-contents/collapsible_content.html
@@ -99,7 +99,7 @@
           </li>
         </ul>
         <pre><code class="language-markup">
-  &lt;div class="collapsible-header active">&lt;i class="mdi-maps-place">&lt;/i>Second&lt;/div>
+  &lt;div class="collapsible-header active">&lt;i class="material-icons">place&lt;/i>Second&lt;/div>
         </code></pre>
       </div>
 

--- a/jade/page-contents/parallax_demo_content.html
+++ b/jade/page-contents/parallax_demo_content.html
@@ -4,9 +4,9 @@
       <div class="nav-wrapper">
         <a href="index.html" class="brand-logo">Materialize</a>
         <ul class="right side-nav" id="nav-mobile">
-          <li class="hide-on-small-only"><a href="parallax.html"><i class="mdi-navigation-arrow-back"></i></a></li>
+          <li class="hide-on-small-only"><a href="parallax.html"><i class="material-icons">arrow_back</i></a></li>
         </ul>
-        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="mdi-navigation-menu"></i></a>
+        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="material-icons">menu</i></a>
       </div>
     </div>
   </nav>

--- a/jade/page-contents/sideNav_content.html
+++ b/jade/page-contents/sideNav_content.html
@@ -21,7 +21,7 @@
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
 &lt;/nav>
         </code></pre>
 
@@ -71,7 +71,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li class="no-padding">
       &lt;ul class="collapsible collapsible-accordion">
         &lt;li>
-          &lt;a class="collapsible-header">Dropdown&lt;i class="mdi-navigation-arrow-drop-down">&lt;/i>&lt;/a>
+          &lt;a class="collapsible-header">Dropdown&lt;i class="material-icons">arrow_drop_down&lt;/i>&lt;/a>
           &lt;div class="collapsible-body">
             &lt;ul>
               &lt;li>&lt;a href="#!">First&lt;/a>&lt;/li>
@@ -87,7 +87,7 @@ $('.button-collapse').sideNav('hide');
   &lt;ul class="right hide-on-med-and-down">
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
-    &lt;li>&lt;a class="dropdown-button" href="#!" data-activates="dropdown1">Dropdown&lt;i class="mdi-navigation-arrow-drop-down right">&lt;/i>&lt;/a>&lt;/li>
+    &lt;li>&lt;a class="dropdown-button" href="#!" data-activates="dropdown1">Dropdown&lt;i class="material-icons right">arrow_drop_down&lt;/i>&lt;/a>&lt;/li>
     &lt;ul id='dropdown1' class='dropdown-content'>
       &lt;li>&lt;a href="#!">First&lt;/a>&lt;/li>
       &lt;li>&lt;a href="#!">Second&lt;/a>&lt;/li>
@@ -95,7 +95,7 @@ $('.button-collapse').sideNav('hide');
       &lt;li>&lt;a href="#!">Fourth&lt;/a>&lt;/li>
     &lt;/ul>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
 
         <h4>Fullscreen HTML Structure</h4>
@@ -106,7 +106,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse show-on-large">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse show-on-large">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
 
         <h4>Fixed HTML Structure</h4>
@@ -116,7 +116,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
         <p>If you are planning on using this you will have to offset your content by the width of the side menu. Place the padding on where the offset content will be, which in our case is in header, main and footer.</p>
         <pre><code class="language-css col s12">

--- a/jade/parallax/parallax_content.html
+++ b/jade/parallax/parallax_content.html
@@ -4,14 +4,14 @@
       <div class="nav-wrapper">
         <a href="index.html" class="brand-logo">Materialize</a>
         <ul class="right side-nav" id="nav-mobile">
-          <li class="hide-on-small-only"><a href="collapsible.html"><i class="mdi-navigation-arrow-back"></i></a></li>
+          <li class="hide-on-small-only"><a href="collapsible.html"><i class="material-icons">arrow_back</i></a></li>
           <li><a href="about.html">About</a></li>
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="sass.html">Sass</a></li>
           <li><a href="badges.html">Components</a></li>
           <li class="active"><a href="collapsible.html">JavaScript</a></li>
         </ul>
-        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="mdi-navigation-menu"></i></a>
+        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="material-icons">menu</i></a>
       </div>
     </div>
   </nav>

--- a/media-css.html
+++ b/media-css.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Media CSS</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/media.html
+++ b/media.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Media</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/mobile.html
+++ b/mobile.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Mobile</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/modals.html
+++ b/modals.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Modals</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/navbar.html
+++ b/navbar.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Navbar</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/pagination.html
+++ b/pagination.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Pagination</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/parallax-demo.html
+++ b/parallax-demo.html
@@ -36,9 +36,9 @@
       <div class="nav-wrapper">
         <a href="index.html" class="brand-logo">Materialize</a>
         <ul class="right side-nav" id="nav-mobile">
-          <li class="hide-on-small-only"><a href="parallax.html"><i class="mdi-navigation-arrow-back"></i></a></li>
+          <li class="hide-on-small-only"><a href="parallax.html"><i class="material-icons">arrow_back</i></a></li>
         </ul>
-        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="mdi-navigation-menu"></i></a>
+        <a class="button-collapse" href="#" data-activates='nav-mobile'><i class="material-icons">menu</i></a>
       </div>
     </div>
   </nav>

--- a/parallax.html
+++ b/parallax.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Parallax</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/preloader.html
+++ b/preloader.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Preloader</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/pushpin.html
+++ b/pushpin.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Pushpin</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/sass.html
+++ b/sass.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Sass</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/scrollfire.html
+++ b/scrollfire.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">ScrollFire</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/scrollspy.html
+++ b/scrollspy.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Scrollspy</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/shadow.html
+++ b/shadow.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Shadow</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/showcase.html
+++ b/showcase.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Showcase</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/side-nav.html
+++ b/side-nav.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">SideNav</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>
@@ -124,7 +124,7 @@
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
 &lt;/nav>
         </code></pre>
 
@@ -174,7 +174,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li class="no-padding">
       &lt;ul class="collapsible collapsible-accordion">
         &lt;li>
-          &lt;a class="collapsible-header">Dropdown&lt;i class="mdi-navigation-arrow-drop-down">&lt;/i>&lt;/a>
+          &lt;a class="collapsible-header">Dropdown&lt;i class="material-icons">arrow_drop_down&lt;/i>&lt;/a>
           &lt;div class="collapsible-body">
             &lt;ul>
               &lt;li>&lt;a href="#!">First&lt;/a>&lt;/li>
@@ -190,7 +190,7 @@ $('.button-collapse').sideNav('hide');
   &lt;ul class="right hide-on-med-and-down">
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
-    &lt;li>&lt;a class="dropdown-button" href="#!" data-activates="dropdown1">Dropdown&lt;i class="mdi-navigation-arrow-drop-down right">&lt;/i>&lt;/a>&lt;/li>
+    &lt;li>&lt;a class="dropdown-button" href="#!" data-activates="dropdown1">Dropdown&lt;i class="material-icons right">arrow_drop_down&lt;/i>&lt;/a>&lt;/li>
     &lt;ul id='dropdown1' class='dropdown-content'>
       &lt;li>&lt;a href="#!">First&lt;/a>&lt;/li>
       &lt;li>&lt;a href="#!">Second&lt;/a>&lt;/li>
@@ -198,7 +198,7 @@ $('.button-collapse').sideNav('hide');
       &lt;li>&lt;a href="#!">Fourth&lt;/a>&lt;/li>
     &lt;/ul>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
 
         <h4>Fullscreen HTML Structure</h4>
@@ -209,7 +209,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse show-on-large">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse show-on-large">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
 
         <h4>Fixed HTML Structure</h4>
@@ -219,7 +219,7 @@ $('.button-collapse').sideNav('hide');
     &lt;li>&lt;a href="#!">First Sidebar Link&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">Second Sidebar Link&lt;/a>&lt;/li>
   &lt;/ul>
-  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="mdi-navigation-menu">&lt;/i>&lt;/a>
+  &lt;a href="#" data-activates="slide-out" class="button-collapse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
         </code></pre>
         <p>If you are planning on using this you will have to offset your content by the width of the side menu. Place the padding on where the offset content will be, which in our case is in header, main and footer.</p>
         <pre><code class="language-css col s12">

--- a/table.html
+++ b/table.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Table</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/tabs.html
+++ b/tabs.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Tabs</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/transitions.html
+++ b/transitions.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Transitions</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/typography.html
+++ b/typography.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Typography</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>

--- a/waves.html
+++ b/waves.html
@@ -37,7 +37,7 @@
           <div class="nav-wrapper"><a class="page-title">Waves</a></div>
         </div>
       </nav>
-      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="mdi-navigation-menu"></i></a></div>
+      <div class="container"><a href="#" data-activates="nav-mobile" class="button-collapse top-nav full hide-on-large-only"><i class="material-icons">menu</i></a></div>
       <ul id="nav-mobile" class="side-nav fixed">
         <li class="logo"><a id="logo-container" href="http://materializecss.com/" class="brand-logo">
             <object id="front-page-logo" type="image/svg+xml" data="res/materialize.svg">Your browser does not support SVG</object></a></li>


### PR DESCRIPTION
All mdi-* class references are now the new material-icons references.

I didn't touch the tests, as they seem to break when doing this. (old version?)
Same goes for the templates, which are broken as is.