### PR TITLE
Removing width change onModalOpen

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -10,9 +10,7 @@
     openModal: function(options) {
 
       var $body = $('body');
-      var oldWidth = $body.innerWidth();
       $body.css('overflow', 'hidden');
-      $body.width(oldWidth);
 
       var defaults = {
         opacity: 0.5,


### PR DESCRIPTION
Removing width change onModalOpen, providing a better user experience on how navbar looks like.
![sem titulo](https://cloud.githubusercontent.com/assets/16328050/14412714/f02b60fe-ff3e-11e5-9e5e-fe4f63889f1b.png)
