### PR TITLE
Decentralized icon on the nav bar for small screens

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5251,6 +5251,7 @@ nav {
     position: relative;
     height: 100%; }
     nav .nav-wrapper i {
+      line-height: inherit;
       display: block;
       font-size: 2rem; }
   @media only screen and (min-width : 993px) {
@@ -5335,7 +5336,6 @@ nav {
       top: 0;
       left: 0; }
       nav .input-field label i {
-        line-height: inherit;
         color: rgba(255, 255, 255, 0.7);
         -webkit-transition: color .3s;
         -moz-transition: color .3s;

--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5335,6 +5335,7 @@ nav {
       top: 0;
       left: 0; }
       nav .input-field label i {
+        line-height: inherit;
         color: rgba(255, 255, 255, 0.7);
         -webkit-transition: color .3s;
         -moz-transition: color .3s;

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5251,6 +5251,7 @@ nav {
     position: relative;
     height: 100%; }
     nav .nav-wrapper i {
+      line-height: inherit;
       display: block;
       font-size: 2rem; }
   @media only screen and (min-width : 993px) {
@@ -5335,7 +5336,6 @@ nav {
       top: 0;
       left: 0; }
       nav .input-field label i {
-        line-height: inherit;
         color: rgba(255, 255, 255, 0.7);
         -webkit-transition: color .3s;
         -moz-transition: color .3s;

--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5335,6 +5335,7 @@ nav {
       top: 0;
       left: 0; }
       nav .input-field label i {
+        line-height: inherit;
         color: rgba(255, 255, 255, 0.7);
         -webkit-transition: color .3s;
         -moz-transition: color .3s;

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -121,6 +121,7 @@ nav {
       left: 0;
 
       i {
+        line-height: inherit;
         color: rgba(255,255,255,.7);
         @include transition(color .3s);
       }

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -13,6 +13,7 @@ nav {
     height: 100%;
 
     i {
+      line-height: inherit;
       display: block;
       font-size: 2rem;
     }
@@ -121,7 +122,6 @@ nav {
       left: 0;
 
       i {
-        line-height: inherit;
         color: rgba(255,255,255,.7);
         @include transition(color .3s);
       }


### PR DESCRIPTION
The search bar icon gets decentralized when the screen is small.
I tested this behavior on
- Google Chrome 44.0.2403.130 (64-bit) - elementary OS 0.2.1
- Firefox 39.0.3 - elementary OS 0.2.1
- Google Chrome 44.0.2403.133 - Android 4.4.4

![screenshot from 2015-08-10 21 55 01](https://cloud.githubusercontent.com/assets/5948318/9188903/0379f1f8-3fb8-11e5-9d31-8e223b71105c.png)
![screenshot from 2015-08-10 21 55 10](https://cloud.githubusercontent.com/assets/5948318/9188904/037a2e48-3fb8-11e5-847b-2ae9e5378b52.png)

The problem is that on small screens, the line-height: 1 of the material-icons class is dominant. So, adding line-height: inherit to the icon inside the navbar solves the problem.

Working Codepen: http://codepen.io/brunocalou/pen/RPdYGR
Resize the page to see the bug
