### PR TITLE
Add support to disable appending images with auto complete

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -281,7 +281,8 @@
     $.fn.autocomplete = function (options) {
       // Defaults
       var defaults = {
-        data: {}
+        data: {},
+        append_image: true
       };
 
       options = $.extend(defaults, options);
@@ -334,7 +335,7 @@
                     key.toLowerCase().indexOf(val) !== -1 &&
                     key.toLowerCase() !== val) {
                   var autocompleteOption = $('<li></li>');
-                  if(!!data[key]) {
+                  if(!!data[key] && options.append_image) {
                     autocompleteOption.append('<img src="'+ data[key] +'" class="right circle"><span>'+ key +'</span>');
                   } else {
                     autocompleteOption.append('<span>'+ key +'</span>');


### PR DESCRIPTION
Adds  default option that would let us disable appending images to autocomplete li. By default, it would work as it working previously.

If you want to disable adding images to autocomplete, just do 

```
$('input.autocomplete').autocomplete({
    data: {
      "Apple": null,
      "Microsoft": null,
      "Google": 'http://placehold.it/250x250'
    },
   append_image: false
  });
```

**Before**
<img width="724" alt="screen shot 2016-08-29 at 3 48 23 pm" src="https://cloud.githubusercontent.com/assets/6991154/18049374/4d7d4958-6e01-11e6-84db-f3c0a6204780.png">

**After**
<img width="718" alt="screen shot 2016-08-29 at 3 48 59 pm" src="https://cloud.githubusercontent.com/assets/6991154/18049379/54935d2c-6e01-11e6-86ef-a1439b8ba818.png">

Described in [issue#3583](https://github.com/Dogfalo/materialize/issues/3583)
