### PR TITLE
Fix to stop page jumping when modal open

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -9,8 +9,6 @@
   $.fn.extend({
     openModal: function(options) {
 
-      $('body').css('overflow', 'hidden');
-
       var defaults = {
         opacity: 0.5,
         in_duration: 350,
@@ -105,9 +103,6 @@
       $overlay = $('#' + overlayID);
 
       options = $.extend(defaults, options);
-
-      // Disable scrolling
-      $('body').css('overflow', '');
 
       $modal.find('.modal-close').off('click.close');
       $(document).off('keyup.leanModal' + overlayID);


### PR DESCRIPTION
Adding overflow hidden to body has the undesired effect of causing the
body width to change as the scrollbar is hidden. The default of the lean
modal lib is not to block scrolling on the bg so removed the code that
tries to stop bg scrolling.