### PR TITLE
add hover effect to button backgrounds

### DIFF
--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -408,7 +408,7 @@ $colors: (
   .#{$color}-btn {
       background-color: $color_value !important;
       &:hover {
-          background-color: lighten($color_value, 12%)!important;
+          background-color: lighten($color_value, 5%)!important;
       }
   }
 }

--- a/sass/components/_color.scss
+++ b/sass/components/_color.scss
@@ -373,6 +373,12 @@ $colors: (
       .#{$color_name}-text {
         color: $color_value !important;
       }
+      .#{$color_name}-btn {
+        background-color: $color_value !important;
+        &:hover {
+          background-color: lighten($color_value, 5%)!important;
+        }
+      }
     }
     @else if $color_name != "shades" {
       .#{$color_name}.#{$color_type} {
@@ -380,6 +386,12 @@ $colors: (
       }
       .#{$color_name}-text.text-#{$color_type} {
         color: $color_value !important;
+      }
+      .#{$color_name}-btn.btn-#{$color_type} {
+        background-color: $color_value !important;
+        &:hover {
+          background-color: lighten($color_value, 5%)!important;
+        }
       }
     }
   }
@@ -392,6 +404,12 @@ $colors: (
   }
   .#{$color}-text {
     color: $color_value !important;
+  }
+  .#{$color}-btn {
+      background-color: $color_value !important;
+      &:hover {
+          background-color: lighten($color_value, 12%)!important;
+      }
   }
 }
 


### PR DESCRIPTION
added a 'color'-btn class to the colors file so that you can change the background of buttons whilst maintaining the hover effect of lightening the background 5%.

Example usage - http://jotmagic-pl.azurewebsites.net/Basics/Buttons
(Note I use 12% lighten here)
