### PR TITLE
fix jade forms_content.html optgroup markup

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -370,7 +370,7 @@
   &lt;/div>
 
   &lt;div class="input-field col s12">
-    &lt;select multiple>
+    &lt;select>
       &lt;optgroup label="team 1">
         &lt;option value="1">Option 1&lt;/option>
         &lt;option value="2">Option 2&lt;/option>


### PR DESCRIPTION
Previous pull request changed the wrong file - sorry for that - here we go again with the jade file.

The Documentation for Forms shows a single select Optgroup Form but the markup presented later uses <select multiple> thus not matching the example shown.
