### PR TITLE
Select bugfixes.

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -573,8 +573,8 @@ $(document).ready(function() {
             <h4>Updating Select</h4>
             <p>You can update the material select by passing new values with this function below, in this case you don't need to use the destroying select function.</p>
             <pre><code class="language-javascript">
-  $('select').val([value1, value2]).trigger('change.update'); // for multiple select
-  $('select').val(value).trigger('change.update'); // for single select
+  $('select').val([value1, value2]).trigger('update'); // for multiple select
+  $('select').val(value).trigger('update'); // for single select
             </code></pre>
           </div>
           <div class="col s12">

--- a/forms.html
+++ b/forms.html
@@ -564,16 +564,24 @@
             <h4>Initialization</h4>
             <p>You must initialize the select element as shown below. In addition, you will need a separate call for any dynamically generated select elements your page generates.</p>
             <pre><code class="language-javascript col s12">
-  $(document).ready(function() {
-    $('select').material_select();
-  });
+$(document).ready(function() {
+  $('select').material_select();
+});
             </code></pre>
           </div>
           <div class="col s12">
-            <h4>Updating/Destroying Select</h4>
-            <p>If you want to update the items inside the select, just rerun the initialization code from above after editing the original select. Or you can destroy the material select with this function below, and create a new select altogether</p>
+            <h4>Updating Select</h4>
+            <p>You can update the material select by passing new values with this function below, in this case you don't need to use the destroying select function.</p>
             <pre><code class="language-javascript">
-  $('select').material_select('destroy');
+  $('select').val([value1, value2]).trigger('change.update'); // for multiple select
+  $('select').val(value).trigger('change.update'); // for single select
+            </code></pre>
+          </div>
+          <div class="col s12">
+            <h4>Destroying Select</h4>
+            <p>Or you can destroy the material select with this function below, and create a new select altogether</p>
+            <pre><code class="language-javascript">
+$('select').material_select('destroy');
             </code></pre>
           </div>
         </div>

--- a/forms.html
+++ b/forms.html
@@ -424,7 +424,7 @@
                   <option value="" disabled selected>Choose your option</option>
                   <option value="" data-icon="images/sample-1.jpg" class="circle">example 1</option>
                   <option value="" data-icon="images/office.jpg" class="circle">example 2</option>
-                  <option value="" data-icon="images/yuna.jpg" class="circle">example 1</option>
+                  <option value="" data-icon="images/yuna.jpg" class="circle">example 3</option>
                 </select>
                 <label>Images in select</label>
               </div>
@@ -493,7 +493,7 @@
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="" data-icon="images/sample-1.jpg" class="circle">example 1&lt;/option>
       &lt;option value="" data-icon="images/office.jpg" class="circle">example 2&lt;/option>
-      &lt;option value="" data-icon="images/yuna.jpg" class="circle">example 1&lt;/option>
+      &lt;option value="" data-icon="images/yuna.jpg" class="circle">example 3&lt;/option>
     &lt;/select>
     &lt;label>Images in select&lt;/label>
   &lt;/div>

--- a/forms.html
+++ b/forms.html
@@ -405,7 +405,7 @@
               <div class="input-field col s12 m6">
                 <select>
                   <optgroup label="team 1">
-                    <option value="1">Option 1</option>
+                    <option value="1" selected>Option 1</option>
                     <option value="2">Option 2</option>
                   </optgroup>
                   <optgroup label="team 2">
@@ -413,7 +413,20 @@
                     <option value="4">Option 4</option>
                   </optgroup>
                 </select>
-                <label>Optgroups</label>
+                <label>Single Select with optgroups</label>
+              </div>
+              <div class="input-field col s12 m6">
+                <select multiple>
+                  <optgroup label="team 1">
+                    <option value="1" selected>Option 1</option>
+                    <option value="2">Option 2</option>
+                  </optgroup>
+                  <optgroup label="team 2">
+                    <option value="3" selected>Option 3</option>
+                    <option value="4">Option 4</option>
+                  </optgroup>
+                </select>
+                <label>Multiple Select with optgroups</label>
               </div>
               <div class="col s12">
                 <br>
@@ -474,10 +487,10 @@
     &lt;label>Materialize Multiple Select&lt;/label>
   &lt;/div>
 
-  &lt;div class="input-field col s12">
-    &lt;select multiple>
+  &lt;div class="input-field col s12 m6">
+    &lt;select>
       &lt;optgroup label="team 1">
-        &lt;option value="1">Option 1&lt;/option>
+        &lt;option value="1" selected>Option 1&lt;/option>
         &lt;option value="2">Option 2&lt;/option>
       &lt;/optgroup>
       &lt;optgroup label="team 2">
@@ -485,7 +498,21 @@
         &lt;option value="4">Option 4&lt;/option>
       &lt;/optgroup>
     &lt;/select>
-    &lt;label>Optgroups&lt;/label>
+    &lt;label>Single Select with optgroups&lt;/label>
+  &lt;/div>
+  
+  &lt;div class="input-field col s12 m6">
+    &lt;select multiple>
+      &lt;optgroup label="team 1">
+        &lt;option value="1" selected>Option 1&lt;/option>
+        &lt;option value="2">Option 2&lt;/option>
+      &lt;/optgroup>
+      &lt;optgroup label="team 2">
+        &lt;option value="3" selected>Option 3&lt;/option>
+        &lt;option value="4">Option 4&lt;/option>
+      &lt;/optgroup>
+    &lt;/select>
+    &lt;label>Multiple Select with optgroups&lt;/label>
   &lt;/div>
 
   &lt;div class="input-field col s12 m6">

--- a/js/forms.js
+++ b/js/forms.js
@@ -569,11 +569,6 @@
             $(this).trigger('close');
             options.find('li.active:not(.disabled)').removeClass('active');
           }
-        },
-        'keydown': function (e) {
-          if ($newSelect.is(':disabled')) {
-            onKeyDown(e);
-          }
         }
       });
 
