### PR TITLE
fix markup mistake for optgroups in forms.html

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -482,7 +482,7 @@
   &lt;/div>
 
   &lt;div class="input-field col s12">
-    &lt;select multiple>
+    &lt;select>
       &lt;optgroup label="team 1">
         &lt;option value="1">Option 1&lt;/option>
         &lt;option value="2">Option 2&lt;/option>

--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -370,7 +370,7 @@
   &lt;/div>
 
   &lt;div class="input-field col s12">
-    &lt;select multiple>
+    &lt;select>
       &lt;optgroup label="team 1">
         &lt;option value="1">Option 1&lt;/option>
         &lt;option value="2">Option 2&lt;/option>


### PR DESCRIPTION
The Documentation for Forms shows a single select Optgroup Form (See Line 413 in forms.html) but the markup presented later uses `<select multiple>` thus not matching the example shown.