### PR TITLE
Correct jquery require

### DIFF
--- a/js/initial.js
+++ b/js/initial.js
@@ -3,7 +3,7 @@ if (typeof(jQuery) === 'undefined') {
   var jQuery;
   // Check if require is a defined function.
   if (typeof(require) === 'function') {
-    jQuery = $ = require('jQuery');
+    jQuery = $ = require('jquery');
   // Else use the dollar sign alias.
   } else {
     jQuery = $;


### PR DESCRIPTION
The jquery require should be lowercase. The way it is, it cases a warning in when [compiling with webpack](https://github.com/webpack/webpack/issues/382).