### PR TITLE
Changed classList to className for better compatibility

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -262,7 +262,7 @@
             if (!(target instanceof SVGElement) && target.className.indexOf('waves-effect') !== -1) {
                 element = target;
                 break;
-            } else if (target.classList.contains('waves-effect')) {
+            } else if (target.className.indexOf('waves-effect') !== -1) {
                 element = target;
                 break;
             }


### PR DESCRIPTION
`classList.contains()` has worse browser support than `className.indexOf()` and classList has only been used on this one row.

Thus the change would allow both better cross-browser compatibility, as well as a more consistent codebase.
