### PR TITLE
Dropdown - Stop Event Propagation Support

### DIFF
--- a/dropdown.html
+++ b/dropdown.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -175,6 +175,10 @@
             <tr>
               <td>alignment</td>
               <td>Defines the edge the menu is aligned to. Default: 'left'</td>
+            </tr>
+            <tr>
+              <td>stopPropagation</td>
+              <td>If true, stops the event propagating from the dropdown origin click handler. Default: true</td>
             </tr>
           </tbody>
         </table>

--- a/dropdown.html
+++ b/dropdown.html
@@ -178,7 +178,7 @@
             </tr>
             <tr>
               <td>stopPropagation</td>
-              <td>If true, stops the event propagating from the dropdown origin click handler. Default: true</td>
+              <td>If true, stops the event propagating from the dropdown origin click handler. Default: false</td>
             </tr>
           </tbody>
         </table>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -16,7 +16,7 @@
       gutter: 0, // Spacing from edge
       belowOrigin: false,
       alignment: 'left',
-      stopPropagation: true
+      stopPropagation: false
     };
 
     this.each(function(){
@@ -197,7 +197,7 @@
       // Click handler to show dropdown
       origin.unbind('click.' + origin.attr('id'));
       origin.bind('click.'+origin.attr('id'), function(e){
-        if (!isFocused) {
+          if (!isFocused) {
           if ( origin[0] == e.currentTarget &&
                !origin.hasClass('active') &&
                ($(e.target).closest('.dropdown-content').length === 0)) {

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,7 +15,8 @@
       hover: false,
       gutter: 0, // Spacing from edge
       belowOrigin: false,
-      alignment: 'left'
+      alignment: 'left',
+      stopPropagation: true
     };
 
     this.each(function(){
@@ -40,7 +41,9 @@
       if (origin.data('beloworigin') !== undefined)
         options.belowOrigin = origin.data('beloworigin');
       if (origin.data('alignment') !== undefined)
-        options.alignment = origin.data('alignment');
+          options.alignment = origin.data('alignment');
+      if (origin.data('stopPropagation') !== undefined)
+          options.stopPropagation = origin.data('stopPropagation');
     }
 
     updateOptions();
@@ -198,7 +201,9 @@
           if ( origin[0] == e.currentTarget &&
                !origin.hasClass('active') &&
                ($(e.target).closest('.dropdown-content').length === 0)) {
-            e.preventDefault(); // Prevents button click from moving window
+              e.preventDefault(); // Prevents button click from moving window
+              if (options.stopPropagation)
+                  e.stopPropagation();
             placeDropdown('click');
           }
           // If origin is clicked and menu is open, close menu


### PR DESCRIPTION
Added support to stop event propagation on origin element click handler.

My use for this was adding a context button (with dropdown) to an accordion header. Without this it triggers the click handler on the accordion header.
