### PR TITLE
Add a data attribute to the autocomplete input field so that the valu…

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -281,7 +281,8 @@
     $.fn.autocomplete = function (options) {
       // Defaults
       var defaults = {
-        data: {}
+        data: {},
+        data_attr : ''
       };
 
       options = $.extend(defaults, options);
@@ -349,7 +350,14 @@
 
           // Set input value
           $autocomplete.on('click', 'li', function () {
-            $input.val($(this).text().trim());
+            var val = $(this).text().trim();
+            $input.val(value);
+
+            // set data attribute value
+            if(options.data_attr){
+                $input.attr(options.data_attr, data[value]);
+            }
+
             $input.trigger('change');
             $autocomplete.empty();
           });


### PR DESCRIPTION
Add a data attribute to the autocomplete input field so that the value so that the value can be used when we pass data list to autocomplete plugin.

E.g :

```
$('input.autocomplete').autocomplete({
    data: {
      "Apple": 1,
      "Microsoft": 2,
      "Google": 3
    },
    data_attr : 'data-id'
  });
```

**Before**

```
<input type="text" id="autocomplete-input" class="autocomplete">
```

**After**

```
<input type="text" id="autocomplete-input" class="autocomplete" data-id="1">
```

Addresses [Issue#3586](https://github.com/Dogfalo/materialize/issues/3586)
