### PR TITLE
Make bower.json package name lower-case

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Materialize",
+  "name": "materialize",
   "description": "A modern responsive front-end framework based on Material Design",
   "keywords": [
     "css",


### PR DESCRIPTION
Please consider following the convention of using lower-case for package names in bower, npm, etc. I lost a significant amount of time today debugging a strange problem that was ultimately caused by this package using a capitalized name but being referenced in the code by a lower-case one on a  case-sensitive file system.
