### PR TITLE
Fix lorempixel image not showing

### DIFF
--- a/jade/page-contents/cards_content.html
+++ b/jade/page-contents/cards_content.html
@@ -103,7 +103,7 @@
             <h2 class="header">Horizontal Card</h2>
             <div class="card horizontal">
               <div class="card-image">
-                <img src="http://lorempixel.com/100/190/nature/10">
+                <img src="http://lorempixel.com/100/190/nature/9">
               </div>
               <div class="card-stacked">
                 <div class="card-content">
@@ -128,7 +128,7 @@
     &lt;h2 class="header">Horizontal Card&lt;/h2>
     &lt;div class="card horizontal">
       &lt;div class="card-image">
-        &lt;img src="http://lorempixel.com/100/190/nature/10">
+        &lt;img src="http://lorempixel.com/100/190/nature/9">
       &lt;/div>
       &lt;div class="card-stacked">
         &lt;div class="card-content">


### PR DESCRIPTION
Currently on Chrome Version 52.0.2743.116 m (64-bit), the URL `http://lorempixel.com/100/190/nature/10` returns no content and the `Content-Length` header is `0`.

I am not sure if the image on the new URL provides the desired result but it works.