### PR TITLE
Display color and type requested when warning about unknown color

### DIFF
--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -406,7 +406,7 @@ $colors: (
       @return map-get($curr_color, $type);
     }
   }
-  @warn "Unknown `#{name}` in $colors.";
+  @warn "Unknown `#{$color}` - `#{$type}` in $colors.";
   @return null;
 }
 


### PR DESCRIPTION
When using the color function, to request a color and it's variant, it displays: `Line 39 WARN: "Unknown `name` in $colors."` _name_ should be the color name and not the word "name", also added the requested color type.
