### PR TITLE
fix #2086: pagination chevron alignment

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -158,7 +158,8 @@ video.responsive-video {
     }
 
     i {
-      font-size: 2rem;
+      font-size: 2.2rem;
+      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
Fixes #2086 by setting vertical-align on the icon to middle, and adjusting the icon size slightly to match the font size of the pagination numbers.