@@ -586,6 +581,15 @@
       $(window).on({
         'click': function() {
           multiple && (optionsHover || $newSelect.trigger('close'));
+
+          if ($newSelect.is(':disabled')) {
+            $newSelect.prop('disabled', false);
+          }
+        },
+        'keydown': function(e) {
+          if ($newSelect.is(':disabled')) {
+            onKeyDown(e);
+          }
         }
       });
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -462,6 +462,7 @@
             return !v;
           });
           $newSelect.trigger('focus');
+          $select.trigger('change');
 
           e.stopPropagation();
         });
@@ -538,6 +539,8 @@
             setValueToInput(optgroupValuesSelected);
           }
         }
+
+        $select.trigger('change');
       });
 
       // Input events

--- a/js/forms.js
+++ b/js/forms.js
@@ -301,7 +301,7 @@
       if (multiple && optgroups) {
         var optgroupValuesSelected = [];
 
-        for (var k = 0, optgroupsCount = $select.find('optgroup').length; k < optgroupsCount; k++) {
+        for (var i = 0, optgroupsCount = $select.find('optgroup').length; i < optgroupsCount; i++) {
           optionsValuesSelected.push([]);
         }
       }
@@ -336,7 +336,7 @@
             options.append($('<li class="' + disabledClass + '"><span>' + option.html() + '</span></li>'));
           }
         } else {
-          if (!!icon_url) {
+          if (icon_url) {
             options.append($('<li class="optgroup ' + disabledClass + '"><img src="' + icon_url + '"' + classes + '><span>' + option.attr('label') + '</span></li>'));
           } else {
             options.append($('<li class="optgroup ' + disabledClass + '"><span>' + option.attr('label') + '</span></li>'));
@@ -382,9 +382,7 @@
               }
 
               options.scrollTo($(this));
-              $('input[type="checkbox"]', this).prop('checked', function(i, v) {
-                return !v;
-              });
+              $('input[type="checkbox"]', this).prop('checked', function(i, v) { return !v; });
               $newSelect.trigger('focus');
             } else {
               options.find('li.active').removeClass('active');
@@ -420,10 +418,7 @@
       $newSelect.after(options);
       // Check if section element is disabled
       if (!$select.is(':disabled')) {
-        $newSelect.dropdown({
-          'hover': false,
-          'closeOnClick': false
-        });
+        $newSelect.dropdown({'hover': false, 'closeOnClick': false});
       }
 
       // Copy tabindex
@@ -558,8 +553,8 @@
         if (multiple && optgroups) {
           optgroupValuesSelected.length = 0;
 
-          for (var l = 0, lCount = optionsValuesSelected.length; l < lCount; l++) {
-            optionsValuesSelected[l].length = 0;
+          for (var i = 0, count = optionsValuesSelected.length; i < count; i++) {
+            optionsValuesSelected[i].length = 0;
           }
         } else {
           optionsValuesSelected.length = 0;
@@ -712,8 +707,7 @@
 
       // Creates an array with the values to display
       function generatesValuesArray() {
-        var arrayValues = [],
-            value = '';
+        var arrayValues = [];
 
         for (var i = 0, count = optionsValuesSelected.length; i < count; i++) {
           var text = $select.find('option').eq(optionsValuesSelected[i]).text().trim();
@@ -725,10 +719,10 @@
       }
 
       // Updates the value in the dropdown input (Option 1, Option 2, ...)
-      function setValueToInput(optgroupValuesSelected) {
-        sortArrayValues(optgroupValuesSelected);
+      function setValueToInput(array) {
+        sortArrayValues(array);
 
-        var value = optgroupValuesSelected.join(', ');
+        var value = array.join(', ');
 
         if (!value) {
           value = $select.find('option:disabled').eq(0).text() || "";
@@ -737,7 +731,7 @@
         $newSelect.val(value);
       }
 
-      // Sorts the values from the array in alphabetical order.
+      // Sorts the values from the array in alphabetical order
       function sortArrayValues(array) {
         array.sort(function(a, b) {
           var x = a.toLowerCase(),

--- a/js/forms.js
+++ b/js/forms.js
@@ -558,6 +558,8 @@
               activateOption(options, selectedOption, 'active');
             }
           }
+
+          $newSelect.prop('disabled', true);
         },
         'click': function(e) {
           e.stopPropagation();
@@ -566,6 +568,11 @@
           if (!multiple) {
             $(this).trigger('close');
             options.find('li.active:not(.disabled)').removeClass('active');
+          }
+        },
+        'keydown': function (e) {
+          if ($newSelect.is(':disabled')) {
+            onKeyDown(e);
           }
         }
       });
@@ -704,6 +711,7 @@
             // ESC - close options
             if (e.which == 27) {
               $newSelect.trigger('close');
+              $newSelect.prop('disabled', false);
             }
 
             // ARROW UP - move to previous not disabled option

--- a/js/forms.js
+++ b/js/forms.js
@@ -306,6 +306,19 @@
         }
       }
 
+      // Scan for existing options before an optgroup
+      if (optgroups) {
+        if ($select.find('> option:not(:disabled)').length) {
+          $select.find('> option:not(:disabled)').each(function() {
+            // Put it in comments
+            $(this).wrap(function() {
+              return '<!-- ' + this.outerHTML + ' -->';
+            });
+            $(this).remove();
+          });
+        }
+      }
+
       var label = $select.find('option:selected').html() || $select.find('option:disabled').eq(0).html() || "";
 
       // Function that renders and appends the element taking into
@@ -348,19 +361,6 @@
           return element;
         }
       };
-
-      // Scan for existing options before an optgroup
-      if (optgroups) {
-        if ($select.find('> option:not(:disabled)').length) {
-          $select.find('> option:not(:disabled)').each(function() {
-            // Put it in comments
-            $(this).wrap(function() {
-              return '<!-- ' + this.outerHTML + ' -->';
-            });
-            $(this).remove();
-          });
-        }
-      }
 
       /* Create dropdown structure. */
       if (selectChildren.length) {

--- a/js/forms.js
+++ b/js/forms.js
@@ -557,9 +557,7 @@
               var selectedOption = options.find('li[data-value="' + $select.find('option:not(:disabled):selected').val() + '"]')[0];
               activateOption(options, selectedOption, 'active');
             }
-          }
-
-          $newSelect.prop('disabled', true);
+          }²
         },
         'click': function(e) {
           e.stopPropagation();
@@ -581,15 +579,6 @@
       $(window).on({
         'click': function() {
           multiple && (optionsHover || $newSelect.trigger('close'));
-
-          if ($newSelect.is(':disabled')) {
-            $newSelect.prop('disabled', false);
-          }
-        },
-        'keydown': function(e) {
-          if ($newSelect.is(':disabled')) {
-            onKeyDown(e);
-          }
         }
       });
 
@@ -715,7 +704,6 @@
             // ESC - close options
             if (e.which == 27) {
               $newSelect.trigger('close');
-              $newSelect.prop('disabled', false);
             }
 
             // ARROW UP - move to previous not disabled option

--- a/js/forms.js
+++ b/js/forms.js
@@ -655,16 +655,14 @@
             }
 
             // Automatically clean filter query so user can search again by starting letters
