### PR TITLE
Fixed jQuery Compatability Bug with Scrollspy

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -71,7 +71,7 @@
 			bottom = top + jWindow.height();
 
 		// determine which elements are in view
-//        + 60 accounts for fixed nav
+		// + 60 accounts for fixed nav
 		var intersections = findElements(top+offset.top + 200, right+offset.right, bottom+offset.bottom, left+offset.left);
 		$.each(intersections, function(i, element) {
 
@@ -108,7 +108,7 @@
 
 	/**
 	 * Get time in ms
-   * @license https://raw.github.com/jashkenas/underscore/master/LICENSE
+	 * @license https://raw.github.com/jashkenas/underscore/master/LICENSE
 	 * @type {function}
 	 * @return {number}
 	 */
@@ -176,15 +176,14 @@
 			elements.push($(element));
 			$(element).data("scrollSpy:id", i);
 			// Smooth scroll to section
-		  $('a[href=#' + $(element).attr('id') + ']').click(function(e) {
-		    e.preventDefault();
-		    var offset = $(this.hash).offset().top + 1;
+			$('a[href="#' + $(element).attr('id') + '"]').click(function(e) {
+				e.preventDefault();
+				var offset = $(this.hash).offset().top + 1;
 
-//          offset - 200 allows elements near bottom of page to scroll
-			
-	    	$('html, body').animate({ scrollTop: offset - 200 }, {duration: 400, queue: false, easing: 'easeOutCubic'});
-			
-		  });
+//              offset - 200 allows elements near bottom of page to scroll
+
+				$('html, body').animate({ scrollTop: offset - 200 }, {duration: 400, queue: false, easing: 'easeOutCubic'});
+			});
 		});
 		options = options || {
 			throttle: 100
@@ -196,7 +195,7 @@
 		offset.left = options.offsetLeft || 0;
 
 		var throttledScroll = throttle(onScroll, options.throttle || 100);
-		var readyScroll = function(){
+		var readyScroll = function() {
 			$(document).ready(throttledScroll);
 		};
 
@@ -212,13 +211,13 @@
 
 		selector.on('scrollSpy:enter', function() {
 			visible = $.grep(visible, function(value) {
-	      return value.height() != 0;
-	    });
+				return value.height() != 0;
+	    	});
 
 			var $this = $(this);
 
 			if (visible[0]) {
-				$('a[href=#' + visible[0].attr('id') + ']').removeClass('active');
+				$('a[href="#' + visible[0].attr('id') + '"]').removeClass('active');
 				if ($this.data('scrollSpy:id') < visible[0].data('scrollSpy:id')) {
 					visible.unshift($(this));
 				}
@@ -231,22 +230,22 @@
 			}
 
 
-			$('a[href=#' + visible[0].attr('id') + ']').addClass('active');
+			$('a[href="#' + visible[0].attr('id') + '"]').addClass('active');
 		});
 		selector.on('scrollSpy:exit', function() {
 			visible = $.grep(visible, function(value) {
-	      return value.height() != 0;
-	    });
+				return value.height() != 0;
+			});
 
 			if (visible[0]) {
-				$('a[href=#' + visible[0].attr('id') + ']').removeClass('active');
+				$('a[href="#' + visible[0].attr('id') + '"]').removeClass('active');
 				var $this = $(this);
 				visible = $.grep(visible, function(value) {
-	        return value.attr('id') != $this.attr('id');
-	      });
-	      if (visible[0]) { // Check if empty
-					$('a[href=#' + visible[0].attr('id') + ']').addClass('active');
-	      }
+					return value.attr('id') != $this.attr('id');
+				});
+				if (visible[0]) { // Check if empty
+					$('a[href="#' + visible[0].attr('id') + '"]').addClass('active');
+				}
 			}
 		});
 


### PR DESCRIPTION
Should fix #2647. Changed all jQuery selectors from `$('a[href=#id]')` to `$('a[href="#id"]')`.