### PR TITLE
line-height from .toast {} changed

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5658,7 +5658,7 @@ small {
   position: relative;
   max-width: 100%;
   height: 48px;
-  line-height: 48px;
+  line-height: inherit;
   background-color: #323232;
   padding: 0 25px;
   font-size: 1.1rem;


### PR DESCRIPTION
On smaller resolutions, when text are large (a lot of chars), the line-height crashs and nothing is readable

![before](https://cloud.githubusercontent.com/assets/6654033/9547941/f5da9aa6-4d73-11e5-8f85-842a985a4c7d.png)

![after](https://cloud.githubusercontent.com/assets/6654033/9547940/f5d5686a-4d73-11e5-8159-df20b761c39e.png)