### PR TITLE
Click-to-Toggle FAB Menus

### DIFF
--- a/buttons.html
+++ b/buttons.html
@@ -162,7 +162,7 @@
               <li><a class="btn-floating blue"><i class="material-icons">attach_file</i></a></li>
             </ul>
           </div>
-</div>
+        </div>
         <pre><code class="language-markup col s12">
   &lt;div class="fixed-action-btn horizontal" style="bottom: 45px; right: 24px;">
     &lt;a class="btn-floating btn-large red">
@@ -197,6 +197,36 @@
             <li><a class="btn-floating blue"><i class="material-icons">attach_file</i></a></li>
           </ul>
         </div>
+
+        <h4 class="light">Click-only FAB</h4>
+        <p>If you want to disable the hover behaviour, and instead toggle the FAB menu when the user clicks on the large button (works great on mobile!), just add the <code class="language-markup">click-to-toggle</code> class to the FAB.</p>
+        <div style="position: relative; height: 70px;">
+          <div class="fixed-action-btn horizontal click-to-toggle" style="position: absolute; right: 24px;">
+            <a class="btn-floating btn-large red">
+              <i class="large mdi-navigation-menu"></i>
+            </a>
+            <ul>
+              <li><a class="btn-floating red"><i class="material-icons">insert_chart</i></a></li>
+              <li><a class="btn-floating yellow darken-1"><i class="material-icons">format_quote</i></a></li>
+              <li><a class="btn-floating green"><i class="material-icons">publish</i></a></li>
+              <li><a class="btn-floating blue"><i class="material-icons">attach_file</i></a></li>
+            </ul>
+          </div>
+        </div>
+        <pre><code class="language-markup col s12">
+  &lt;div class="fixed-action-btn horizontal click-to-toggle" style="bottom: 45px; right: 24px;">
+    &lt;a class="btn-floating btn-large red">
+      &lt;i class="large mdi-navigation-menu">&lt;/i>
+    &lt;/a>
+    &lt;ul>
+      &lt;li>&lt;a class="btn-floating red">&lt;i class="material-icons">insert_chart&lt;/i>&lt;/a>&lt;/li>
+      &lt;li>&lt;a class="btn-floating yellow darken-1">&lt;i class="material-icons">format_quote&lt;/i>&lt;/a>&lt;/li>
+      &lt;li>&lt;a class="btn-floating green">&lt;i class="material-icons">publish&lt;/i>&lt;/a>&lt;/li>
+      &lt;li>&lt;a class="btn-floating blue">&lt;i class="material-icons">attach_file&lt;/i>&lt;/a>&lt;/li>
+    &lt;/ul>
+  &lt;/div>
+        </code></pre>
+
       </div>
       <div id="flat" class="section scrollspy">
         <h2 class="header">Flat</h2>

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -4,15 +4,25 @@
     // jQuery reverse
     $.fn.reverse = [].reverse;
 
-    $(document).on('mouseenter.fixedActionBtn', '.fixed-action-btn', function(e) {
+    // Hover behaviour: make sure this doesn't work on .click-to-toggle FABs!
+    $(document).on('mouseenter.fixedActionBtn', '.fixed-action-btn:not(.click-to-toggle)', function(e) {
       var $this = $(this);
       openFABMenu($this);
-
     });
-
-    $(document).on('mouseleave.fixedActionBtn', '.fixed-action-btn', function(e) {
+    $(document).on('mouseleave.fixedActionBtn', '.fixed-action-btn:not(.click-to-toggle)', function(e) {
       var $this = $(this);
       closeFABMenu($this);
+    });
+
+    // Toggle-on-click behaviour.
+    $(document).on('click.fixedActionBtn', '.fixed-action-btn.click-to-toggle .btn-large', function(e) {
+      var $this = $(this);
+      var $menu = $( $this.parent()[0] );
+      if ( $menu.hasClass('active') ) {
+        closeFABMenu($menu);
+      } else {
+        openFABMenu($menu);
+      }
     });
 
   });
@@ -35,13 +45,13 @@
       // Get direction option
       var horizontal = $this.hasClass('horizontal');
       var offsetY, offsetX;
-      
+
       if (horizontal === true) {
         offsetX = 40;
       } else {
         offsetY = 40;
       }
-      
+
       $this.addClass('active');
       $this.find('ul .btn-floating').velocity(
         { scaleY: ".4", scaleX: ".4", translateY: offsetY + 'px', translateX: offsetX + 'px'},


### PR DESCRIPTION
FAB (`.fixed-action-btn`) menus which contain the semantic class `.click-to-toggle` will alternately show/hide their menu contents only when the large fixed button is clicked.  The `.click-to-toggle` class will also disable the default hover behaviour.  Closes #2040.