### PR TITLE
Add option in ScrollSpy to set the vertical offset

### DIFF
--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -171,6 +171,10 @@
 	 */
 	$.scrollSpy = function(selector, options) {
 		var visible = [];
+		options = options || {
+			throttle: 100,
+			scrollOffsetFix: 200 // offset - 200 allows elements near bottom of page to scroll
+		};
 		selector = $(selector);
 		selector.each(function(i, element) {
 			elements.push($(element));
@@ -179,16 +183,9 @@
 		  $('a[href="#' + $(element).attr('id') + '"]').click(function(e) {
 		    e.preventDefault();
 		    var offset = $(this.hash).offset().top + 1;
-
-//          offset - 200 allows elements near bottom of page to scroll
-			
-	    	$('html, body').animate({ scrollTop: offset - 200 }, {duration: 400, queue: false, easing: 'easeOutCubic'});
-			
+	    	$('html, body').animate({ scrollTop: offset - options.scrollOffsetFix }, {duration: 400, queue: false, easing: 'easeOutCubic'});
 		  });
 		});
-		options = options || {
-			throttle: 100
-		};
 
 		offset.top = options.offsetTop || 0;
 		offset.right = options.offsetRight || 0;


### PR DESCRIPTION
A fixed offset of 200px is set in ScrollSpy by default and it should be changed by any user according to its website design.

We can now call :

```
$('.scrollspy').scrollSpy({ scrollOffsetFix : 55 });
```

By default, `200px` will be used as hardcoded.