### PR TITLE
Input field's label made not interactive.

### DIFF
--- a/sass/components/_mixins.scss
+++ b/sass/components/_mixins.scss
@@ -3,3 +3,16 @@
 //     -moz-box-shadow: $args1, $args2;
 //     box-shadow: $args1, $args2;
 // }
+
+@mixin not-selectable {
+	-webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+@mixin not-clickable {
+	pointer-events: none;
+}

--- a/sass/components/_mixins.scss
+++ b/sass/components/_mixins.scss
@@ -4,15 +4,10 @@
 //     box-shadow: $args1, $args2;
 // }
 
-@mixin not-selectable {
-	-webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+@mixin no-select {
     user-select: none;
 }
 
-@mixin not-clickable {
-	pointer-events: none;
+@mixin no-click {
+    pointer-events: none;
 }

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -145,8 +145,8 @@ textarea.materialize-textarea {
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;
-    @include not-selectable;
-    @include not-clickable;
+    @include no-select;
+    @include no-click;
   }
 
   label.active {

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -145,6 +145,8 @@ textarea.materialize-textarea {
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;
+    @include not-selectable;
+		@include not-clickable;
   }
 
   label.active {

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -146,7 +146,7 @@ textarea.materialize-textarea {
     cursor: text;
     transition: .2s ease-out;
     @include not-selectable;
-		@include not-clickable;
+    @include not-clickable;
   }
 
   label.active {


### PR DESCRIPTION
This PR contains a fix for input field's label. A label could be improved to be not interactive. Having label responsive to selection and mouse events introduces UX issues in Angular 2 apps using materializecss project for styling. 
