### PR TITLE
typo in parallax-template index.html

### DIFF
--- a/templates/parallax-template/index.html
+++ b/templates/parallax-template/index.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -158,7 +157,7 @@
 
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-  <script src="../../dist/js/materialize.js"></script>
+  <script src="js/materialize.js"></script>
   <script src="js/init.js"></script>
 
   </body>


### PR DESCRIPTION
doctype added twice + wrong link to materialize.js which is why the parallax in the template failed
