### PR TITLE
Dynamically added list items are expandables too without reinitializing

### DIFF
--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -112,21 +112,21 @@
         accordionOpen($panel_headers.filter('.active').first());
       }
       else { // Handle Expandables
-        $panel_headers.each(function () {
-          // Add click handler to only direct collapsible header children
-          $(this).on('click.collapse', function (e) {
-            var element = $(e.target);
-            if (isChildrenOfPanelHeader(element)) {
-              element = getPanelHeader(element);
-            }
-            element.toggleClass('active');
-            expandableOpen(element);
-          });
-          // Open any bodies that have the active class
-          if ($(this).hasClass('active')) {
-            expandableOpen($(this));
+        // Add click handler to only direct collapsible header children
+        $this.on('click', '> li > .collapsible-header', function(e) {
+          var $header = $(this),
+          element = $(e.target);
+
+          if (isChildrenOfPanelHeader(element)) {
+            element = getPanelHeader(element);
           }
 
+          element.toggleClass('active');
+          expandableOpen(element);
+
+          if ($header.hasClass('active')) {
+            expandableOpen($header);
+          }
         });
       }
 


### PR DESCRIPTION
This attaches one single event handler to an expandable list, but sets
the scope to the collapsible header. This way you attach one event
handler instead of potentially hundreds and it'll make sure any new
dynamically added list item is able to be collapsed without
reinitializing the component.

It also plays nicely with frameworks (Vuejs for example). Due to the 
nature of Javascript, reinitializing the component causes the last item 
to not work, because the items get cached before the last item is 
rendered by the framework.

Here's a quick example of what I changed: https://jsfiddle.net/nyy085de/

Note: this only changes how the expandables work, not collapsibles. I
don't have the time to have a look at the rest, but I have the feeling
that this kind of thing happens on other parts of the project; applying
event handlers to ONLY a cached element/list of things.