### PR TITLE
Error message didn't fit into label space

### DIFF
--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -10,6 +10,8 @@ button:focus {
 label {
   font-size: $label-font-size;
   color: $input-border-color;
+  pointer-events: none;
+  width: 100%;
 }
 
 /***************************


### PR DESCRIPTION
1. Error message was only fitting into label space [width 100% helps]
2. The other problem was with clicking directly to the label (it didn't animate, just select label text) [pointer events solved the problem]