### PR TITLE
Fix navbar search who wasn't taking full height in all browser

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -117,6 +117,8 @@ nav {
   }
 
   // Navbar Search Form
+  form { height: 100%; }
+
   .input-field {
     margin: 0;
     height: 100%;
@@ -133,6 +135,7 @@ nav {
         box-shadow: none;
       }
     }
+
     label {
       top: 0;
       left: 0;
@@ -146,9 +149,7 @@ nav {
         transform: translateY(0);
       }
     }
-
   }
-
 }
 
 // Fixed Navbar

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -119,6 +119,7 @@ nav {
   // Navbar Search Form
   .input-field {
     margin: 0;
+    height: 100%;
 
     input {
       height: 100%;


### PR DESCRIPTION
Hello, it's a fix to the bug reported by #2971 and #2903. I tested it on IE 11 