### PR TITLE
Fix search .input-field height on Chrome

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -4184,12 +4184,12 @@ nav ul.left {
 }
 
 nav form {
-  height: 100%;
+  height: inherit;
 }
 
 nav .input-field {
   margin: 0;
-  height: 100%;
+  height: inherit;
 }
 
 nav .input-field input {

--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -4193,7 +4193,7 @@ nav .input-field {
 }
 
 nav .input-field input {
-  height: 100%;
+  height: inherit;
   font-size: 1.2rem;
   border: none;
   padding-left: 2rem;


### PR DESCRIPTION
I was trying to use the Search Bar inside the Navbar component and I was getting the following on Chrome Version 50.0.2661.86, it is even not showing up properly on [Materializecss.com](http://materializecss.com/navbar.html):

<img width="907" alt="screen shot 2016-05-02 at 12 17 06 am" src="https://cloud.githubusercontent.com/assets/7807555/14947098/4b10a8f4-0ffb-11e6-9fc1-6b8a671a4751.png">
