### PR TITLE
Autocomplete support for angularjs ng-model

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -350,6 +350,7 @@
           // Set input value
           $autocomplete.on('click', 'li', function () {
             $input.val($(this).text().trim());
+            $input.trigger('change');
             $autocomplete.empty();
           });
         }


### PR DESCRIPTION
When using ng-model on autocomplete fields the value captured is the typed one, not the selected on the list. This change tells angular that the value has changed.

Furthermore, this change improves autocomplete since it mocks browser's behavior of broadcast any change on input fields.