### PR TITLE
Support srcset and sizes attributes for materialbox.js

### DIFF
--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -121,6 +121,12 @@
           newHeight = windowHeight * 0.9;
         }
 
+        // Update responsive image sizes if present
+        if(origin[0].hasAttribute('sizes')) {
+          origin.data('sizes', origin.attr('sizes'));
+          origin.attr('sizes', Math.round(newWidth) + 'px');
+        }
+
         // Animate image + set z-index
         if(origin.hasClass('responsive-img')) {
           origin.velocity({'max-width': newWidth, 'width': originalWidth}, {duration: 0, queue: false,
@@ -250,6 +256,11 @@
               origin.removeClass('active');
               doneAnimating = true;
               $(this).remove();
+
+              // Reset sizes property
+              if (origin.data('sizes')) {
+                origin.attr('sizes', origin.data('sizes'));
+              }
 
               // Remove overflow overrides on ancestors
               if (ancestorsChanged) {


### PR DESCRIPTION
Responsive images with the `srcset` and `sizes` property set allow the browser to dynamically download a larger source file as needed when the browser or image size changes. 

This pull request adds support for images that use these properties:

``` html
<img 
    class="materialboxed" 
    width="650" 
    src="sample.jpg" 
    srcset="sample-thumbnail.jpg 200w, sample-large.jpg 800w" 
    sizes="(max-width: 200px) 100vw, 200px" />
```

When the image is expanded, materialbox.js will now update the `sizes` attribute (if present) to match the larger size that the image is about to be displayed at. 

It will also reset the `sizes` attribute to its original value when `returnToOriginal()` is called.  

For sites that use these properties along with materialboxed, this pull request enables the thumbnails to be displayed with small source files, and the browser will download the appropriate larger file when the image is expanded. 
#2452
