### PR TITLE
MaterialBox overlay transparency

### DIFF
--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -87,11 +87,11 @@
           .click(function(){
             if (doneAnimating === true)
             returnToOriginal();
-          });
+          });o
           // Animate Overlay
           // Put before in origin image to preserve z-index layering.
           origin.before(overlay);
-          overlay.velocity({opacity: 1},
+          overlay.velocity({opacity: 0.8},
                            {duration: inDuration, queue: false, easing: 'easeOutQuad'} );
 
         // Add and animate caption if it exists


### PR DESCRIPTION
It might look nicer if the MaterialBox overlay is transparent. I set the overlay's transparency to 0.8, which looks nice but still lets the user focus on the image.
Realized you're not supposed to edit src files so this looks like the last commit.