### PR TITLE
Option to show elements with 'inline-block' instead only 'block'.

### DIFF
--- a/jade/page-contents/helpers_content.html
+++ b/jade/page-contents/helpers_content.html
@@ -101,6 +101,41 @@
         </code></pre><br>
 
       </div><!--  End Hiding Section  -->
+        
+      <!--  Showing Section-->
+      <div id="showing" class="section scrollspy">
+        <h2 class="header">Showing Content</h2>
+        <table class="striped">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Screen Range</th>
+            </tr>
+          </thead>
+            <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>.show-on-large</strong> or <strong>.show-on-large-inline</strong></code></td>
+              <td>Shown for all Devices</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>.show-on-medium</strong> or <strong>.show-on-medium-inline</strong></code></td>
+              <td>Shown for Mobile Only</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>.show-on-small</strong> or <strong>.show-on-small-inline</strong></code></td>
+              <td>Shown for Tablet Only</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>.show-on-medium-and-up</strong> or <strong>.show-on-medium-and-up-inline</strong></code></td>
+              <td>Shown for Tablet and Below</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>.show-on-medium-and-down</strong> or <strong>.show-on-medium-and-down-inline</strong></code></td>
+              <td>Shown for Tablet and Above</td>
+            </tr>
+          </tbody>
+        </table>
+      </div><!--  End Showing Section  -->
 
 
 
@@ -158,6 +193,7 @@
           <ul class="section table-of-contents">
             <li><a href="#valign">Alignment</a></li>
             <li><a href="#hiding">Hiding Content</a></li>
+            <li><a href="#showing">Showing Content</a></li>
             <li><a href="#formatting">Formatting</a></li>
           </ul>
         </div>

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -330,7 +330,31 @@ ul.staggered-list li {
     display: block !important;
   }
 }
-
+.show-on-large-inline {
+  @media #{$large-and-up} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-inline {
+  @media only screen and (min-width: $small-screen) and (max-width: $medium-screen) {
+    display: inline-block !important;
+  }
+}
+.show-on-small-inline {
+  @media #{$small-and-down} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-and-up-inline {
+  @media #{$medium-and-up} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-and-down-inline {
+  @media #{$medium-and-down} {
+    display: inline-block !important;
+  }
+}
 
 // Center text on mobile
 .center-on-small-only {


### PR DESCRIPTION
Created classes like ".show-on-large-inline" that allows you to show an element with 'inline-block' instead of 'block'.
I also updated the documentation page.