### PR TITLE
add missing variable declaration

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -79,7 +79,7 @@
       var offsetLeft = origin.offset().left;
       var offsetTop = origin.offset().top - $(window).scrollTop();
       var currAlignment = options.alignment;
-      var activatesLeft, gutterSpacing;
+      var activatesLeft, gutterSpacing, leftPosition;
 
       // Below Origin
       var verticalOffset = 0;


### PR DESCRIPTION
I was having issues with the Dropdown, but it randomly stopped working today after working about a week ago.  My guess it that I restarted my computer, and Chrome updated, and the js compiler no longer implicitly adds this variable declaration.

I wasn't sure if I was supposed to run `grunt js_compile` or anything before making a PR -- let me know if you want me to do that.