### PR TITLE
sass selector syntax fix

### DIFF
--- a/sass/components/forms/_radio-buttons.scss
+++ b/sass/components/forms/_radio-buttons.scss
@@ -74,7 +74,7 @@
   z-index: 0;
 }
 
-[type="radio"]:checked + label:after, {
+[type="radio"]:checked + label:after {
   transform: scale(1.02);
 }
 


### PR DESCRIPTION
Default IDE inspector shows error with this sass syntax.