### PR TITLE
fix .active class to :active state

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -84,7 +84,7 @@ nav {
       float: left;
       padding: 0;
 
-      &:hover, &.active {
+      &:hover, &:active {
         background-color: rgba(0,0,0,.1);
       }
     }


### PR DESCRIPTION
under navbar links, &hover, &.active has active set as a class rather than a state.  this is an update to fix that.