### PR TITLE
Remove hard-coded vertical align.

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -40,8 +40,11 @@ select {
     color: initial;
     position: absolute;
     right: 0;
-    top: 16px;
+    top: 0;
+    bottom: 0;
+    margin: auto 0;
     font-size: 10px;
+    height: 10px;
     &.disabled {
       color: $input-disabled-color;
     }


### PR DESCRIPTION
Remove hard-coded 'top' value for vertical aligning Select's dropdown arrow. This adapts to any height of parent element.