### PR TITLE
Modal enhancement to reset scroll position on exit

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -98,7 +98,8 @@
     closeModal: function(options) {
       var defaults = {
         out_duration: 250,
-        complete: undefined
+        complete: undefined,
+        resetContentScrollPosition: true
       },
       $modal = $(this),
       overlayID = $modal.data('overlay-id'),
@@ -108,6 +109,9 @@
 
       // Disable scrolling
       $('body').css('overflow', '');
+
+      //If user scrolled to the bottom of content then reset scroll position on exit if option allows.
+      if (options.resetContentScrollPosition) $modal.find(".modal-content").scrollTop(0, 0);
 
       $modal.find('.modal-close').off('click.close');
       $(document).off('keyup.leanModal' + overlayID);


### PR DESCRIPTION
When a modal has dynamic content that can change with every load of the
modal (my use case is with different forms in angularjs) the scroll
position persists between loads. Added an option that is true by default
that will reset the modal content scroll position x,y to 0,0 when the
modal window is closed.
