### PR TITLE
Add trigger for tab click client event

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -101,6 +101,9 @@
           $indicator.velocity({"right": $tabs_width - (($index + 1) * $tab_width)}, {duration: 300, queue: false, easing: 'easeOutQuad', delay: 90});
         }
 
+        // Trigger for any post-tab change handling
+        $('ul.tabs').trigger('tab_change', $active);
+
         // Prevent the anchor's default click action
         e.preventDefault();
       });


### PR DESCRIPTION
Add a trigger for the tab click event.  This is useful in cases where elements within the tab div need redrawing or resizing after the display attribute has been changed.
