### PR TITLE
Always prevent the default behaviour on clickable dropdowns

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -215,10 +215,10 @@
         origin.unbind('click.' + origin.attr('id'));
         origin.bind('click.'+origin.attr('id'), function(e){
           if (!isFocused) {
+            e.preventDefault(); // Prevents button click from moving window
             if ( origin[0] == e.currentTarget &&
                  !origin.hasClass('active') &&
                  ($(e.target).closest('.dropdown-content').length === 0)) {
-              e.preventDefault(); // Prevents button click from moving window
               if (options.stopPropagation) {
                 e.stopPropagation();
               }


### PR DESCRIPTION
Currently preventDefault() is only called when opening the dropdown menu. But unfortunately this is not of much use, because the default (aka visiting the link) _is_ executed, when the dropdown menu is closed again, resulting in an ugly extra history state.

This pull requests always prevents the default behaviour, when using a clickable dropdown menu.
