### PR TITLE
[btn-floating] ligature alignment

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -78,6 +78,7 @@
     color: $button-color-raised;
     font-size: $button-large-icon-font-size;
     line-height: $button-floating-size;
+    vertical-align: top;
   }
 
   &:hover {


### PR DESCRIPTION
On mobile safari, inline elements do not seem to be aligned to top by default. 
Fixes vertical alignment of <i> element / font icons.
