### PR TITLE
Fix leak from P.$root reference on date picker

### DIFF
--- a/js/date_picker/picker.js
+++ b/js/date_picker/picker.js
@@ -176,7 +176,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 if ( !STATE.start ) return P
 
                 // Then close the picker.
-                P.close()
+                P.close(false, true)
 
                 // Remove the hidden field.
                 if ( P._hidden ) {
@@ -321,7 +321,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             /**
              * Close the picker
              */
-            close: function( giveFocus ) {
+            close: function( giveFocus, isStopping ) {
 
                 // If we need to give focus, do it before changing states.
                 if ( giveFocus ) {
@@ -346,6 +346,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     // Remove the “opened” and “focused” class from the picker root.
                     P.$root.removeClass( CLASSES.opened + ' ' + CLASSES.focused )
                     aria( P.$root[0], 'hidden', true )
+                    if (isStopping) {
+                      P.$root = null;
+                    }
 
                 }, 0 )
 


### PR DESCRIPTION
During teardown, close() is called which schedules a function to hide
the date picker. Close accepts a teardown argument so that it can
nullify the reference it has to its root dom node.

Master version:
![screen shot 2016-02-19 at 16 00 24](https://cloud.githubusercontent.com/assets/729176/13190303/07cdff22-d722-11e5-9ed8-9fa58196695c.png)

Fix branch version:
![screen shot 2016-02-19 at 16 00 37](https://cloud.githubusercontent.com/assets/729176/13190314/14171be2-d722-11e5-8e1e-a7e93b581018.png)
