### PR TITLE
openModal and blank scrollbar due to overflow: hidden

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -9,7 +9,7 @@
   $.fn.extend({
     openModal: function(options) {
 
-      $('body').css('overflow', 'hidden');
+      $('body').addClass('modal-opened').css('overflow', 'hidden');
 
       var defaults = {
         opacity: 0.5,
@@ -107,7 +107,7 @@
       options = $.extend(defaults, options);
 
       // Disable scrolling
-      $('body').css('overflow', '');
+      $('body').removeClass('modal-opened').css('overflow', '');
 
       $modal.find('.modal-close').off('click.close');
       $(document).off('keyup.leanModal' + overlayID);


### PR DESCRIPTION
Add class .modal-opened to <body> on opening/closing modals, to handle no scrollbars in the DOM (like prevent glitchy movement on overflow: hidden)
