### PR TITLE
Tabs: External Links (optional)

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -102,8 +102,11 @@
           $indicator.velocity({"right": $tabs_width - (($index + 1) * $tab_width)}, {duration: 300, queue: false, easing: 'easeOutQuad', delay: 90});
         }
 
-        // Prevent the anchor's default click action
-        e.preventDefault();
+        // Prevent the anchor's default click action -- unless this tab
+        // opens an external link!
+        if ( !$(this).attr("target") ) {
+          e.preventDefault();
+        }
       });
 
       // Add scroll for small screens

--- a/tabs.html
+++ b/tabs.html
@@ -182,6 +182,16 @@
         </code></pre>
       </div>
 
+      <div id="external" class="section scrollspy">
+        <h4>Linking to an External Page</h4>
+          <p>By default, Materialize tabs will ignore their default <code class="language-markup">&lt;a href></code> behaviour.  To force a tab to behave as a regular hyperlink, just specify the <code class="language-markup">target</code> property of that link!  A list of <code class="language-markup">target</code> values may be <a href="http://www.w3schools.com/tags/att_a_target.asp">found here</a>.</p>
+        <pre><code class="language-markup col s12">
+  &lt;li class="tab col s2">
+    &lt;a target="_blank" href="https://github.com/Dogfalo/materialize">Test 3&lt;/a>
+  &lt;/li>
+        </code></pre>
+      </div>
+
     </div>
 
     <!-- Table of Contents -->
@@ -198,6 +208,7 @@
             <li><a href="#initialization">Intialization</a></li>
             <li><a href="#method">Methods</a></li>
             <li><a href="#preselecting">Preselecting</a></li>
+            <li><a href="#external">External Links</a></li>
           </ul>
         </div>
       </div>

--- a/test/html/tabs.html
+++ b/test/html/tabs.html
@@ -36,6 +36,7 @@
         <li class="tab"><a href="#test4">Test 6</a></li>
         <li class="tab"><a href="#test4">Test 7</a></li>
         <li class="tab"><a href="#test4">Test 8</a></li>
+        <li class="tab"><a target="_blank" href="http://materializecss.com">External Link</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Specifying the optional `target` property of a tab hyperlink will allow it to behave as a normal hyperlink.  Does not affect any other tabs, which continue to work normally.  External tab links do not have any internal tab content.  Resolves #2121.

I have included documentation w/ example in `tabs.html` as well as a test tab inside `test/html/tabs.html`.