### PR TITLE
Fixing parallax with jQuery 3

### DIFF
--- a/js/parallax.js
+++ b/js/parallax.js
@@ -39,7 +39,7 @@
         $this.children("img").one("load", function() {
           updateParallax(true);
         }).each(function() {
-          if(this.complete) $(this).load();
+          if(this.complete) $(this).trigger("load");
         });
 
         $(window).scroll(function() {


### PR DESCRIPTION
With jQuery 3.0, `.load()` no longer works (https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed). This breaks the current parallax implementation. 

This fixes that.