### PR TITLE
BUG : Added missing quote to the slider image

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -96,7 +96,7 @@
         $slides.find('img').each(function () {
           var placeholderBase64 = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
           if ($(this).attr('src') !== placeholderBase64) {
-            $(this).css('background-image', 'url(' + $(this).attr('src') + ')' );
+            $(this).css('background-image', 'url(\'' + $(this).attr('src') + '\')' );
             $(this).attr('src', placeholderBase64);
           }
         });


### PR DESCRIPTION
Without quotes in the background-image property, images with parentheses in the url are not displayed.
The style is not valid .
