### PR TITLE
Toast: Line Breaking and Improved Spacing

### DIFF
--- a/sass/components/_toast.scss
+++ b/sass/components/_toast.scss
@@ -10,12 +10,14 @@
   @media #{$medium-only} {
     min-width: 30%;
     left: 5%;
+    right: 5%;
     bottom: 7%;
   }
   @media #{$large-and-up} {
     min-width: 8%;
     top: 10%;
     right: 7%;
+    left: 7%;
   }
 }
 
@@ -28,10 +30,12 @@
   margin-top: 10px;
   position: relative;
   max-width:100%;
-  height: $toast-height;
-  line-height: $toast-height;
+  height: auto;
+  min-height: $toast-height;
+  line-height: 1.5em;
+  word-break: break-all;
   background-color: $toast-color;
-  padding: 0 25px;
+  padding: 10px 25px;
   font-size: 1.1rem;
   font-weight: 300;
   color: $toast-text-color;


### PR DESCRIPTION
If toast content is too long for the screen, it currently does not line break properly because toast height is fixed and line-height is the same as container height.  In addition, long toast messages at large screen widths can force the far side of the toast container to be flush with the edge of the window, which is inconsistent with the 5% or 7% the user expects.

This PR introduces two fixes:

*  Multiline toast content now line breaks appropriately, and toast height will expand or reduce to fit content.  Default (single-line) toast height will always revert to the value specified by `$toast-height`.
*  Toast container at medium and large widths sets a 5% or 7% margin on *both* sides of the toast, which produces a more consistent user experience.  This matches how Google renders toast, for example, on the Google Store.