### PR TITLE
Added scrollspy initialization example for single page site page nav

### DIFF
--- a/scrollspy.html
+++ b/scrollspy.html
@@ -156,6 +156,19 @@
     $('.scrollspy').scrollSpy();
   });
         </code></pre>
+
+        <pre><code class="language-javascript">
+  // Alternate initialization for fixed navbar navigation on single page sites  
+  $(document).ready(function(){
+    $('.scrollspy').scrollSpy();
+    $('.scrollspy').on('scrollSpy:enter', function() {
+      $('.navbar-fixed').find('a[href="#'+$(this).attr('id')+'"]').parent().addClass('active'); //add active class to the li of the nav link  
+    });
+    $('.scrollspy').on('scrollSpy:exit', function() {
+      $('.navbar-fixed').find('a[href="#'+$(this).attr('id')+'"]').parent().removeClass('active'); //remove active class to the li of the nav link  
+    });        
+  });
+        </code></pre>
       </div>
 
 


### PR DESCRIPTION
**Documentation Update for Scrollspy**
When creating a single page site using materializecss, I noticed that the scrollspy implementation worked differently than expected.

Scrolling into the section, I expected the corresponding <li> of the navbar button to be set to `class="active"`

However, it appeared that only the navbar button's child <a> was set to `class="active"`

The example code I added to scrollspy.html fixes this issue, and it will be useful for anyone else developing single page sites with materialize.css