### PR TITLE
(fix) Fix links to materialize css/js in templates

### DIFF
--- a/templates/masonry-template/index.html
+++ b/templates/masonry-template/index.html
@@ -6,7 +6,7 @@
   <title>Parallax Template - Materialize</title>
 
   <!-- CSS  -->
-  <link href="css/materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <link href="../../dist/css/materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link href="css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
 </head>
 <body>
@@ -156,7 +156,7 @@
 
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-  <script src="js/materialize.js"></script>
+  <script src="../../dist/js/materialize.js"></script>
   <script src="js/init.js"></script>
 
   </body>

--- a/templates/parallax-template/index.html
+++ b/templates/parallax-template/index.html
@@ -8,7 +8,7 @@
 
   <!-- CSS  -->
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="css/materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <link href="../../dist/css/materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link href="css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
 </head>
 <body>

--- a/templates/starter-template/index.html
+++ b/templates/starter-template/index.html
@@ -7,7 +7,7 @@
 
   <!-- CSS  -->
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="css/materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <link href="../../dist/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link href="css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
 </head>
 <body>
@@ -119,7 +119,7 @@
 
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-  <script src="../../bin/materialize.js"></script>
+  <script src="../../dist/js/materialize.js"></script>
   <script src="js/init.js"></script>
 
   </body>


### PR DESCRIPTION
For consistency and clarity, this commit fixes the `href` and `src`
links to materialize.css and materialize.js -- just like it is in the
corresponding `preview.html` files.

Fixes #2404, fixes #2147, fixes

See issues #2333, #1947 and #2206 (PR -- with merge conflicts)

Sign-off: @profnandaa