### PR TITLE
Modal - on close use same options open

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -33,6 +33,7 @@
 
       // Override defaults
       options = $.extend(defaults, options);
+      $modal.data('options', options);
 
       if (options.dismissible) {
         $overlay.click(function() {
@@ -104,6 +105,8 @@
       overlayID = $modal.data('overlay-id'),
       $overlay = $('#' + overlayID);
 
+      if (!options)
+        options = $modal.data('options');
       options = $.extend(defaults, options);
 
       // Disable scrolling


### PR DESCRIPTION
To allow a close callback to be defined by the function that opens the modal and called when closed by a generic close trigger, this change stores the options used to open the modal and automatically uses them in close() if they have not been passed in.
