### PR TITLE
Accessibility of select lists with images #3492

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -413,9 +413,9 @@
 
           // Check for multiple type.
           if (type === 'multiple') {
-            options.append($('<li class="' + disabledClass + '"><img src="' + icon_url + '"' + classString + '><span><input type="checkbox"' + disabledClass + '/><label></label>' + option.html() + '</span></li>'));
+            options.append($('<li class="' + disabledClass + '"><img alt="" src="' + icon_url + '"' + classString + '><span><input type="checkbox"' + disabledClass + '/><label></label>' + option.html() + '</span></li>'));
           } else {
-            options.append($('<li class="' + disabledClass + optgroupClass + '"><img src="' + icon_url + '"' + classString + '><span>' + option.html() + '</span></li>'));
+            options.append($('<li class="' + disabledClass + optgroupClass + '"><img alt="" src="' + icon_url + '"' + classString + '><span>' + option.html() + '</span></li>'));
           }
           return true;
         }


### PR DESCRIPTION
This PR adds null alt="" attributes to icons that appear within the fancy select lists that have images in them. This helps improve accessibility of these items because these images are purely for decoration and setting a null alt attribute tells screen readers to ignore them.