### PR TITLE
Add modal option for ending top attribute

### DIFF
--- a/js/leanModal.js
+++ b/js/leanModal.js
@@ -21,7 +21,8 @@
         ready: undefined,
         complete: undefined,
         dismissible: true,
-        starting_top: '4%'
+        starting_top: '4%',
+        ending_top: '10%'
       },
       $modal = $(this);
 
@@ -86,7 +87,7 @@
       else {
         $.Velocity.hook($modal, "scaleX", 0.7);
         $modal.css({ top: options.starting_top });
-        $modal.velocity({top: "10%", opacity: 1, scaleX: '1'}, {
+        $modal.velocity({top: options.ending_top, opacity: 1, scaleX: '1'}, {
           duration: options.in_duration,
           queue: false,
           ease: "easeOutCubic",

--- a/modals.html
+++ b/modals.html
@@ -284,6 +284,7 @@
       opacity: .5, // Opacity of modal background
       in_duration: 300, // Transition in duration
       out_duration: 200, // Transition out duration
+      ending_top: '10%', // Ending top style attribute
       ready: function() { alert('Ready'); }, // Callback for Modal open
       complete: function() { alert('Closed'); } // Callback for Modal close
     }


### PR DESCRIPTION
Additional modal options for changing the default ending top of 10% for the modal.

See request at: [Issue 3041](https://github.com/Dogfalo/materialize/issues/3041)