### PR TITLE
Fixed un-hovering animation

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -2652,6 +2652,11 @@ ul li {
   box-shadow: 0 27px 24px 0 rgba(0, 0, 0, 0.2), 0 40px 77px 0 rgba(0, 0, 0, 0.22);
 }
 
+.hoverable {
+  transition: box-shadow .25s;
+  box-shadow: 0;
+}
+
 .hoverable:hover {
   transition: box-shadow .25s;
   box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -77,6 +77,11 @@ ul {
   box-shadow: 0 27px 24px 0 rgba(0, 0, 0, 0.2), 0 40px 77px 0 rgba(0, 0, 0, 0.22);
 }
 
+.hoverable {
+  transition: box-shadow .25s;
+  box-shadow: 0;
+}
+
 .hoverable:hover {
   transition: box-shadow .25s;
   box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);


### PR DESCRIPTION
Previously, when "un-hovering" an element, it had no animation. Now has a fade-out.