### PR TITLE
require 'jquery' lowercase

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -8,7 +8,7 @@ if (typeof(jQuery) === 'undefined') {
   var jQuery;
   // Check if require is a defined function.
   if (typeof(require) === 'function') {
-    jQuery = $ = require('jQuery');
+    jQuery = $ = require('jquery');
   // Else use the dollar sign alias.
   } else {
     jQuery = $;


### PR DESCRIPTION
This seems to have been fixed in the `initial.js` source but not in `dist/js/materialize.js` - jquery is required with improper casing, causing a warning when resolving the package: "There is another module with an equal name when case is ignored. This can lead to unexpected behavior when compiling on a filesystem with other case-semantic."