### PR TITLE
Option to Keep Dropdown Open After Click

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,7 +15,8 @@
       hover: false,
       gutter: 0, // Spacing from edge
       belowOrigin: false,
-      alignment: 'left'
+      alignment: 'left',
+      closeOnClick: true
     };
 
     this.each(function(){
@@ -41,6 +42,8 @@
         options.belowOrigin = origin.data('beloworigin');
       if (origin.data('alignment') !== undefined)
         options.alignment = origin.data('alignment');
+      if (origin.data('closeonclick') !== undefined)
+        options.closeOnClick = origin.data('closeonclick');
     }
 
     updateOptions();
@@ -209,7 +212,7 @@
           // If menu open, add click close handler to document
           if (activates.hasClass('active')) {
             $(document).bind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'), function (e) {
-              if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
+              if (!activates.is(e.target) && !origin.is(e.target) && (!activates.find(e.target).length) && (options.closeOnClick || !origin.find(e.target).length)) {
                 hideDropdown();
                 $(document).unbind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'));
               }


### PR DESCRIPTION
Adds a closeOnClick option to the dropdown (default true). When set to true, the dropdown behaves as it currently does. When set to false, the dropdown will remain open when an element inside the dropdown is clicked. The dropdown can be closed by clicking outside of it.