### PR TITLE
Updates to allow custom HTML in select elements

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -321,24 +321,28 @@
         // add icons
         var icon_url = option.data('icon');
         var classes = option.attr('class');
+        var placeholder = option.attr('data-placeholder');
+        var optionContent = option.data('content') || option.html();
+        var placeholderString = '';
+        if (!!placeholder) placeholderString = ' data-placeholder="' + option.data('placeholder') + '"'; 
         if (!!icon_url) {
           var classString = '';
           if (!!classes) classString = ' class="' + classes + '"';
 
           // Check for multiple type.
           if (type === 'multiple') {
-            options.append($('<li class="' + disabledClass + '"><img src="' + icon_url + '"' + classString + '><span><input type="checkbox"' + disabledClass + '/><label></label>' + option.html() + '</span></li>'));
+            options.append($('<li class="' + disabledClass + '"' + placeholderString + '><img src="' + icon_url + '"' + classString + '><span><input type="checkbox"' + disabledClass + '/><label></label>' + optionContent + '</span></li>'));
           } else {
-            options.append($('<li class="' + disabledClass + '"><img src="' + icon_url + '"' + classString + '><span>' + option.html() + '</span></li>'));
+            options.append($('<li li class="' + disabledClass + '"' + placeholderString + '><img src="' + icon_url + '"' + classString + '><span>' + optionContent + '</span></li>'));
           }
           return true;
         }
 
         // Check for multiple type.
         if (type === 'multiple') {
-          options.append($('<li class="' + disabledClass + '"><span><input type="checkbox"' + disabledClass + '/><label></label>' + option.html() + '</span></li>'));
+          options.append($('<li li class="' + disabledClass + '"' + placeholderString + '><span><input type="checkbox"' + disabledClass + '/><label></label>' + optionContent + '</span></li>'));
         } else {
-          options.append($('<li class="' + disabledClass + '"><span>' + option.html() + '</span></li>'));
+          options.append($('<li li class="' + disabledClass + '"' + placeholderString + '><span>' + optionContent + '</span></li>'));
         }
       };
 
@@ -378,7 +382,9 @@
             } else {
               options.find('li').removeClass('active');
               $(this).toggleClass('active');
-              $newSelect.val($(this).text());
+              //CHANGED: Get text for value from the data-placeholder attribute instead
+              var newValue = $(this).data('placeholder') || $(this).text();
+              $newSelect.val(newValue);
             }
 
             activateOption(options, $(this));
@@ -579,7 +585,7 @@
       var value = '';
 
       for (var i = 0, count = entriesArray.length; i < count; i++) {
-        var text = select.find('option').eq(entriesArray[i]).text();
+        var text = select.find('option').eq(entriesArray[i]).data('placeholder') || select.find('option').eq(entriesArray[i]).text();
 
         i === 0 ? value += text : value += ', ' + text;
       }


### PR DESCRIPTION
These changes allow you to pass a placeholder and HTML content through `data` attributes in each `option` tag for select elements. When used in this manner, the value of `data-placeholder` will act as the text to indicate which option is selected when the select form is closed, and you can specify your own escaped/stringified HTML in `data-content` which will act as the selectable element when the select form is open.

Putting HTML in string form inside a `data` attribute is similar to the way HTML is used in tooltips/popovers in bootstrap.

**Fully backwards compatible.**

Example usage:

```
<div class="input-field">
  <select id="primaryItem" class="icons">
    <option value="" disabled selected>Click to choose a product...</option>
    <option value="product1" data-icon="product1.png" data-placeholder="Awesome Product" data-content="<div>Awesome Product</div><span>by: Brazen Tech Mfg.</span>" class="left circle">Awesome Product</option>
    <option value="product2" data-icon="product2.png" data-placeholder="Some Other Awesome Product" data-content="<div>Some Other Awesome Product</div><span>by: Brazen Tech Mfg.</span>" class="left circle">Some Other Awesome Product</option>
  </select>
  <label>Featured Product</label>
</div>
```

Any questions let me know!
