### PR TITLE
fixed sidenav icon alignment

### DIFF
--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -47,6 +47,11 @@
     height: $sidenav-item-height;
     line-height: $sidenav-item-height;
     padding: 0 ($sidenav-padding * 2);
+    vertical-align: middle;
+
+    * {
+      vertical-align: middle;
+    }
 
     &:hover { background-color: rgba(0,0,0,.05);}
 


### PR DESCRIPTION
I added a little fix to vertically center icons, if you choose to use them in the sidenav:

![screen-shot-2016-07-18-at-17 07 06](https://cloud.githubusercontent.com/assets/520915/16919651/e30159aa-4d0a-11e6-88a7-991e220e367b.jpg)
