### PR TITLE
Nest i.[left|right|tiny|small|medium|large] inside i.material-icons

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -104,33 +104,6 @@ blockquote {
   border-left: 5px solid $primary-color;
 }
 
-// Icon Styles
-
-i {
-  line-height: inherit;
-
-  &.left {
-    float: left;
-    margin-right: 15px;
-  }
-  &.right {
-    float: right;
-    margin-left: 15px;
-  }
-  &.tiny {
-    font-size: 1rem;
-  }
-  &.small {
-    font-size: 2rem;
-  }
-  &.medium {
-    font-size: 4rem;
-  }
-  &.large {
-    font-size: 6rem;
-  }
-}
-
 // Images
 img.responsive-img,
 video.responsive-video {
@@ -202,6 +175,31 @@ video.responsive-video {
     display: inline-block;
     float: left;
     font-size: 24px;
+    
+    // Icon Styles
+
+    line-height: inherit;
+  
+    &.left {
+      float: left;
+      margin-right: 15px;
+    }
+    &.right {
+      float: right;
+      margin-left: 15px;
+    }
+    &.tiny {
+      font-size: 1rem;
+    }
+    &.small {
+      font-size: 2rem;
+    }
+    &.medium {
+      font-size: 4rem;
+    }
+    &.large {
+      font-size: 6rem;
+    }
   }
 
   &:before {


### PR DESCRIPTION
Nest i.[left|right|tiny|small|medium|large] inside i.material-icons.

Shouldn't this be better since it's more specified and then it's still able to change sizes of the icons even in the `nav`
