### PR TITLE
Add support for materialize multiple select. Fix bug with active class.

### DIFF
--- a/css/ghpages-materialize.css
+++ b/css/ghpages-materialize.css
@@ -5919,13 +5919,19 @@ button.btn-floating {
     width: 100%;
     text-align: left;
     text-transform: none; }
-    .dropdown-content li:hover, .dropdown-content li.active {
+    .dropdown-content li:hover, .dropdown-content li.active, .dropdown-content li.selected {
       background-color: #eee; }
+    .dropdown-content li.active.selected {
+      background-color: #e1e1e1;
+    }
     .dropdown-content li > a, .dropdown-content li > span {
       font-size: 1.2rem;
       color: #26a69a;
       display: block;
       padding: 1rem 1rem; }
+    .dropdown-content li > a, .dropdown-content li > span > label {
+      top: 0.6rem;
+      left: 0.2rem; }
     .dropdown-content li > a > i {
       height: inherit;
       line-height: inherit; }

--- a/forms.html
+++ b/forms.html
@@ -378,6 +378,17 @@
                 </select>
                 <label>Materialize Select</label>
               </div>
+              <div class="input-field col s12">
+                <br>
+                <p>You can add the property <code class="language-markup">multiple</code> to get the multiple select and select several options.</p>
+                <select multiple>
+                  <option value="" disabled selected>Choose your option</option>
+                  <option value="1">Option 1</option>
+                  <option value="2">Option 2</option>
+                  <option value="3">Option 3</option>
+                </select>
+                <label>Materialize Multiple Select</label>
+              </div>
               <div class="col s12">
                 <br>
                 <p>You can add the class <code class="language-markup">browser-default</code> to get the browser default.</p>
@@ -403,13 +414,23 @@
     &lt;label>Materialize Select&lt;/label>
   &lt;/div>
 
-    &lt;label>Browser Select&lt;/label>
-    &lt;select class="browser-default">
+  &lt;div class="col s12">
+    &lt;select multiple>
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="1">Option 1&lt;/option>
       &lt;option value="2">Option 2&lt;/option>
       &lt;option value="3">Option 3&lt;/option>
     &lt;/select>
+    &lt;label>Materialize Multiple Select&lt;/label>
+  &lt;/div>
+
+  &lt;label>Browser Select&lt;/label>
+  &lt;select class="browser-default">
+    &lt;option value="" disabled selected>Choose your option&lt;/option>
+    &lt;option value="1">Option 1&lt;/option>
+    &lt;option value="2">Option 2&lt;/option>
+    &lt;option value="3">Option 3&lt;/option>
+  &lt;/select>
             </code></pre>
           </div>
           <div class="col s12">

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -48,7 +48,9 @@
       updateOptions();
 
       // Attach dropdown to its activator
-      origin.after(activates);
+      origin.on("click", function () {
+        origin.after(activates);
+      });
 
       /*
        Helper function to position and resize dropdown.

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,183 +15,185 @@
       hover: false,
       gutter: 0, // Spacing from edge
       belowOrigin: false,
-      alignment: 'left'
+      alignment: 'left',
+      closeOnClick: true
     };
 
     this.each(function(){
-    var origin = $(this);
-    var options = $.extend({}, defaults, option);
+      var origin = $(this);
+      var options = $.extend({}, defaults, option);
 
-    // Dropdown menu
-    var activates = $("#"+ origin.attr('data-activates'));
+      // Dropdown menu
+      var activates = $("#"+ origin.attr('data-activates'));
 
-    function updateOptions() {
-      if (origin.data('induration') !== undefined)
-        options.inDuration = origin.data('inDuration');
-      if (origin.data('outduration') !== undefined)
-        options.outDuration = origin.data('outDuration');
-      if (origin.data('constrainwidth') !== undefined)
-        options.constrain_width = origin.data('constrainwidth');
-      if (origin.data('hover') !== undefined)
-        options.hover = origin.data('hover');
-      if (origin.data('gutter') !== undefined)
-        options.gutter = origin.data('gutter');
-      if (origin.data('beloworigin') !== undefined)
-        options.belowOrigin = origin.data('beloworigin');
-      if (origin.data('alignment') !== undefined)
-        options.alignment = origin.data('alignment');
-    }
+      function updateOptions() {
+        if (origin.data('induration') !== undefined)
+          options.inDuration = origin.data('inDuration');
+        if (origin.data('outduration') !== undefined)
+          options.outDuration = origin.data('outDuration');
+        if (origin.data('constrainwidth') !== undefined)
+          options.constrain_width = origin.data('constrainwidth');
+        if (origin.data('hover') !== undefined)
+          options.hover = origin.data('hover');
+        if (origin.data('gutter') !== undefined)
+          options.gutter = origin.data('gutter');
+        if (origin.data('beloworigin') !== undefined)
+          options.belowOrigin = origin.data('beloworigin');
+        if (origin.data('alignment') !== undefined)
+          options.alignment = origin.data('alignment');
+        if (origin.data('closeOnClick') !== undefined)
+          options.closeOnClick = origin.data('closeOnClick');
+      }
 
-    updateOptions();
-
-    // Attach dropdown to its activator
-    origin.after(activates);
-
-    /*
-      Helper function to position and resize dropdown.
-      Used in hover and click handler.
-    */
-    function placeDropdown() {
-      // Check html data attributes
       updateOptions();
 
-      // Set Dropdown state
-      activates.addClass('active');
+      // Attach dropdown to its activator
+      origin.after(activates);
 
-      // Constrain width
-      if (options.constrain_width === true) {
-        activates.css('width', origin.outerWidth());
-      }
-      else {
-        activates.css('white-space', 'nowrap');
-      }
-      var offset = 0;
-      if (options.belowOrigin === true) {
-        offset = origin.height();
-      }
+      /*
+       Helper function to position and resize dropdown.
+       Used in hover and click handler.
+       */
+      function placeDropdown() {
+        // Check html data attributes
+        updateOptions();
 
-      // Offscreen detection
-      var offsetLeft = origin.offset().left;
-      var activatesLeft, width_difference, gutter_spacing;
-      if (offsetLeft + activates.innerWidth() > $(window).width()) {
-        options.alignment = 'right';
-      }
-      else if (offsetLeft - activates.innerWidth() + origin.innerWidth() < 0) {
-        options.alignment = 'left';
-      }
+        // Set Dropdown state
+        activates.addClass('active');
 
-      // Handle edge alignment
-      if (options.alignment === 'left') {
-        width_difference = 0;
-        gutter_spacing = options.gutter;
-        activatesLeft = origin.position().left + width_difference + gutter_spacing;
-
-        // Position dropdown
-        activates.css({ left: activatesLeft });
-      }
-      else if (options.alignment === 'right') {
-        var offsetRight = $(window).width() - offsetLeft - origin.innerWidth();
-        width_difference = 0;
-        gutter_spacing = options.gutter;
-        activatesLeft =  ( $(window).width() - origin.position().left - origin.innerWidth() ) + gutter_spacing;
-
-        // Position dropdown
-        activates.css({ right: activatesLeft });
-      }
-      // Position dropdown
-      activates.css({
-        position: 'absolute',
-        top: origin.position().top + offset,
-      });
-
-
-
-      // Show dropdown
-      activates.stop(true, true).css('opacity', 0)
-        .slideDown({
-        queue: false,
-        duration: options.inDuration,
-        easing: 'easeOutCubic',
-        complete: function() {
-          $(this).css('height', '');
+        // Constrain width
+        if (options.constrain_width === true) {
+          activates.css('width', origin.outerWidth());
         }
-      })
-        .animate( {opacity: 1}, {queue: false, duration: options.inDuration, easing: 'easeOutSine'});
-    }
-
-    function hideDropdown() {
-      activates.fadeOut(options.outDuration);
-      activates.removeClass('active');
-    }
-
-    // Hover
-    if (options.hover) {
-      var open = false;
-      origin.unbind('click.' + origin.attr('id'));
-      // Hover handler to show dropdown
-      origin.on('mouseenter', function(e){ // Mouse over
-        if (open === false) {
-          placeDropdown();
-          open = true;
-        }
-      });
-      origin.on('mouseleave', function(e){
-        // If hover on origin then to something other than dropdown content, then close
-        var toEl = e.toElement || e.relatedTarget; // added browser compatibility for target element
-        if(!$(toEl).closest('.dropdown-content').is(activates)) {
-          activates.stop(true, true);
-          hideDropdown();
-          open = false;
-        }
-      });
-
-      activates.on('mouseleave', function(e){ // Mouse out
-        var toEl = e.toElement || e.relatedTarget;
-        if(!$(toEl).closest('.dropdown-button').is(origin)) {
-          activates.stop(true, true);
-          hideDropdown();
-          open = false;
-        }
-      });
-
-    // Click
-    } else {
-
-      // Click handler to show dropdown
-      origin.unbind('click.' + origin.attr('id'));
-      origin.bind('click.'+origin.attr('id'), function(e){
-
-        if ( origin[0] == e.currentTarget && ($(e.target).closest('.dropdown-content').length === 0) ) {
-          e.preventDefault(); // Prevents button click from moving window
-          placeDropdown();
-
-        }
-        // If origin is clicked and menu is open, close menu
         else {
-          if (origin.hasClass('active')) {
-            hideDropdown();
-            $(document).unbind('click.' + activates.attr('id'));
-          }
+          activates.css('white-space', 'nowrap');
         }
-        // If menu open, add click close handler to document
-        if (activates.hasClass('active')) {
-          $(document).bind('click.'+ activates.attr('id'), function (e) {
-            if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length > 0) ) {
+        var offset = 0;
+        if (options.belowOrigin === true) {
+          offset = origin.height();
+        }
+
+        // Offscreen detection
+        var offsetLeft = origin.offset().left;
+        var activatesLeft, width_difference, gutter_spacing;
+        if (offsetLeft + activates.innerWidth() > $(window).width()) {
+          options.alignment = 'right';
+        }
+        else if (offsetLeft - activates.innerWidth() + origin.innerWidth() < 0) {
+          options.alignment = 'left';
+        }
+
+        // Handle edge alignment
+        if (options.alignment === 'left') {
+          width_difference = 0;
+          gutter_spacing = options.gutter;
+          activatesLeft = origin.position().left + width_difference + gutter_spacing;
+
+          // Position dropdown
+          activates.css({ left: activatesLeft });
+        }
+        else if (options.alignment === 'right') {
+          var offsetRight = $(window).width() - offsetLeft - origin.innerWidth();
+          width_difference = 0;
+          gutter_spacing = options.gutter;
+          activatesLeft =  ( $(window).width() - origin.position().left - origin.innerWidth() ) + gutter_spacing;
+
+          // Position dropdown
+          activates.css({ right: activatesLeft });
+        }
+        // Position dropdown
+        activates.css({
+          position: 'absolute',
+          top: origin.position().top + offset,
+        });
+
+
+
+        // Show dropdown
+        activates.stop(true, true).css('opacity', 0)
+            .slideDown({
+              queue: false,
+              duration: options.inDuration,
+              easing: 'easeOutCubic',
+              complete: function() {
+                $(this).css('height', '');
+              }
+            })
+            .animate( {opacity: 1}, {queue: false, duration: options.inDuration, easing: 'easeOutSine'});
+      }
+
+      function hideDropdown() {
+        activates.fadeOut(options.outDuration);
+        activates.removeClass('active');
+      }
+
+      // Hover
+      if (options.hover) {
+        var open = false;
+        origin.unbind('click.' + origin.attr('id'));
+        // Hover handler to show dropdown
+        origin.on('mouseenter', function(e){ // Mouse over
+          if (open === false) {
+            placeDropdown();
+            open = true;
+          }
+        });
+        origin.on('mouseleave', function(e){
+          // If hover on origin then to something other than dropdown content, then close
+          var toEl = e.toElement || e.relatedTarget; // added browser compatibility for target element
+          if(!$(toEl).closest('.dropdown-content').is(activates)) {
+            activates.stop(true, true);
+            hideDropdown();
+            open = false;
+          }
+        });
+
+        activates.on('mouseleave', function(e){ // Mouse out
+          var toEl = e.toElement || e.relatedTarget;
+          if(!$(toEl).closest('.dropdown-button').is(origin)) {
+            activates.stop(true, true);
+            hideDropdown();
+            open = false;
+          }
+        });
+
+        // Click
+      } else {
+        // Click handler to show dropdown
+        origin.unbind('click.' + origin.attr('id'));
+        origin.bind('click.'+origin.attr('id'), function(e){
+
+          if ( origin[0] == e.currentTarget && ($(e.target).closest('.dropdown-content').length === 0) ) {
+            e.preventDefault(); // Prevents button click from moving window
+            placeDropdown();
+
+          }
+          // If origin is clicked and menu is open, close menu
+          else {
+            if (origin.hasClass('active')) {
               hideDropdown();
               $(document).unbind('click.' + activates.attr('id'));
             }
-          });
-        }
-      });
+          }
+          // If menu open, add click close handler to document
+          if (activates.hasClass('active')) {
+            $(document).bind('click.'+ activates.attr('id'), function (e) {
+              if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length > 0) && options.closeOnClick) {
+                hideDropdown();
+                $(document).unbind('click.' + activates.attr('id'));
+              }
+            });
+          }
+        });
 
-    } // End else
+      } // End else
 
