### PR TITLE
Changed tabs and tab width calculation from methods that cause rounding.

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -11,8 +11,8 @@
 
       $this.width('100%');
       var $active, $content, $links = $this.find('li.tab a'),
-          $tabs_width = $this.width(),
-          $tab_width = $this.find('li').first().outerWidth(),
+          $tabs_width = $this[0].getBoundingClientRect().width,
+          $tab_width = $this.find('li')[0].getBoundingClientRect().width,
           $index = 0;
 
       // If the location.hash matches one of the links, use that as the active tab.
@@ -42,8 +42,8 @@
         $indicator.css({"left": $index * $tab_width});
       }
       $(window).resize(function () {
-        $tabs_width = $this.width();
-        $tab_width = $this.find('li').first().outerWidth();
+        $tabs_width = $this[0].getBoundingClientRect().width;
+        $tab_width = $this.find('li')[0].getBoundingClientRect().width;
         if ($index < 0) {
           $index = 0;
         }
@@ -66,8 +66,8 @@
           return;
         }
 
-        $tabs_width = $this.width();
-        $tab_width = $this.find('li').first().outerWidth();
+        $tabs_width = $this[0].getBoundingClientRect().width;
+        $tab_width = $this.find('li')[0].getBoundingClientRect().width;
 
         // Make the old tab inactive.
         $active.removeClass('active');

--- a/tests/spec/tabs/tabsSpec.js
+++ b/tests/spec/tabs/tabsSpec.js
@@ -62,10 +62,10 @@ describe("Tabs Plugin", function () {
       var tabsScrollWidth = 0;
       normalTabs.parent().css('width', '400px');
       normalTabs.find('.tab').each(function() {
-        tabsScrollWidth += $(this).width();
+        tabsScrollWidth += $(this)[0].getBoundingClientRect().width;
       });
 
-      expect(tabsScrollWidth).toBeGreaterThan(normalTabs.width(), 'Scroll width should exceed tabs width');
+      expect(tabsScrollWidth).toBeGreaterThan(normalTabs[0].getBoundingClientRect().width, 'Scroll width should exceed tabs width');
     });
 
   });


### PR DESCRIPTION
#2635 is being caused by the tab indicator sometimes having a `right:-1px` being set.  This happens when the width of the tabs container has a decimal.  Because the width() and outerWidth() jquery methods round the return value, `$indicator.css({"right": $tabs_width - (($index + 1) * $tab_width)})` would sometimes result in `-1`, causing a horizontal scroll bar to appear.  

Replacing those methods with getBoundingClientRect() fixes this issue, as that method will always return exact pixel values.