### PR TITLE
Correction autocomplete documentation

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -940,7 +940,7 @@
       &lt;div class="row">
         &lt;div class="input-field col s12">
           &lt;i class="material-icons prefix">textsms&lt;/i>
-          &lt;input type="text" id="autocomplete">
+          &lt;input type="text" class="autocomplete">
           &lt;label for="autocomplete">Autocomplete&lt;/label>
         &lt;/div>
       &lt;/div>


### PR DESCRIPTION
In autocomplete documentation we have an id attribute that actually should be class attribute. This confuses beginners.