### PR TITLE
Character Counter: allow and prefer to use data-maxlength attr instead of length

### DIFF
--- a/js/character_counter.js
+++ b/js/character_counter.js
@@ -10,7 +10,7 @@
         return;
       }
 
-      var itHasLengthAttribute = $input.attr('length') !== undefined;
+      var itHasLengthAttribute = $input.attr('data-maxlength') !== undefined || $input.attr('length') !== undefined;
 
       if(itHasLengthAttribute){
         $input.on('input', updateCounter);
@@ -24,7 +24,7 @@
   };
 
   function updateCounter(){
-    var maxLength     = +$(this).attr('length'),
+    var maxLength     = $(this).attr('data-maxlength') !== undefined ? +$(this).attr('data-maxlength') : +$(this).attr('length'),
     actualLength      = +$(this).val().length,
     isValidLength     = actualLength <= maxLength;
 


### PR DESCRIPTION
The length input attribute is invalid because it doesn't exist.
http://www.w3schools.com/tags/tag_input.asp

I think data-maxlength (or data-length?) should be used (at least preferred to use).
