### PR TITLE
offset issue - fix css priority

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5090,95 +5090,107 @@ nav ul a span.badge {
     .row .col[class*="push-"], .row .col[class*="pull-"] {
       position: relative; }
     .row .col.s1 {
-      width: 8.33333%; }
+      width: 8.33333%;
+      margin-left: 0; }
+    .row .col.s2 {
+      width: 16.66667%;
+      margin-left: 0; }
+    .row .col.s3 {
+      width: 25%;
+      margin-left: 0; }
+    .row .col.s4 {
+      width: 33.33333%;
+      margin-left: 0; }
+    .row .col.s5 {
+      width: 41.66667%;
+      margin-left: 0; }
+    .row .col.s6 {
+      width: 50%;
+      margin-left: 0; }
+    .row .col.s7 {
+      width: 58.33333%;
+      margin-left: 0; }
+    .row .col.s8 {
+      width: 66.66667%;
+      margin-left: 0; }
+    .row .col.s9 {
+      width: 75%;
+      margin-left: 0; }
+    .row .col.s10 {
+      width: 83.33333%;
+      margin-left: 0; }
+    .row .col.s11 {
+      width: 91.66667%;
+      margin-left: 0; }
+    .row .col.s12 {
+      width: 100%;
+      margin-left: 0; }
     .row .col.offset-s1 {
       margin-left: 8.33333%; }
     .row .col.pull-s1 {
       right: 8.33333%; }
     .row .col.push-s1 {
       left: 8.33333%; }
-    .row .col.s2 {
-      width: 16.66667%; }
     .row .col.offset-s2 {
       margin-left: 16.66667%; }
     .row .col.pull-s2 {
       right: 16.66667%; }
     .row .col.push-s2 {
       left: 16.66667%; }
-    .row .col.s3 {
-      width: 25%; }
     .row .col.offset-s3 {
       margin-left: 25%; }
     .row .col.pull-s3 {
       right: 25%; }
     .row .col.push-s3 {
       left: 25%; }
-    .row .col.s4 {
-      width: 33.33333%; }
     .row .col.offset-s4 {
       margin-left: 33.33333%; }
     .row .col.pull-s4 {
       right: 33.33333%; }
     .row .col.push-s4 {
       left: 33.33333%; }
-    .row .col.s5 {
-      width: 41.66667%; }
     .row .col.offset-s5 {
       margin-left: 41.66667%; }
     .row .col.pull-s5 {
       right: 41.66667%; }
     .row .col.push-s5 {
       left: 41.66667%; }
-    .row .col.s6 {
-      width: 50%; }
     .row .col.offset-s6 {
       margin-left: 50%; }
     .row .col.pull-s6 {
       right: 50%; }
     .row .col.push-s6 {
       left: 50%; }
-    .row .col.s7 {
-      width: 58.33333%; }
     .row .col.offset-s7 {
       margin-left: 58.33333%; }
     .row .col.pull-s7 {
       right: 58.33333%; }
     .row .col.push-s7 {
       left: 58.33333%; }
-    .row .col.s8 {
-      width: 66.66667%; }
     .row .col.offset-s8 {
       margin-left: 66.66667%; }
     .row .col.pull-s8 {
       right: 66.66667%; }
     .row .col.push-s8 {
       left: 66.66667%; }
-    .row .col.s9 {
-      width: 75%; }
     .row .col.offset-s9 {
       margin-left: 75%; }
     .row .col.pull-s9 {
       right: 75%; }
     .row .col.push-s9 {
       left: 75%; }
-    .row .col.s10 {
-      width: 83.33333%; }
     .row .col.offset-s10 {
       margin-left: 83.33333%; }
     .row .col.pull-s10 {
       right: 83.33333%; }
     .row .col.push-s10 {
       left: 83.33333%; }
-    .row .col.s11 {
-      width: 91.66667%; }
     .row .col.offset-s11 {
       margin-left: 91.66667%; }
     .row .col.pull-s11 {
       right: 91.66667%; }
     .row .col.push-s11 {
       left: 91.66667%; }
