### PR TITLE
Fix sideNav 'initialization' bug

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -229,6 +229,8 @@
                 // menu_id.css({'translateX': 0});
                 $('#sidenav-overlay').velocity({opacity: 1 }, {duration: 50, queue: false, easing: 'easeOutQuad'});
                 dragTarget.css({width: '50%', right: 0, left: ''});
+                
+                menuOut = true;
               }
               else if (!menuOut || velocityX > 0.3) {
                 // Enable Scrolling
@@ -250,6 +252,8 @@
                 menu_id.velocity({'translateX': [0, rightPos]}, {duration: 300, queue: false, easing: 'easeOutQuad'});
                 $('#sidenav-overlay').velocity({opacity: 1 }, {duration: 50, queue: false, easing: 'easeOutQuad'});
                 dragTarget.css({width: '50%', right: '', left: 0});
+                
+                menuOut = true;
               }
               else if (!menuOut || velocityX < -0.3) {
                 // Enable Scrolling

--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -130,7 +130,9 @@
         var menuOut = false;
 
         dragTarget.on('click', function(){
-          removeMenu();
+          if(menuOut == true) {
+            removeMenu();
+          }
         });
 
         dragTarget.hammer({


### PR DESCRIPTION
Fixed the following bug:
*sideNav runs an 'initialization' event when click is made on the side of the web page. This 'event' is when the sideNav abruptly appears and disappears. This only happens on the first click

**To reproduce the bug:
1) Have a normal sideNav (take note on what edge it is set, for this case, the default edge, 'left', will do)
2) Click on the edge of the window, in this case, the leftmost part of the page.
3) You'll notice a very fast appearance and disappearance of the sideNav.

Note: this is very noticeable in mobile / small screen users

Cause(s):
a) The events for handling touch aren't setting menuOut to its proper value
b) the click event for the overlay doesn't check if there is really an overlay and/or the menuOut variable is true.