### PR TITLE
Fix for issue 2077

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1,4 +1,7 @@
+//fixed in v0.97.1 
 window.Materialize = {};
+// fix for issue 2077 
+Materialize = window.Materialize;
 
 // Unique ID
 Materialize.guid = (function() {


### PR DESCRIPTION
Fix or issue: https://github.com/Dogfalo/materialize/issues/2077

The previous version 0.97.1 had initialized globally Materialize. 
But it was not accessible in the scope of the function in global.js