### PR TITLE
Input error message width fix

### DIFF
--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -137,6 +137,8 @@ textarea.materialize-textarea {
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;
+    width: 100%;
+    text-align: left;
   }
   label.active {
     font-size: $label-font-size;

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -142,7 +142,6 @@ textarea.materialize-textarea {
     font-size: $label-font-size;
     transform: translateY(-140%);
     width: 100%;
-    text-align: left;
   }
 
   // Prefix Icons

--- a/sass/components/_form.scss
+++ b/sass/components/_form.scss
@@ -137,12 +137,12 @@ textarea.materialize-textarea {
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;
-    width: 100%;
-    text-align: left;
   }
   label.active {
     font-size: $label-font-size;
     transform: translateY(-140%);
+    width: 100%;
+    text-align: left;
   }
 
   // Prefix Icons


### PR DESCRIPTION
When adding a custom error message to a form input that is longer than the input label, the error message text stacks vertically (see screenshot below). This fixes that by making the label fullwidth when it is active.
<img width="541" alt="screen shot 2016-01-06 at 10 38 46 am" src="https://cloud.githubusercontent.com/assets/11077930/12146490/d0217a14-b461-11e5-821d-b5c88034de51.png">


After the fix:

<img width="527" alt="screen shot 2016-01-06 at 10 52 04 am" src="https://cloud.githubusercontent.com/assets/11077930/12146787/92162d26-b463-11e5-822b-3a751a7f1f08.png">


