### PR TITLE
scrollFire: callback function, repeat fire option

### DIFF
--- a/jade/page-contents/scrollfire_content.html
+++ b/jade/page-contents/scrollfire_content.html
@@ -14,7 +14,7 @@
         <pre><code class="language-javascript col s12">
   var options = [
     {selector: '.class', offset: 200, callback: 'globalFunction()' },
-    {selector: '.other-class', offset: 200, callback: 'globalFunction()' },
+    {selector: '.other-class', offset: 200, callback: this.onOtherClassVisible },
   ];
   Materialize.scrollFire(options);
         </code></pre>
@@ -41,7 +41,7 @@
             </tr>
             <tr>
               <td>Callback</td>
-              <td>This string is the function call that you want to make when the user scrolls to the threshold. It will only be called once.</td>
+              <td>The function call that you want to make when the user scrolls to the threshold. It will only be called once.  This can be a string or function object.</td>
             </tr>
           </tbody>
         </table>

--- a/jade/page-contents/scrollfire_content.html
+++ b/jade/page-contents/scrollfire_content.html
@@ -14,7 +14,7 @@
         <pre><code class="language-javascript col s12">
   var options = [
     {selector: '.class', offset: 200, callback: 'globalFunction()' },
-    {selector: '.other-class', offset: 200, callback: this.onOtherClassVisible },
+    {selector: '.other-class', offset: 200, callback: this.onOtherClassVisible, repeat: true },
   ];
   Materialize.scrollFire(options);
         </code></pre>
@@ -41,7 +41,11 @@
             </tr>
             <tr>
               <td>Callback</td>
-              <td>The function call that you want to make when the user scrolls to the threshold. It will only be called once.  This can be a string or function object.</td>
+              <td>The function call that you want to make when the user scrolls to the threshold. By default, it will only be called once.  This can be a string or function object.</td>
+            </tr>
+            <tr>
+              <td>Repeat</td>
+              <td>Set to true to invoke the callback every time the selector reaches the bottom of the user's window.  Default is false; the callback will be called only once.</td>
             </tr>
           </tbody>
         </table>

--- a/js/scrollFire.js
+++ b/js/scrollFire.js
@@ -23,13 +23,14 @@
             var selector = value.selector,
                 offset = value.offset,
                 callback = value.callback;
+                repeat = value.repeat;
 
             var currentElement = document.querySelector(selector);
             if ( currentElement !== null) {
               var elementOffset = currentElement.getBoundingClientRect().top + window.pageYOffset;
 
               if (windowScroll > (elementOffset + offset)) {
-                if (value.done !== true) {
+                if (repeat || value.done !== true) {
                   if (typeof callback === 'function') {
                     callback();
                   } else {

--- a/js/scrollFire.js
+++ b/js/scrollFire.js
@@ -30,8 +30,12 @@
 
               if (windowScroll > (elementOffset + offset)) {
                 if (value.done !== true) {
-                  var callbackFunc = new Function(callback);
-                  callbackFunc();
+                  if (typeof callback === 'function') {
+                    callback();
+                  } else {
+                    var callbackFunc = new Function(callback);
+                    callbackFunc();
+                  }
                   value.done = true;
                 }
               }


### PR DESCRIPTION
Currently, the callback option of scrollFire has to be a string, which gets called like this:

```
var callbackFunc = new Function(callback);
callbackFunc();
```

This means the function must be global, and there's no way to pass it any context. 7861638 checks if the callback is a function, and then calls it.  

I wanted to use th scrollFire for infinite scroll.  I put my trigger element at the bottom of the list, and my callback renders more content when the trigger element comes into view.  Currently, there's no way get it to invoke the callback more than once.  d7999ea adds `repeat` option, which will invoke the callback each time the trigger element comes into view.  

Here's an example of how I used a callback function and the `repeat` option to set up infinite scroll in a React component:

```
showMore: function() {
    this.setState({to: Math.min(this.state.items.length, this.state.to+pageSize)});
},
componentDidMount() {
    // ... load content
    Materialize.scrollFire([
        { selector: '#moreMarker', offset: 0, callback: this.showMore, repeat: true }
    ]);
},
render() {
    return (
        <div>
            <ItemList items={this.state.items.slice(0, this.state.to)} />
            <div id="moreMarker" className="chip">More...</div>
        </div>
    );
}
```
