### PR TITLE
Update initial.js

### DIFF
--- a/js/initial.js
+++ b/js/initial.js
@@ -1,11 +1,11 @@
 // Check for jQuery.
 if (typeof(jQuery) === 'undefined') {
-  var jQuery;
+  //var jQuery;
   // Check if require is a defined function.
   if (typeof(require) === 'function') {
-    jQuery = $ = require('jquery');
+    window.jQuery = window.$ = require('jquery');
   // Else use the dollar sign alias.
   } else {
-    jQuery = $;
+    window.jQuery = $;
   }
 }


### PR DESCRIPTION
Fix for the error `TypeError: $*.velocity is not a function` that occurs when using webpack to require('materialize-css')
