### PR TITLE
Amend bower.json to match bower spec

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Materialize",
+  "name": "materialize",
   "description": "A modern responsive front-end framework based on Material Design",
   "keywords": [
     "css",
@@ -15,22 +15,7 @@
   ],
   "main": [
     "bin/materialize.css",
-    "bin/materialize.js",
-    "fonts/roboto/Roboto-Bold.ttf",
-    "fonts/roboto/Roboto-Bold.woff",
-    "fonts/roboto/Roboto-Bold.woff2",
-    "fonts/roboto/Roboto-Light.ttf",
-    "fonts/roboto/Roboto-Light.woff",
-    "fonts/roboto/Roboto-Light.woff2",
-    "fonts/roboto/Roboto-Medium.ttf",
-    "fonts/roboto/Roboto-Medium.woff",
-    "fonts/roboto/Roboto-Medium.woff2",
-    "fonts/roboto/Roboto-Regular.ttf",
-    "fonts/roboto/Roboto-Regular.woff",
-    "fonts/roboto/Roboto-Regular.woff2",
-    "fonts/roboto/Roboto-Thin.ttf",
-    "fonts/roboto/Roboto-Thin.woff",
-    "fonts/roboto/Roboto-Thin.woff2"
+    "bin/materialize.js" 
   ],
   "ignore": [
     "jade/",


### PR DESCRIPTION
**Fixes bower warnings**
- Make the name lowercase
- Remove font files from the main field as they are referenced in the main CSS file  
From the [spec](https://github.com/bower/spec/blob/master/json.md): 

> Image and font files may be used or referenced within the JS or Sass files, but are not main files as they are not entry-points.

Resolves #3195, #3012, #2389