### PR TITLE
Fix jQuery version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "Gruntfile.js"
   ],
   "dependencies": {
-    "jquery": ">=2.1.1"
+    "jquery": "~2.1.1"
   },
   "devDependencies": {
   }


### PR DESCRIPTION
Fixed jQuery version in bower.json to download the latest compatible jQuery 2 depenency instead of the incompatible jQuery 3

issue #3524 
