### PR TITLE
Fix pagination links to fill entire li tags

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -149,13 +149,16 @@ video.responsive-video {
 
   li {
     display: inline-block;
-    font-size: 1.2rem;
-    padding: 0 10px;
-    line-height: 30px;
     border-radius: 2px;
     text-align: center;
 
-    a { color: #444; }
+    a {
+      color: #444;
+      display: inline-block;
+      font-size: 1.2rem;
+      padding: 0 10px;
+      line-height: 30px;
+    }
 
     &.active a { color: #fff; }
 


### PR DESCRIPTION
The pagination links don't fill entire li tags. Although the waves effect event is fired on click, the link is not.