### PR TITLE
Fix text label and error label overlap

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -5840,7 +5840,7 @@ textarea.materialize-textarea + label:after {
   display: block;
   content: "";
   position: absolute;
-  top: 65px;
+  top: 54px;
   opacity: 0;
   transition: .2s opacity ease-out, .2s color ease-out;
 }
@@ -5870,8 +5870,8 @@ textarea.materialize-textarea + label:after {
 
 .input-field label.active {
   font-size: 0.8rem;
-  -webkit-transform: translateY(-140%);
-          transform: translateY(-140%);
+  -webkit-transform: translateY(-120%);
+          transform: translateY(-120%);
 }
 
 .input-field .prefix {


### PR DESCRIPTION
Fix text label and error label overlap when two textfields are in same row and vertically stacked.

Fixed issue #3286 without shifting data-error to right.

Earlier when we have same row and two data fields are coming vertically as shown in issue #3286.

Before fixing
![image](https://cloud.githubusercontent.com/assets/12707743/16226469/3758a21c-37c9-11e6-8864-1373b0bd9a53.png)

After fixing
![image](https://cloud.githubusercontent.com/assets/12707743/16226477/3ed1cbc2-37c9-11e6-8a31-d34ecacb11e4.png)