-            setTimeout(function() {
-              filterQuery = [];
-            }, 1000);
+            setTimeout(function() { filterQuery = []; }, 1000);
           };
 
       $newSelect.on('keydown', onKeyDown);
 
       /* Functions */
 
-      // Updates from the variable entries (entriesArray) to match the dropdown options
+      // Updates from optionsValuesSelected to match active dropdown items to the selected select options
       function toggleIndexFromArray(indexOption, indexLi, indexOptgroup) {
         var index, notAdded;
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -407,7 +407,7 @@
       $select.addClass('initialized');
 
       // Select change event - Update the select's values on the fly by passing new values from an array
-      $select.on('change.update', function () {
+      $select.on('update', function () {
         if (multiple) {
           resetOptions();
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -478,7 +478,7 @@
       // escape double quotes
       var sanitizedLabelHtml = label.replace(/"/g, '&quot;').trim();
 
-      var $newSelect = $('<input type="text" class="select-dropdown" readonly="true" ' + (($select.is(':disabled')) ? 'disabled' : '') + ' data-activates="select-options-' + uniqueID + '" value="' + sanitizedLabelHtml + '" ' + (required ? 'required' : '') + '/>');
+      var $newSelect = $('<input type="text" class="select-dropdown" readonly="readonly" ' + (($select.is(':disabled')) ? 'disabled' : '') + ' data-activates="select-options-' + uniqueID + '" value="' + sanitizedLabelHtml + '" ' + (required ? 'required' : '') + '/>');
       $select.before($newSelect);
       $newSelect.before(dropdownIcon);
 

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -21,12 +21,8 @@
     text-align: left;
     text-transform: none;
 
-    &:hover, &.active, &.selected {
+    &:hover, &.active {
       background-color: $dropdown-hover-bg-color;
-    }
-
-    &.active.selected {
-      background-color: darken($dropdown-hover-bg-color, 5%);
     }
 
     &.divider {

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -21,8 +21,12 @@
     text-align: left;
     text-transform: none;
 
-    &:hover, &.active {
+    &:hover, &.active, &.selected {
       background-color: $dropdown-hover-bg-color;
+    }
+
+    &.active.selected {
+      background-color: darken($dropdown-hover-bg-color, 5%);
     }
 
     &.divider {

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -652,7 +652,13 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
 }
 
 select { display: none; }
-select.browser-default { display: block; }
+select.browser-default {
+  display: block;
+  margin-top: 15px;
+}
+select.browser-default + label {
+  top: -0.8rem;
+}
 
 // Disabled styles
 select:disabled {
@@ -693,7 +699,7 @@ select:disabled {
 .select-dropdown li.optgroup {
   border-top: 1px solid $dropdown-hover-bg-color;
 
-  &.active > span {
+  &.selected > span {
     color: rgba(0, 0, 0, .7);
   }
 

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -656,9 +656,7 @@ select.browser-default {
   display: block;
   margin-top: 15px;
 }
-select.browser-default + label {
-  top: -0.8rem;
-}
+select.browser-default + label { top: -0.8rem; }
 
 // Disabled styles
 select:disabled {

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -655,8 +655,9 @@ select { display: none; }
 select.browser-default {
   display: block;
   margin-top: 15px;
+
+  & + label { top: -0.8rem; }
 }
-select.browser-default + label { top: -0.8rem; }
 
 // Disabled styles
 select:disabled {
@@ -681,6 +682,17 @@ select:disabled {
 .select-dropdown li.optgroup {
   color: rgba(0,0,0,.3);
   background-color: transparent;
+}
+
+.select-dropdown {
+  li.disabled, li.disabled > span, li.optgroup {
+    color: rgba(0,0,0,.3);
+    background-color: transparent;
+  }
+
+  li.disabled > span label::before {
+    border: 2px solid rgba(0, 0, 0, 0.3);
+  }
 }
 
 // Icons

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -637,8 +637,12 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
     color: initial;
     position: absolute;
     right: 0;
-    top: 16px;
+    top: 6px;
     font-size: 10px;
+    background-color: #FFF;
+    padding: 5px 0;
+    z-index: 1;
+
     &.disabled {
       color: $input-disabled-color;
     }
@@ -679,9 +683,9 @@ select:disabled {
 
 .select-dropdown li.disabled,
 .select-dropdown li.disabled > span,
+.select-dropdown li.optgroup.disabled > span,
 .select-dropdown li.optgroup {
   color: rgba(0,0,0,.3);
-  background-color: transparent;
 }
 
 .select-dropdown {
@@ -691,7 +695,7 @@ select:disabled {
   }
 
   li.disabled > span label::before {
-    border: 2px solid rgba(0, 0, 0, 0.3);
+    border: 2px solid rgba(0, 0, 0, .3);
   }
 }
 
@@ -714,7 +718,7 @@ select:disabled {
   }
 
   & > span {
-    color: rgba(0, 0, 0, .4);
+    color: $radio-empty-color;
   }
 
   & ~ li:not(.optgroup) {

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -18,19 +18,19 @@ label {
 
 // Style Placeholders
 ::-webkit-input-placeholder {
-   color: lighten($input-border-color, 20%);
+  color: lighten($input-border-color, 20%);
 }
 
 :-moz-placeholder { /* Firefox 18- */
-   color: lighten($input-border-color, 20%);
+  color: lighten($input-border-color, 20%);
 }
 
 ::-moz-placeholder {  /* Firefox 19+ */
-   color: lighten($input-border-color, 20%);
+  color: lighten($input-border-color, 20%);
 }
 
 :-ms-input-placeholder {
-   color: lighten($input-border-color, 20%);
+  color: lighten($input-border-color, 20%);
 }
 
 // Text inputs
@@ -210,9 +210,9 @@ textarea.materialize-textarea {
 
 // Default textarea
 textarea {
-   width: 100%;
-   height: 3rem;
-   background-color: transparent;
+  width: 100%;
+  height: 3rem;
+  background-color: transparent;
 
   &.materialize-textarea {
     overflow-y: hidden; /* prevents scroll bar flash */
@@ -459,15 +459,15 @@ form p:last-child {
   // Unchecked style
   &:not(:checked) + label:before {
     width: 0;
-     height: 0;
-     border: 3px solid transparent;
-     left: 6px;
-     top: 10px;
+    height: 0;
+    border: 3px solid transparent;
+    left: 6px;
+    top: 10px;
 
-     -webkit-transform: rotateZ(37deg);
-             transform: rotateZ(37deg);
-     -webkit-transform-origin: 20% 40%;
-             transform-origin: 100% 100%;
+    -webkit-transform: rotateZ(37deg);
+    transform: rotateZ(37deg);
+    -webkit-transform-origin: 20% 40%;
+    transform-origin: 100% 100%;
   }
 
   &:not(:checked) + label:after {
@@ -532,69 +532,69 @@ form p:last-child {
 ***************/
 .switch,
 .switch * {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -khtml-user-select: none;
-    -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -ms-user-select: none;
 }
 
 .switch label {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .switch label input[type=checkbox]{
-    opacity: 0;
-    width: 0;
-    height: 0;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
 .switch label input[type=checkbox]:checked + .lever {
-    background-color: $switch-checked-lever-bg;
+  background-color: $switch-checked-lever-bg;
 }
 
 .switch label input[type=checkbox]:checked + .lever:after {
-    background-color: $switch-bg-color;
+  background-color: $switch-bg-color;
 }
 
 .switch label .lever {
-    content: "";
-    display: inline-block;
-    position: relative;
-    width: 40px;
-    height: 15px;
-    background-color: $switch-unchecked-lever-bg;
-    border-radius: 15px;
-    margin-right: 10px;
-    transition: background 0.3s ease;
-    vertical-align: middle;
-    margin: 0 16px;
+  content: "";
+  display: inline-block;
+  position: relative;
+  width: 40px;
+  height: 15px;
+  background-color: $switch-unchecked-lever-bg;
+  border-radius: 15px;
+  margin-right: 10px;
+  transition: background 0.3s ease;
+  vertical-align: middle;
+  margin: 0 16px;
 }
 
 .switch label .lever:after {
-    content: "";
-    position: absolute;
-    display: inline-block;
-    width: 21px;
-    height: 21px;
-    background-color: $switch-unchecked-bg;
-    border-radius: 21px;
-    box-shadow: 0 1px 3px 1px rgba(0,0,0,.4);
-    left: -5px;
-    top: -3px;
-    transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease;
+  content: "";
+  position: absolute;
+  display: inline-block;
+  width: 21px;
+  height: 21px;
+  background-color: $switch-unchecked-bg;
+  border-radius: 21px;
+  box-shadow: 0 1px 3px 1px rgba(0,0,0,.4);
+  left: -5px;
+  top: -3px;
+  transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease;
 }
 
 // Switch active style
 input[type=checkbox]:checked:not(:disabled) ~ .lever:active:after {
-       box-shadow: 0 1px 3px 1px rgba(0,0,0,.4), 0 0 0 15px transparentize($switch-bg-color, .9);
+  box-shadow: 0 1px 3px 1px rgba(0,0,0,.4), 0 0 0 15px transparentize($switch-bg-color, .9);
 }
 
 input[type=checkbox]:not(:disabled) ~ .lever:active:after {
-       box-shadow: 0 1px 3px 1px rgba(0,0,0,.4), 0 0 0 15px rgba(0, 0, 0, .08);
+  box-shadow: 0 1px 3px 1px rgba(0,0,0,.4), 0 0 0 15px rgba(0, 0, 0, .08);
 }
 
 .switch label input[type=checkbox]:checked + .lever:after {
-    left: 24px;
+  left: 24px;
 }
 
 // Disabled Styles
@@ -603,7 +603,7 @@ input[type=checkbox]:not(:disabled) ~ .lever:active:after {
 }
 .switch label input[type=checkbox][disabled] + .lever:after,
 .switch label input[type=checkbox][disabled]:checked + .lever:after {
-    background-color: $input-disabled-solid-color;
+  background-color: $input-disabled-solid-color;
 }
 
 /***************
@@ -693,7 +693,7 @@ select:disabled {
 .select-dropdown li.optgroup {
   border-top: 1px solid $dropdown-hover-bg-color;
 
-  &.selected > span {
+  &.active > span {
     color: rgba(0, 0, 0, .7);
   }
 
@@ -909,10 +909,10 @@ input[type=range]:focus::-ms-fill-upper {
    Text Inputs + Textarea
 ****************************/
 select {
-   background-color: rgba(255, 255, 255, 0.90);
-   width: 100%;
-   padding: 5px;
-   border: 1px solid #f2f2f2;
-   border-radius: 2px;
-   height: 3rem;
+  background-color: rgba(255, 255, 255, 0.90);
+  width: 100%;
+  padding: 5px;
+  border: 1px solid #f2f2f2;
+  border-radius: 2px;
+  height: 3rem;
 }


### PR DESCRIPTION
This PR fixes all these issues :

https://github.com/Dogfalo/materialize/issues/2274
https://github.com/Dogfalo/materialize/issues/1707
https://github.com/Dogfalo/materialize/issues/1296
https://github.com/Dogfalo/materialize/issues/2535
https://github.com/Dogfalo/materialize/issues/2522
https://github.com/Dogfalo/materialize/issues/2548
https://github.com/Dogfalo/materialize/issues/2554

This issue should be fixed but not sure while we get no return, I changed **readonly="true"** to **readonly="readonly"** :
https://github.com/Dogfalo/materialize/issues/2448

This issue is partially fixed, I just added the **required** attribute when it's here to the input :
https://github.com/Dogfalo/materialize/issues/2536

The fix is working on FF, but not Chrome and Opera.
Safari and IE < 10 don't support required attribute yet.

However, since your last fixes this issue isn't still fixed :
https://github.com/Dogfalo/materialize/issues/2436

So, in this PR we can now update a select value programmatically like this :

```
$('select').val([value1, value2]).trigger('update'); // for multiple select 
```

```
$('select').val(value).trigger('update'); // for single select
```

Then, as @Sabartius was asking for in #2274 , options text showed inside the input aren't ordered anymore the way we clicked them, now we preserve the order (by name) of the options.

Optgroups are now working in single and multiple select and accept icon with data-icon, just like an option, because someone could prefer to add an icon to the optgroups instead the options.

Finally, there are some optimizations, documentation and the values displayed in the input are now sanitized from blank spaces.

You have to change the Jasmine tests because now there is a click event on li.optgroup which wasn't the case before.

Hope it'll fixes the last select bugs.

There is a JSfiddle of several working examples (result tab) : http://jsfiddle.net/TyrionGraphiste/ccw7ygLc/2/embedded/