### PR TITLE
Small error in length comparator

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -83,7 +83,7 @@
       else {
         if (object.hasClass('validate')) {
           // Check for character counter attributes
-          if ((object.is(':valid') && hasLength && (len < lenAttr)) || (object.is(':valid') && !hasLength)) {
+          if ((object.is(':valid') && hasLength && (len <= lenAttr)) || (object.is(':valid') && !hasLength)) {
             object.removeClass('invalid');
             object.addClass('valid');
           }


### PR DESCRIPTION
If I create an input with a length of 10, I write 10 characters and I focus out the input, the entry is marked as invalid because there is a small error in the comparator.

http://codepen.io/anon/pen/vOwZXa