-    // Listen to open and close event - useful for select component
-    origin.on('open', placeDropdown);
-    origin.on('close', hideDropdown);
+      // Listen to open and close event - useful for select component
+      origin.on('open', placeDropdown);
+      origin.on('close', hideDropdown);
 
 
-   });
+    });
   }; // End dropdown plugin
 
   $(document).ready(function(){

--- a/js/forms.js
+++ b/js/forms.js
@@ -386,9 +386,10 @@
 
           label = $(this).val();
 
-          if (multiple && !$(this).siblings('ul.dropdown-content').is(':visible')) {
-            $(this).trigger('open');
-          } else if (multiple) {
+          if (multiple) {
+            if (!$(this).siblings('ul.dropdown-content').is(':visible'))
+              $(this).trigger('open');
+
             var selectedOption = options.find('li:not(.disabled)')[0];
           } else {
             $(this).trigger('open');

--- a/js/forms.js
+++ b/js/forms.js
@@ -380,13 +380,15 @@
       $select.addClass('initialized');
 
       $newSelect.on({
-        'focus': function (e){
+        'focus': function (){
           if ($('ul.select-dropdown').not(options[0]).is(':visible'))
             $('input.select-dropdown').trigger('close');
 
           label = $(this).val();
 
-          if (multiple) {
+          if (multiple && !$(this).siblings('ul.dropdown-content').is(':visible')) {
+            $(this).trigger('open');
+          } else if (multiple) {
             var selectedOption = options.find('li:not(.disabled)')[0];
           } else {
             $(this).trigger('open');
@@ -400,11 +402,6 @@
         },
         'click': function (e){
           e.stopPropagation();
-        },
-        'keyup': function () {
-          if (multiple && !$(this).siblings('ul.dropdown-content').is(':visible')) {
-            $(this).trigger('open');
-          }
         }
       });
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -387,9 +387,6 @@
           label = $(this).val();
 
           if (multiple) {
-            if (e.relatedTarget)
-              $(this).trigger('open');
-
             var selectedOption = options.find('li:not(.disabled)')[0];
           } else {
             $(this).trigger('open');
@@ -403,6 +400,11 @@
         },
         'click': function (e){
           e.stopPropagation();
+        },
+        'keyup': function () {
+          if (multiple && !$(this).siblings('ul.dropdown-content').is(':visible')) {
+            $(this).trigger('open');
+          }
         }
       });
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -275,14 +275,15 @@
   // Select Plugin
   $.fn.material_select = function (callback) {
     $(this).each(function(){
-      $select = $(this);
+      var $select = $(this);
 
-      if ( $select.hasClass('browser-default')) {
+      if ($select.hasClass('browser-default')) {
         return; // Continue to next (return false breaks out of entire loop)
       }
 
-      // Tear down structure if Select needs to be rebuilt
-      var lastID = $select.data('select-id');
+      var multiple = $select.attr('multiple') ? true : false,
+          lastID = $select.data('select-id'); // Tear down structure if Select needs to be rebuilt
+
       if (lastID) {
         $select.parent().find('span.caret').remove();
         $select.parent().find('input').remove();
@@ -293,16 +294,18 @@
 
       // If destroying the select, remove the selelct-id and reset it to it's uninitialized state.
       if(callback === 'destroy') {
-          $select.data('select-id', null).removeClass('initialized');
-          return;
+        $select.data('select-id', null).removeClass('initialized');
+        return;
       }
 
       var uniqueID = Materialize.guid();
       $select.data('select-id', uniqueID);
       var wrapper = $('<div class="select-wrapper"></div>');
       wrapper.addClass($select.attr('class'));
-      var options = $('<ul id="select-options-' + uniqueID+'" class="dropdown-content select-dropdown"></ul>');
+      var options = $('<ul id="select-options-' + uniqueID +'" class="dropdown-content select-dropdown ' + (multiple ? 'multiple-select-dropdown' : '') + '"></ul>');
       var selectOptions = $select.children('option');
+
+      var valuesSelected = [];
 
       var label;
       if ($select.find('option:selected') !== undefined) {
@@ -316,19 +319,30 @@
       // Create Dropdown structure
       selectOptions.each(function () {
         // Add disabled attr if disabled
-        options.append($('<li class="' + (($(this).is(':disabled')) ? 'disabled' : '') + '"><span>' + $(this).html() + '</span></li>'));
+        if (multiple) {
+          options.append($('<li class="' + (($(this).is(':disabled')) ? 'disabled' : '') + '"><span><input type="checkbox"' + (($(this).is(':disabled')) ? 'disabled' : '') + '/><label></label>' + $(this).html() + '</span></li>'));
+        } else {
+          options.append($('<li class="' + (($(this).is(':disabled')) ? 'disabled' : '') + '"><span>' + $(this).html() + '</span></li>'));
+        }
       });
-
 
       options.find('li').each(function (i) {
         var $curr_select = $select;
         $(this).click(function () {
           // Check if option element is disabled
           if (!$(this).hasClass('disabled')) {
+            if (multiple) {
+              $('input[type="checkbox"]', this).prop('checked', function(i, v) { return !v; });
+              toggleEntryFromArray(valuesSelected, $(this).index(), $curr_select);
+            } else {
+              options.find('li').removeClass('active');
+              $(this).toggleClass('active');
+              $curr_select.siblings('input.select-dropdown').val($(this).text());
+            }
+
             $curr_select.find('option').eq(i).prop('selected', true);
             // Trigger onchange() event
             $curr_select.trigger('change');
-            $curr_select.siblings('input.select-dropdown').val($(this).text());
             if (typeof callback !== 'undefined') callback();
           }
         });
@@ -339,7 +353,7 @@
       $select.wrap(wrapper);
       // Add Select Display Element
       var dropdownIcon = $('<span class="caret">&#9660;</span>');
-      if ( $select.is(':disabled') )
+      if ($select.is(':disabled'))
         dropdownIcon.addClass('disabled');
 
       // escape double quotes
@@ -352,7 +366,7 @@
       $('body').append(options);
       // Check if section element is disabled
       if (!$select.is(':disabled')) {
-        $newSelect.dropdown({"hover": false});
+        $newSelect.dropdown({'hover': false});
       }
 
       // Copy tabindex
@@ -363,102 +377,151 @@
       $select.addClass('initialized');
 
       $newSelect.on('focus', function(){
+        if ($('input.select-dropdown').is(':visible')) {
+          $('input.select-dropdown').trigger('close');
+        }
         $(this).trigger('open');
         label = $(this).val();
-        selectedOption = options.find('li').filter(function() {
-          return $(this).text().toLowerCase() === label.toLowerCase();
-        })[0];
+
+        if (multiple) {
+          var selectedOption = options.find('li').eq(valuesSelected.sort()[0])[0] || options.find('li:first-child')[0];
+        } else {
+          var selectedOption = options.find('li').filter(function() {
+            return $(this).text().toLowerCase() === label.toLowerCase();
+          })[0];
+        }
+
         activateOption(options, selectedOption);
       });
 
-      $newSelect.on('blur', function(){
-        $(this).trigger('close');
-      });
+      if (!multiple) {
+        $newSelect.on('blur', function () {
+          $(this).trigger('close');
+        });
+      } else {
+        $(document).on('click',function(e){
+          if (!options.is(e.target) && options.has(e.target).length === 0) {
+            $newSelect.trigger('close');
+          }
+        });
+      }
 
       // Make option as selected and scroll to selected position
       activateOption = function(collection, newOption) {
-        collection.find('li.active').removeClass('active');
-        $(newOption).addClass('active');
+        collection.find('li.selected').removeClass('selected');
+        $(newOption).addClass('selected');
         collection.scrollTo(newOption);
       };
 
       // Allow user to search by typing
       // this array is cleared after 1 second
-      filterQuery = [];
+      var filterQuery = [],
+          onKeyDown = function(event){
+            // TAB - switch to another input
+            if(event.which == 9){
+              $newSelect.trigger('close');
+              return;
+            }
 
-      onKeyDown = function(event){
-        // TAB - switch to another input
-        if(event.which == 9){
-          $newSelect.trigger('close');
-          return;
-        }
+            // ARROW DOWN WHEN SELECT IS CLOSED - open select options
+            if(event.which == 40 && !options.is(':visible')){
+              $newSelect.trigger('open');
+              return;
+            }
 
-        // ARROW DOWN WHEN SELECT IS CLOSED - open select options
-        if(event.which == 40 && !options.is(":visible")){
-          $newSelect.trigger('open');
-          return;
-        }
+            // ENTER WHEN SELECT IS CLOSED - submit form
+            if(event.which == 13 && !options.is(':visible')){
+              return;
+            }
 
-        // ENTER WHEN SELECT IS CLOSED - submit form
-        if(event.which == 13 && !options.is(":visible")){
-          return;
-        }
+            event.preventDefault();
 
-        event.preventDefault();
+            // CASE WHEN USER TYPE LETTERS
+            var letter = String.fromCharCode(event.which).toLowerCase(),
+                nonLetters = [9,13,27,38,40];
+            if (letter && (nonLetters.indexOf(event.which) === -1)){
+              filterQuery.push(letter);
 
-        // CASE WHEN USER TYPE LETTERS
-        letter = String.fromCharCode(event.which).toLowerCase();
-        var nonLetters = [9,13,27,38,40];
-        if (letter && (nonLetters.indexOf(event.which) === -1)){
-          filterQuery.push(letter);
+              var string = filterQuery.join(''),
+                  newOption = options.find('li').filter(function() {
+                    return $(this).text().toLowerCase().indexOf(string) === 0;
+                  })[0];
 
-          string = filterQuery.join("");
+              if(newOption){
+                activateOption(options, newOption);
+              }
+            }
 
-          newOption = options.find('li').filter(function() {
-            return $(this).text().toLowerCase().indexOf(string) === 0;
-          })[0];
+            // ENTER - select option and close when select options are opened
+            if(event.which == 13){
+              activeOption = options.find('li.selected:not(.disabled)')[0];
+              if(activeOption){
+                $(activeOption).trigger('click');
+                if (!multiple) {
+                  $newSelect.trigger('close');
+                }
+              }
+            }
 
-          if(newOption){
-            activateOption(options, newOption);
-          }
-        }
+            // ARROW DOWN - move to next not disabled option
+            if(event.which == 40){
+              newOption = options.find('li.selected')[0] || options.find('li')[0];
+              newOption = $(newOption).next('li:not(.disabled)')[0];
 
-        // ENTER - select option and close when select options are opened
-        if(event.which == 13){
-          activeOption = options.find('li.active:not(.disabled)')[0];
-          if(activeOption){
-            $(activeOption).trigger('click');
-            $newSelect.trigger('close');
-          }
-        }
+              if(newOption){
+                activateOption(options, newOption);
+              }
+            }
 
-        // ARROW DOWN - move to next not disabled option
-        if(event.which == 40){
-          newOption = options.find('li.active').next('li:not(.disabled)')[0];
-          if(newOption){
-            activateOption(options, newOption);
-          }
-        }
+            // ESC - close options
+            if(event.which == 27){
+              $newSelect.trigger('close');
+            }
 
-        // ESC - close options
-        if(event.which == 27){
-          $newSelect.trigger('close');
-        }
+            // ARROW UP - move to previous not disabled option
+            if(event.which == 38){
+              newOption = options.find('li.selected').prev('li:not(.disabled)')[0];
+              if(newOption){
+                activateOption(options, newOption);
+              }
+            }
 
-        // ARROW UP - move to previous not disabled option
-        if(event.which == 38){
-          newOption = options.find('li.active').prev('li:not(.disabled)')[0];
-          if(newOption){
-            activateOption(options, newOption);
-          }
-        }
-
-        // Automaticaly clean filter query so user can search again by starting letters
-        setTimeout(function(){ filterQuery = []; }, 1000);
-      };
+            // Automaticaly clean filter query so user can search again by starting letters
+            setTimeout(function(){ filterQuery = []; }, 1000);
+          };
 
       $newSelect.on('keydown', onKeyDown);
     });
+
+    function toggleEntryFromArray(entriesArray, entryIndex, select) {
+      var index = entriesArray.indexOf(entryIndex);
+
+      if (index === -1) {
+        entriesArray.push(entryIndex);
+      } else {
+        entriesArray.splice(index, 1);
+      }
+
+      select.siblings('ul.dropdown-content').find('li').eq(entryIndex).toggleClass('active');
+      select.find('option').eq(entryIndex).prop('selected', true);
+      setValueToInput(entriesArray, select);
+    }
+
+    function setValueToInput(entriesArray, select) {
+      var value = '';
+
+      for (var i = 0, count = entriesArray.length; i < count; i++) {
+        var text = select.find('option').eq(entriesArray[i]).text();
+
+        i === 0 ? value += text : value += ', ' + text;
+      }
+
+      if (value === '') {
+        value = select.find('option:disabled').eq(0).text();
+      }
+
+      select.siblings('input.select-dropdown').val(value);
+    }
   };
 
 }( jQuery ));

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -20,8 +20,12 @@
     text-align: left;
     text-transform: none;
 
-    &:hover, &.active {
+    &:hover, &.active, &.selected {
       background-color: $dropdown-hover-bg-color;
+    }
+
+    &.active.selected {
+      background-color: darken($dropdown-hover-bg-color, 5%);
     }
 
     & > a, & > span {
@@ -29,6 +33,11 @@
       color: $dropdown-color;
       display: block;
       padding: 1rem 1rem;
+    }
+
+    & > span > label {
+      top: 0.6rem;
+      left: 0.2rem;
     }
 
     // Icon alignment override


### PR DESCRIPTION
This PR adds the support for multiple select which wasn't still supported by materialize, you just need to add the attribute "multiple" to the select element.
This fix the active class, so we can recover all selected items with `li.active` or with getting the selected options from the native select, both are working.

Here there is a [demo](https://jsfiddle.net/TyrionGraphiste/ocowsehq/2/embedded/result/).
I hope it will fix some issues, it's working on all browsers on my side, take time to test it on old browsers if you can.

Here there is all the issues fixed with the PR :
- [#1002](https://github.com/Dogfalo/materialize/issues/1002)
- [#1764](https://github.com/Dogfalo/materialize/issues/1764)
- [#540](https://github.com/Dogfalo/materialize/issues/540)

Then, don't hesitate to change the code ! I'm not a developer and tried to follow your code style.

PS : Sorry for typos ! I'm not **en** !