### PR TITLE
Add documentation for <small>, <strong>, <em>, .light and .thin

### DIFF
--- a/jade/page-contents/typography_content.html
+++ b/jade/page-contents/typography_content.html
@@ -23,7 +23,6 @@
         </code></pre>
       </div>
 
-
         <div id="headers" class="section scrollspy">
           <h2 class="header">Headers</h2>
           <p>We provide some basic styling on header tags. In the example, you can see the the 6 header tags' different sizes.</p>
@@ -34,6 +33,68 @@
             <h4>Heading h4</h4>
             <h5>Heading h5</h5>
             <h6>Heading h6</h6>
+          </div>
+        </div>
+
+        <div id="formatting" class="section scrollspy">
+          <h2 class="header">Formatting</h2>
+          <p>
+            Materialize comes with a few useful additional helper classes to format <small>small</small>, <strong>bold</strong>,
+            <em>emphasized</em>, <span class="light">light</span> and <span class="thin">thin</span> text blocks, which of course
+            can also be combined with headings and any other tags.
+          </p>
+          <div class="card-panel">
+            <h3>
+              <strong>Bold</strong> heading with a
+              <small>small part</small>
+              and <em>emphasis</em>
+            </h3>
+          </div>
+          <div class="row">
+            <div class="col s12 l6">
+              <small>Small text</small>
+              <pre><code class="language-markup">
+  &lt;small>
+    text-size is 0.75%.
+  &lt;/small>
+              </code></pre>
+            </div>
+            <div class="col s12 l6">
+              <strong>Bold text</strong>
+              <pre><code class="language-markup">
+  &lt;strong>
+    This is bold!
+  &lt;/strong>
+              </code></pre>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col s12 l6">
+              <em>Emphasized text</em>
+              <pre><code class="language-markup">
+  &lt;em>
+    With emphasis.
+  &lt;/em>
+              </code></pre>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col s12 l6">
+              <span class="light">Light text</span>
+              <pre><code class="language-markup">
+  &lt;span class="light">
+    Reduced font-weight.
+  &lt;/span>
+              </code></pre>
+            </div>
+            <div class="col s12 l6">
+              <span class="thin">Very very thin text</span>
+              <pre><code class="language-markup">
+  &lt;span class="thin">
+    Even less font-weight.
+  &lt;/span>
+              </code></pre>
+            </div>
           </div>
         </div>
 
@@ -85,6 +146,7 @@
           <ul class="section table-of-contents">
             <li><a href="#roboto">Roboto</a></li>
             <li><a href="#headers">Headers</a></li>
+            <li><a href="#formatting">Formatting</a></li>
             <li><a href="#blockquote">Blockquotes</a></li>
             <li><a href="#flow">Flow Text</a></li>
           </ul>


### PR DESCRIPTION
This adds an additional section in Typgraphy named _Formatting_ that highlights the use and how common formatting helpers render, these include:

- `<small>`
- `<strong>`
- `<em>`
- `.light`
- `.thin`

<img width="1090" alt="screenshot 2016-07-08 11 25 17" src="https://cloud.githubusercontent.com/assets/83660/16683373/cdd572e0-44ff-11e6-86e0-8af2397e480c.png">
