### PR TITLE
Support Line Break('\A') to Tooltip message

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -56,7 +56,9 @@
               newTooltip.css({ display: 'block', left: '0px', top: '0px' });
 
               // Set Tooltip text
-              newTooltip.children('span').text(origin.attr('data-tooltip'));
+              newTooltip.children('span').html(origin.attr('data-tooltip').replace(/[&<>]/g,
+                function(tag) { return { '&': '&amp', '<': '&lt', '>': '&gt' }[tag] || tag; }
+              ).replace('\\A', '<br/>'));
 
               // Tooltip positioning
               var originWidth = origin.outerWidth();

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -57,7 +57,7 @@
 
               // Set Tooltip text
               newTooltip.children('span').html(origin.attr('data-tooltip').replace(/[&<>]/g,
-                function(tag) { return { '&': '&amp', '<': '&lt', '>': '&gt' }[tag] || tag; }
+                function(tag) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;' }[tag] || tag; }
               ).replace('\\A', '<br/>'));
 
               // Tooltip positioning


### PR DESCRIPTION
This patch makes it possible for ToolTip to display multi-Line message.
ex.) &lt;a class="tooltipped" data-tooltip="first line\Asecond line"&gt;
