### PR TITLE
Implement a tooltip timer (usefull for mobile devices)

### DIFF
--- a/dialogs.html
+++ b/dialogs.html
@@ -171,14 +171,15 @@
         <pre><code class="language-markup">
   &lt;!-- data-position can be : bottom, top, left, or right -->
   &lt;!-- data-delay controls delay before tooltip shows (in milliseconds)-->
-  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-tooltip="I am tooltip">Hover me!&lt;/a>
+  &lt;!-- data-timer controls delay before tooltip disappears (in milliseconds)-->
+  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-timer="0" data-tooltip="I am tooltip">Hover me!&lt;/a>
         </code></pre>
         <br>
         <h4>Initialization</h4>
         <p>Tooltips are initialized automatically, but if you have dynamically added tooltips, you will need to initialize them.</p>
         <pre><code class="language-javascript">
   $(document).ready(function(){
-    $('.tooltipped').tooltip({delay: 50});
+    $('.tooltipped').tooltip({delay: 50, timer: 0});
   });
         </code></pre>
 

--- a/jade/page-contents/dialogs_content.html
+++ b/jade/page-contents/dialogs_content.html
@@ -61,14 +61,15 @@
         <pre><code class="language-markup">
   &lt;!-- data-position can be : bottom, top, left, or right -->
   &lt;!-- data-delay controls delay before tooltip shows (in milliseconds)-->
-  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-tooltip="I am tooltip">Hover me!&lt;/a>
+  &lt;!-- data-timer controls delay before tooltip disappears (in milliseconds)-->
+  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-timer="0" data-tooltip="I am tooltip">Hover me!&lt;/a>
         </code></pre>
         <br>
         <h4>Initialization</h4>
         <p>Tooltips are initialized automatically, but if you have dynamically added tooltips, you will need to initialize them.</p>
         <pre><code class="language-javascript">
   $(document).ready(function(){
-    $('.tooltipped').tooltip({delay: 50});
+    $('.tooltipped').tooltip({delay: 50, timer: 0});
   });
         </code></pre>
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -5,7 +5,8 @@
 
       // Defaults
       var defaults = {
-        delay: 350
+        delay: 350,
+        timer: 0
       };
 
       // Remove tooltip from the activator
@@ -42,12 +43,15 @@
       //Destroy previously binded events
       origin.off('mouseenter.tooltip mouseleave.tooltip');
       // Mouse In
-      var started = false, timeoutRef;
+      var started = false, timeoutRef, timeoutTimer;
       origin.on({
         'mouseenter.tooltip': function(e) {
           var tooltip_delay = origin.attr('data-delay');
           tooltip_delay = (tooltip_delay === undefined || tooltip_delay === '') ?
               options.delay : tooltip_delay;
+          var tooltip_timer = origin.attr('data-timer');
+          tooltip_timer = (tooltip_timer === undefined || tooltip_timer === '') ?
+              options.timer : tooltip_timer;
           timeoutRef = setTimeout(function(){
             started = true;
             newTooltip.velocity('stop');
@@ -148,6 +152,11 @@
               .velocity({opacity:1},{duration: 55, delay: 0, queue: false})
               .velocity({scale: scale_factor}, {duration: 300, delay: 0, queue: false, easing: 'easeInOutQuad'});
 
+            if (tooltip_timer !== 0) {
+              timeoutTimer = setTimeout(function() {
+                  origin.trigger('mouseleave.tooltip');
+              }, tooltip_timer);
+            }
 
           }, tooltip_delay); // End Interval
 
@@ -157,6 +166,7 @@
           // Reset State
           started = false;
           clearTimeout(timeoutRef);
+          clearTimeout(timeoutTimer);
 
           // Animate back
           setTimeout(function() {


### PR DESCRIPTION
On iPhone and iPad the tooltip didn't disappear after opening.
Therefore I've developed a fork containing a tooltip timer.
This timer is optional.