### PR TITLE
Fixed form labels double click and wierd selection bug. 

### DIFF
--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -131,6 +131,7 @@ textarea.materialize-textarea {
     left: $gutter-width / 2;
     font-size: 1rem;
     cursor: text;
+    pointer-events: none;
     @include transition(.2s ease-out);
   }
   label.active {


### PR DESCRIPTION
When double-clicking on form label it selected the label, not the input.
Added pointer-events:none for input-field label

More info
https://css-tricks.com/almanac/properties/p/pointer-events/
