### PR TITLE
fix: Widen .picker__select--year.browser-default

### DIFF
--- a/sass/components/date_picker/_default.date.scss
+++ b/sass/components/date_picker/_default.date.scss
@@ -46,7 +46,7 @@
 .picker__select--year.browser-default {
   display: inline;
   background-color: #FFFFFF;
-  width: 25%;
+  width: 26%;
 }
 .picker__select--month:focus,
 .picker__select--year:focus {


### PR DESCRIPTION
Widen .picker__select--year.browser-default to 26% from 25%. At 25%, the '6' in 2016 is cut in half. At 26%, the '6' is show in full with equal padding on both sides of '2016'