### PR TITLE
Fix issue with the dropdown on mobile

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -201,7 +201,7 @@
           // If menu open, add click close handler to document
           if (activates.hasClass('active')) {
             $(document).bind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'), function (e) {
-              if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
+              if (!activates.is(e.target) && (!activates.find(e.target).length) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
                 hideDropdown();
                 $(document).unbind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'));
               }


### PR DESCRIPTION
- In some circumstances, attempting to scroll within the dropdown on mobile
  would cause the dropdown to disappear immediately, making it impossible to use
  properly. In my particular case, I was re-styling the dropdowns inside a date picker (http://amsul.ca/pickadate.js/, because it offers a few required features that the materialize date picker doesn't) in order to use the materialize dropdowns. 