### PR TITLE
Trigger dropdown:open/close events

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -171,6 +171,7 @@
             easing: 'easeOutCubic',
             complete: function() {
               $(this).css('height', '');
+              origin.trigger("dropdown:open", this);
             }
           })
           .animate( {opacity: 1}, {queue: false, duration: curr_options.inDuration, easing: 'easeOutSine'});
@@ -179,10 +180,15 @@
       function hideDropdown() {
         // Check for simultaneous focus and click events.
         isFocused = false;
-        activates.fadeOut(curr_options.outDuration);
+        activates.fadeOut({
+          duration: curr_options.outDuration,
+          complete: function() {
+            $(this).css('max-height', '');
+            origin.trigger("dropdown:close", this);
+          }
+        });
         activates.removeClass('active');
         origin.removeClass('active');
-        setTimeout(function() { activates.css('max-height', ''); }, curr_options.outDuration);
       }
 
       // Hover


### PR DESCRIPTION
To allow custom functionality to trigger after the dropdowns have completed opening / closing (i.e. updating the displayed data) this triggers two custom events:
1. dropdown:open
2. dropdown:close
