### PR TITLE
SideNav produces multiple #sidenav-overlay divs

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -255,7 +255,7 @@
               $('body').css('overflow', 'hidden');
               // Push current drag target on top of DOM tree
               $('body').append(dragTarget);
-              
+
               if (options.edge === 'left') {
                 dragTarget.css({width: '50%', right: 0, left: ''});
                 menu_id.velocity({left: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
@@ -265,26 +265,27 @@
                 menu_id.velocity({right: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
                 menu_id.css('left','');
               }
-
-              var overlay = $('<div id="sidenav-overlay"></div>');
-              overlay.css('opacity', 0)
-              .click(function(){
-                menuOut = false;
-                panning = false;
-                removeMenu();
-                overlay.velocity({opacity: 0}, {duration: 300, queue: false, easing: 'easeOutQuad',
-                  complete: function() {
-                    $(this).remove();
-                  } });
-
-              });
-              $('body').append(overlay);
-              overlay.velocity({opacity: 1}, {duration: 300, queue: false, easing: 'easeOutQuad',
-                complete: function () {
-                  menuOut = true;
+              if($('#sidenav-overlay').length == 0) {
+                var overlay = $('<div id="sidenav-overlay"></div>');
+                overlay.css('opacity', 0)
+                .click(function(){
+                  menuOut = false;
                   panning = false;
-                }
-              });
+                  removeMenu();
+                  overlay.velocity({opacity: 0}, {duration: 300, queue: false, easing: 'easeOutQuad',
+                    complete: function() {
+                      $(this).remove();
+                    } });
+
+                });
+                $('body').append(overlay);
+                overlay.velocity({opacity: 1}, {duration: 300, queue: false, easing: 'easeOutQuad',
+                  complete: function () {
+                    menuOut = true;
+                    panning = false;
+                  }
+                });
+              }
             }
 
             return false;


### PR DESCRIPTION
When I click on side menu item, sideNav.js generates multiple sidenav-overlay divs. It's because of absence of checking near line 268 in sideNav.js. This commit fixes it.
![materialize-bug](https://cloud.githubusercontent.com/assets/1220993/9119292/9438a618-3c7e-11e5-9cf9-f548ed7b0955.png)
