### PR TITLE
added basic click through to tooltips

### DIFF
--- a/sass/components/_tooltip.scss
+++ b/sass/components/_tooltip.scss
@@ -15,6 +15,7 @@
     overflow: hidden;
     left:0;
     top:0;
+    pointer-events: none;
     will-change: top, left;
 }
 


### PR DESCRIPTION
Added "pointer-events: none;" to .material-tooltip class so that supporting browsers allow click through and tooltips do not interrupt the intended function of the element they cover while animating away.

Change only added to SASS component in this pull request and not the compiled CSS.