### PR TITLE
Add support for HTML5 attribute maxlength for max character count on inputs and textareas

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -881,6 +881,13 @@
                 <label for="textarea1">Textarea</label>
               </div>
             </div>
+            <br/>
+            <div class="row">
+              <div class="input-field col s12">
+                <textarea id="textarea2" class="materialize-textarea" maxlength="150"></textarea>
+                <label for="textarea2">Textarea</label>
+              </div>
+            </div>
           </form>
         </div>
         <pre><code class="language-markup">
@@ -895,6 +902,12 @@
         &lt;div class="row">
           &lt;div class="input-field col s12">
             &lt;textarea id="textarea1" class="materialize-textarea" length="120">&lt;/textarea>
+            &lt;label for="textarea1">Textarea&lt;/label>
+          &lt;/div>
+        &lt;/div>
+        &lt;div class="row">
+          &lt;div class="input-field col s12">
+            &lt;textarea id="textarea1" class="materialize-textarea" maxlength="150">&lt;/textarea>
             &lt;label for="textarea1">Textarea&lt;/label>
           &lt;/div>
         &lt;/div>

--- a/forms.html
+++ b/forms.html
@@ -907,8 +907,8 @@
         &lt;/div>
         &lt;div class="row">
           &lt;div class="input-field col s12">
-            &lt;textarea id="textarea1" class="materialize-textarea" maxlength="150">&lt;/textarea>
-            &lt;label for="textarea1">Textarea&lt;/label>
+            &lt;textarea id="textarea2" class="materialize-textarea" maxlength="150">&lt;/textarea>
+            &lt;label for="textarea2">Textarea&lt;/label>
           &lt;/div>
         &lt;/div>
       &lt;/form>

--- a/js/character_counter.js
+++ b/js/character_counter.js
@@ -10,7 +10,7 @@
         return;
       }
 
-      var itHasLengthAttribute = $input.attr('length') !== undefined;
+      var itHasLengthAttribute = ($input.attr('length') || $input.attr('maxlength')) !== undefined;
 
       if(itHasLengthAttribute){
         $input.on('input', updateCounter);
@@ -24,8 +24,8 @@
   };
 
   function updateCounter(){
-    var maxLength     = +$(this).attr('length'),
-    actualLength      = +$(this).val().length,
+    var maxLength     = $(this).attr('length') || $(this).attr('maxlength'),
+    actualLength      = $(this).val().length,
     isValidLength     = actualLength <= maxLength;
 
     $(this).parent().find('span[class="character-counter"]')

--- a/js/forms.js
+++ b/js/forms.js
@@ -67,8 +67,9 @@
     });
 
     window.validate_field = function(object) {
-      var hasLength = object.attr('length') !== undefined;
-      var lenAttr = parseInt(object.attr('length'));
+      var maxLength = object.attr('length') || object.attr('maxlength');
+      var hasMaxLength = maxLength !== undefined;
+      var maxLenAttr = parseInt(maxLength);
       var len = object.val().length;
 
       if (object.val().length === 0 && object[0].validity.badInput === false) {
@@ -80,7 +81,7 @@
       else {
         if (object.hasClass('validate')) {
           // Check for character counter attributes
-          if ((object.is(':valid') && hasLength && (len <= lenAttr)) || (object.is(':valid') && !hasLength)) {
+          if ((object.is(':valid') && hasMaxLength && (len <= maxLenAttr)) || (object.is(':valid') && !hasMaxLength)) {
             object.removeClass('invalid');
             object.addClass('valid');
           }


### PR DESCRIPTION
Adds enhancement for https://github.com/Dogfalo/materialize/issues/3108.

This adds character count support for HTML5 attribute "maxlength", meaning you don't have to have the "length" attribute in order for character count to work. However, if you have both, it will choose "length" over "maxlength".

Also note that "maxlength" is a hard limit on character count so the form doesn't let you enter more characters after that length, so having both "length" and "maxlength" at the same length or "length" more than "maxlength" would be meaningless. However, "length" less than "maxlength" would validate the input still but have a hard limit of "maxlength".

I was thinking about changing "length" to something like "data-max-valid-length", but it would break backwards compatibility with people using "length"...
