### PR TITLE
Fix .browser-default on <ul>

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -18,7 +18,7 @@ main {
 }
 
 ul {
-  &.browser-default {
+  &.browser-default li {
     list-style-type: initial;
   }
 


### PR DESCRIPTION
The `.browser-default` class on `ul` didn't work as the list-style-type was being removed on the more specific `ul li` level on line#51

Fixes #2582