### PR TITLE
Update _input-fields.scss to fix problem with input labels when using sass version

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -150,6 +150,7 @@ textarea.materialize-textarea {
   label.active {
     font-size: $label-font-size;
     transform: translateY(-140%);
+    -webkit-transform: translateY(-140%);
   }
 
   // Prefix Icons


### PR DESCRIPTION
"-webkit-transform" is included in distributed (minified) css for labels of input fields. But it gets lost when compiling from scss. The animation of the label will work no longer when using the sass version. Add "-webkit-transform: translateY(-140%);"to "label.active" in _input-field.scss to solve this problem!

Or you could think of something like http://bourbon.io/ for any transition/transform (I found some more, in _navbar.scsc for example).