### PR TITLE
Add icons-material-design to package.js (meteor) 

### DIFF
--- a/package.js
+++ b/package.js
@@ -60,6 +60,7 @@ Package.onUse(function (api) {
     'sass/components/_dropdown.scss',
     'sass/components/_global.scss',
     'sass/components/_grid.scss',
+    'sass/components/_icons-material-design.scss',
     'sass/components/_materialbox.scss',
     'sass/components/_mixins.scss',
     'sass/components/_modal.scss',


### PR DESCRIPTION
5afb6000 was said to add support to sass for meteor, which is a great thing but it throw an error immediatly when the materialize.scss was loaded on client because package.js wasn't loading icons-material-design so this fix add it.