### PR TITLE
Adds support for external links in tab module

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -1173,6 +1173,12 @@ $(document).ready(function(){
 
       // Bind the click event handler
       $this.on('click', 'a', function(e){
+
+      	// Continue with the default action if the anchor is an external link
+        if ($(this).attr('target')) {
+          return;
+        }
+
         if ($(this).parent().hasClass('disabled')) {
           e.preventDefault();
           return;
@@ -1838,7 +1844,7 @@ $(document).ready(function(){
         }
         else {
           // Insert as text;
-          toast.innerHTML = html; 
+          toast.innerHTML = html;
         }
         // Bind hammer
         var hammerHandler = new Hammer(toast, {prevent_default: false});
@@ -2147,7 +2153,7 @@ $(document).ready(function(){
               $('body').css('overflow', 'hidden');
               // Push current drag target on top of DOM tree
               $('body').append(dragTarget);
-              
+
               if (options.edge === 'left') {
                 dragTarget.css({width: '50%', right: 0, left: ''});
                 menu_id.velocity({left: 0}, {duration: 300, queue: false, easing: 'easeOutQuad'});
@@ -2388,9 +2394,9 @@ $(document).ready(function(){
 		    var offset = $(this.hash).offset().top + 1;
 
 //          offset - 200 allows elements near bottom of page to scroll
-			
+
 	    	$('html, body').animate({ scrollTop: offset - 200 }, {duration: 400, queue: false, easing: 'easeOutCubic'});
-			
+
 		  });
 		});
 		options = options || {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -62,6 +62,12 @@
 
       // Bind the click event handler
       $this.on('click', 'a', function(e) {
+
+        // Continue with the default action if the anchor is an external link
+        if ($(this).attr('target')) {
+          return;
+        }
+
         if ($(this).parent().hasClass('disabled')) {
           e.preventDefault();
           return;


### PR DESCRIPTION
That should've been submitted already, but unfortunately it's not in current version of the lib.

Whenever a link among the tabs has either `target="_blank"` or `target="_self"` this should bypass the tabs behavior and take the user to the `href` location.

PS: Apologize for the strage `git diff` but **Atom** is doing things because of... well... reasons.
