### PR TITLE
Close chips only if icon is 'close'

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -2,7 +2,9 @@
   $(document).ready(function() {
 
     $(document).on('click.chip', '.chip .material-icons', function (e) {
-      $(this).parent().remove();
+      if (e.currentTarget.innerHTML === 'close') {
+        $(this).parent().remove();
+      }
     });
 
   });


### PR DESCRIPTION
Prevent closing a chip on icon click if icon isn't a 'close' icon.

This allow the use of icons instead of images without them removing chips on click.

See #2118