### PR TITLE
Modal button margin fix

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -39,7 +39,7 @@
 
     .btn, .btn-flat {
       float: right;
-      margin: 6px 0;
+      margin: 6px 4px;
     }
   }
 }


### PR DESCRIPTION
Adds some left right margin to visually separate the footer buttons when
there is more than one.