-    .row .col.s12 {
-      width: 100%; }
     .row .col.offset-s12 {
       margin-left: 100%; }
     .row .col.pull-s12 {
@@ -5187,95 +5199,107 @@ nav ul a span.badge {
       left: 100%; }
     @media only screen and (min-width : 601px) {
       .row .col.m1 {
-        width: 8.33333%; }
+        width: 8.33333%;
+        margin-left: 0; }
+      .row .col.m2 {
+        width: 16.66667%;
+        margin-left: 0; }
+      .row .col.m3 {
+        width: 25%;
+        margin-left: 0; }
+      .row .col.m4 {
+        width: 33.33333%;
+        margin-left: 0; }
+      .row .col.m5 {
+        width: 41.66667%;
+        margin-left: 0; }
+      .row .col.m6 {
+        width: 50%;
+        margin-left: 0; }
+      .row .col.m7 {
+        width: 58.33333%;
+        margin-left: 0; }
+      .row .col.m8 {
+        width: 66.66667%;
+        margin-left: 0; }
+      .row .col.m9 {
+        width: 75%;
+        margin-left: 0; }
+      .row .col.m10 {
+        width: 83.33333%;
+        margin-left: 0; }
+      .row .col.m11 {
+        width: 91.66667%;
+        margin-left: 0; }
+      .row .col.m12 {
+        width: 100%;
+        margin-left: 0; }
       .row .col.offset-m1 {
         margin-left: 8.33333%; }
       .row .col.pull-m1 {
         right: 8.33333%; }
       .row .col.push-m1 {
         left: 8.33333%; }
-      .row .col.m2 {
-        width: 16.66667%; }
       .row .col.offset-m2 {
         margin-left: 16.66667%; }
       .row .col.pull-m2 {
         right: 16.66667%; }
       .row .col.push-m2 {
         left: 16.66667%; }
-      .row .col.m3 {
-        width: 25%; }
       .row .col.offset-m3 {
         margin-left: 25%; }
       .row .col.pull-m3 {
         right: 25%; }
       .row .col.push-m3 {
         left: 25%; }
-      .row .col.m4 {
-        width: 33.33333%; }
       .row .col.offset-m4 {
         margin-left: 33.33333%; }
       .row .col.pull-m4 {
         right: 33.33333%; }
       .row .col.push-m4 {
         left: 33.33333%; }
-      .row .col.m5 {
-        width: 41.66667%; }
       .row .col.offset-m5 {
         margin-left: 41.66667%; }
       .row .col.pull-m5 {
         right: 41.66667%; }
       .row .col.push-m5 {
         left: 41.66667%; }
-      .row .col.m6 {
-        width: 50%; }
       .row .col.offset-m6 {
         margin-left: 50%; }
       .row .col.pull-m6 {
         right: 50%; }
       .row .col.push-m6 {
         left: 50%; }
-      .row .col.m7 {
-        width: 58.33333%; }
       .row .col.offset-m7 {
         margin-left: 58.33333%; }
       .row .col.pull-m7 {
         right: 58.33333%; }
       .row .col.push-m7 {
         left: 58.33333%; }
-      .row .col.m8 {
-        width: 66.66667%; }
       .row .col.offset-m8 {
         margin-left: 66.66667%; }
       .row .col.pull-m8 {
         right: 66.66667%; }
       .row .col.push-m8 {
         left: 66.66667%; }
-      .row .col.m9 {
-        width: 75%; }
       .row .col.offset-m9 {
         margin-left: 75%; }
       .row .col.pull-m9 {
         right: 75%; }
       .row .col.push-m9 {
         left: 75%; }
-      .row .col.m10 {
-        width: 83.33333%; }
       .row .col.offset-m10 {
         margin-left: 83.33333%; }
       .row .col.pull-m10 {
         right: 83.33333%; }
       .row .col.push-m10 {
         left: 83.33333%; }
-      .row .col.m11 {
-        width: 91.66667%; }
       .row .col.offset-m11 {
         margin-left: 91.66667%; }
       .row .col.pull-m11 {
         right: 91.66667%; }
       .row .col.push-m11 {
         left: 91.66667%; }
-      .row .col.m12 {
-        width: 100%; }
       .row .col.offset-m12 {
         margin-left: 100%; }
       .row .col.pull-m12 {
@@ -5284,95 +5308,107 @@ nav ul a span.badge {
         left: 100%; } }
     @media only screen and (min-width : 993px) {
       .row .col.l1 {
-        width: 8.33333%; }
+        width: 8.33333%;
+        margin-left: 0; }
+      .row .col.l2 {
+        width: 16.66667%;
+        margin-left: 0; }
+      .row .col.l3 {
+        width: 25%;
+        margin-left: 0; }
+      .row .col.l4 {
+        width: 33.33333%;
+        margin-left: 0; }
+      .row .col.l5 {
+        width: 41.66667%;
+        margin-left: 0; }
+      .row .col.l6 {
+        width: 50%;
+        margin-left: 0; }
+      .row .col.l7 {
+        width: 58.33333%;
+        margin-left: 0; }
+      .row .col.l8 {
+        width: 66.66667%;
+        margin-left: 0; }
+      .row .col.l9 {
+        width: 75%;
+        margin-left: 0; }
+      .row .col.l10 {
+        width: 83.33333%;
+        margin-left: 0; }
+      .row .col.l11 {
+        width: 91.66667%;
+        margin-left: 0; }
+      .row .col.l12 {
+        width: 100%;
+        margin-left: 0; }
       .row .col.offset-l1 {
         margin-left: 8.33333%; }
       .row .col.pull-l1 {
         right: 8.33333%; }
       .row .col.push-l1 {
         left: 8.33333%; }
-      .row .col.l2 {
-        width: 16.66667%; }
       .row .col.offset-l2 {
         margin-left: 16.66667%; }
       .row .col.pull-l2 {
         right: 16.66667%; }
       .row .col.push-l2 {
         left: 16.66667%; }
-      .row .col.l3 {
-        width: 25%; }
       .row .col.offset-l3 {
         margin-left: 25%; }
       .row .col.pull-l3 {
         right: 25%; }
       .row .col.push-l3 {
         left: 25%; }
-      .row .col.l4 {
-        width: 33.33333%; }
       .row .col.offset-l4 {
         margin-left: 33.33333%; }
       .row .col.pull-l4 {
         right: 33.33333%; }
       .row .col.push-l4 {
         left: 33.33333%; }
-      .row .col.l5 {
-        width: 41.66667%; }
       .row .col.offset-l5 {
         margin-left: 41.66667%; }
       .row .col.pull-l5 {
         right: 41.66667%; }
       .row .col.push-l5 {
         left: 41.66667%; }
-      .row .col.l6 {
-        width: 50%; }
       .row .col.offset-l6 {
         margin-left: 50%; }
       .row .col.pull-l6 {
         right: 50%; }
       .row .col.push-l6 {
         left: 50%; }
-      .row .col.l7 {
-        width: 58.33333%; }
       .row .col.offset-l7 {
         margin-left: 58.33333%; }
       .row .col.pull-l7 {
         right: 58.33333%; }
       .row .col.push-l7 {
         left: 58.33333%; }
-      .row .col.l8 {
-        width: 66.66667%; }
       .row .col.offset-l8 {
         margin-left: 66.66667%; }
       .row .col.pull-l8 {
         right: 66.66667%; }
       .row .col.push-l8 {
         left: 66.66667%; }
-      .row .col.l9 {
-        width: 75%; }
       .row .col.offset-l9 {
         margin-left: 75%; }
       .row .col.pull-l9 {
         right: 75%; }
       .row .col.push-l9 {
         left: 75%; }
-      .row .col.l10 {
-        width: 83.33333%; }
       .row .col.offset-l10 {
         margin-left: 83.33333%; }
       .row .col.pull-l10 {
         right: 83.33333%; }
       .row .col.push-l10 {
         left: 83.33333%; }
-      .row .col.l11 {
-        width: 91.66667%; }
       .row .col.offset-l11 {
         margin-left: 91.66667%; }
       .row .col.pull-l11 {
         right: 91.66667%; }
       .row .col.push-l11 {
         left: 91.66667%; }
-      .row .col.l12 {
-        width: 100%; }
       .row .col.offset-l12 {
         margin-left: 100%; }
       .row .col.pull-l12 {

--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -19,8 +19,8 @@
 }
 
 .section {
-	padding-top: 1rem;
-	padding-bottom: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 
   &.no-pad {
     padding: 0;
@@ -61,7 +61,14 @@
       $perc: unquote((100 / ($num-cols / $i)) + "%");
       &.s#{$i} {
         width: $perc;
+        margin-left: 0;
       }
+      $i: $i + 1;
+    }
+
+    $i: 1;
+    @while $i <= $num-cols {
+      $perc: unquote((100 / ($num-cols / $i)) + "%");
       &.offset-s#{$i} {
         margin-left: $perc;
       }
@@ -81,7 +88,14 @@
         $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.m#{$i} {
           width: $perc;
+          margin-left: 0;
         }
+        $i: $i + 1
+      }
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.offset-m#{$i} {
           margin-left: $perc;
         }
@@ -102,7 +116,14 @@
         $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.l#{$i} {
           width: $perc;
+          margin-left: 0;
         }
+        $i: $i + 1;
+      }
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.offset-l#{$i} {
           margin-left: $perc;
         }


### PR DESCRIPTION
Hello,

I recently updated materialize and I got issues with offsets.

The fix on master  https://github.com/Dogfalo/materialize/commit/d5db2a3290ab2848f4482aae2933756b8e357346 doesn’t really work.
If we stack multiple sizes the problem is still here.

For example :
class="col m8 offset-m2 l4”

On desktop, offset-m2 is still active because l4 doesn’t override it with a margin-left:0px.

The original problem with offsets comes from this commit https://github.com/Dogfalo/materialize/commit/511043f50a41366c5a4f384f7baa0e30d1702066 which breaks css priority.

I hope my explanation is clear, I just put back margin-left and an additional loop to keep the old css priority.  

Regards.