### PR TITLE
Revert breaking change in Materialize init

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -252,7 +252,7 @@ jQuery.extend( jQuery.easing,
         };
     })(Hammer.Manager.prototype.emit);
 }));
-;window.Materialize = {};
+;Materialize = {};
 
 // Unique ID
 Materialize.guid = (function() {


### PR DESCRIPTION
Materialize = {} and window.Materialize = {} should do the same thing, but the window object is not accessible in node environments, so this change breaks compatibility with Meteor.
This change has been tested in both a dev and live environment and seems to fix the reported problems.