### PR TITLE
showStaggeredList works on table tags

### DIFF
--- a/js/transitions.js
+++ b/js/transitions.js
@@ -33,11 +33,17 @@
   // Horizontal staggered list
   Materialize.showStaggeredList = function(selector) {
     var time = 0;
-    $(selector).find('li').velocity(
+    var elementType = $(selector).prop('nodeName').toLowerCase();
+    var children = 'li';
+    // if selector is a table, animate the rows instead
+    if (elementType === 'table') {
+      children = 'tr';
+    }
+    $(selector).find(children).velocity(
         { translateX: "-100px"},
         { duration: 0 });
 
-    $(selector).find('li').each(function() {
+    $(selector).find(children).each(function() {
       $(this).velocity(
         { opacity: "1", translateX: "0"},
         { duration: 800, delay: time, easing: [60, 10] });

--- a/transitions.html
+++ b/transitions.html
@@ -111,7 +111,7 @@
 
 
         <h4>showStaggeredList</h4>
-        <p>Use this to create a staggered reveal effect for any <code class="language-markup">UL</code> Tag with list items. Just make sure the list items in the <code class="language-markup">UL</code> are <code class="language-css">opacity: 0; to ensure the animation works correctly.</code></p>
+        <p>Use this to create a staggered reveal effect for any <code class="language-markup">UL</code> Tag's list items, or any <code class="language-markup">TABLE</code> Tag's rows. Just make sure the list items or rows are <code class="language-css">opacity: 0;</code> to ensure the animation works correctly.</p>
         <a href="#!" class="btn" onclick="Materialize.showStaggeredList('#staggered-test')">Click Me</a>
         <pre><code class="language-markup">
   &lt;a href="#!" class="btn" onclick="Materialize.showStaggeredList('#staggered-test')">Click Me&lt;/a>


### PR DESCRIPTION
`Materialize.showStaggeredList` does not work on `<table>`' rows:`<tr>`

This pull request fixes this by checking the selector type and choosing the correct children element to animate. By default it will look for `<li>` tags. If the selector is a `<table>` it will look for `<tr>` tags instead.

Working example: http://codepen.io/anon/pen/meOYWd
