### PR TITLE
Material box undefined error fix

### DIFF
--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -253,8 +253,9 @@
               doneAnimating = true;
               $(this).remove();
 
-              // Remove overflow overrides on ancestors
-              ancestorsChanged.css('overflow', '');
+                // Remove overflow overrides on ancestors
+              if(ancestorsChanged !== undefined)
+                ancestorsChanged.css('overflow', '');
             }
           });
 


### PR DESCRIPTION
The ancestorsChanged object can end up being undefined. The .css() method
was being called on an undefined object causing an error to be thrown.
