### PR TITLE
Bug fix - fixed right aligned fixed sidebar

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -36,7 +36,7 @@
         // If fixed sidenav, bring menu out
         if (menu_id.hasClass('fixed')) {
             if (window.innerWidth > 992) {
-              menu_id.css('left', 0);
+              menu_id.css(options.edge, 0);
             }
           }
 


### PR DESCRIPTION
This fixes a bug I experienced with the right aligned fixed sidebar. The sidebar displays on the right but as soon as the javascript loads, it immediately jumps over to the left side of the window.
