### PR TITLE
add methods beforeOpen / beforeClose based on begin method for veloci…

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -15,6 +15,8 @@
         opacity: 0.5,
         in_duration: 350,
         out_duration: 250,
+        beforeOpen: undefined,
+        beforeClose: undefined,
         ready: undefined,
         complete: undefined,
         dismissible: true,
@@ -71,6 +73,11 @@
             if (typeof(options.ready) === "function") {
               options.ready();
             }
+          },
+          begin: function() {
+            if (typeof(options.beforeOpen) === "function") {
+              options.beforeOpen();
+            }
           }
         });
       }
@@ -85,6 +92,11 @@
           complete: function() {
             if (typeof(options.ready) === "function") {
               options.ready();
+            }
+          },
+          begin: function() {
+            if (typeof(options.beforeOpen) === "function") {
+              options.beforeOpen();
             }
           }
         });
@@ -131,6 +143,11 @@
             }
             $overlay.remove();
             _stack--;
+          },
+          begin: function() {
+            if (typeof(options.beforeClose) === "function") {
+              options.beforeClose();
+            }
           }
         });
       }
@@ -148,6 +165,11 @@
               }
               $overlay.remove();
               _stack--;
+            }
+          },
+          begin: function() {
+            if (typeof(options.beforeClose) === "function") {
+              options.beforeClose();
             }
           }
         );


### PR DESCRIPTION
Velocity.js offers [begin method](http://julian.com/research/velocity/#beginAndComplete) before events start so this could be handy for the beginning of the modal show and close event accordingly. So i 've created 2 methods which are `beforeOpen()` and `beforeClose()` based on the `begin()` method.
