### PR TITLE
Cover case where input tag has no type specified

### DIFF
--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -34,6 +34,7 @@ label {
 }
 
 // Text inputs
+input:not([type]),
 input[type=text],
 input[type=password],
 input[type=email],


### PR DESCRIPTION
An input tag with no type attribute is considered to be of type="text",
but was not being picked up by Materialize.