### PR TITLE
Fix input labeling on FF/Fedora

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -142,6 +142,7 @@ textarea.materialize-textarea {
     color: $input-border-color;
     position: absolute;
     top: 0.8rem;
+    left: 0rem;
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;


### PR DESCRIPTION
Per these codepens: http://codepen.io/anon/pen/KrALvb vs http://codepen.io/anon/pen/dXQEkO, on FF48 and Fedora 23, labels are misaligned with their input boxes. 

![2016-08-09-140851_365x242_scrot](https://cloud.githubusercontent.com/assets/914030/17529968/0e25ed80-5e3b-11e6-8fc6-f8c3f804b5ed.png)

This was also cross tested on a live Ubuntu 16.04 image with FF45:

![2016-08-09-141253_565x371_scrot](https://cloud.githubusercontent.com/assets/914030/17530081/a0646276-5e3b-11e6-961d-42be619da4a9.png)

Thanks,

Alex
