### PR TITLE
Autocomplete improvement - replacing data, arrow keys usage, etc

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -967,14 +967,20 @@
         </code></pre>
 
         <h4>Initialization</h4>
-        <p>The data is a json object where the key is the matching string and the value is an optional image url.</p>
+        <p>The data is a JavaScript object where the key is the matching string and the value is an optional image url.</p>
+        <p>There is also one additional option <code class="language-markup">maxElementsAmount</code>. You can set here, how many elements will display in an auto complete list. If you skip this option you will see all available and matching options.</p>
+        <p>If you want to update data after initialization - for instance for AJAX request - just run initialization on particular element one more time. It will override current data.</p>
         <pre><code class="language-javascript">
-  $('input.autocomplete').autocomplete({
+  $('input.autocomplete').autocomplete(
     data: {
       "Apple": null,
       "Microsoft": null,
+      "Micro Center": null,
+      "Micro Mobility": null,
+      "Micro Systems": null,
       "Google": 'http://placehold.it/250x250'
-    }
+    },
+    maxElementsAmount: 3 // optional
   });
         </code></pre>
       </div>

--- a/js/forms.js
+++ b/js/forms.js
@@ -279,85 +279,161 @@
      * Auto complete plugin  *
      *************************/
     $.fn.autocomplete = function (options) {
-      // Defaults
       var defaults = {
-        data: {}
-      };
+        data: {},
+        maxElementsAmount: null
+      },
+      currentLi = 0,
+      autocompleteOption = null,
+      currentAutocompleteVal = '';
 
       options = $.extend(defaults, options);
 
-      return this.each(function() {
-        var $input = $(this);
-        var data = options.data,
-            $inputDiv = $input.closest('.input-field'); // Div to append on
+      // Set input value
+      function setIputValue(ulElement, inputElement) {
+        ulElement.on('click', 'li', function () {
+          inputElement.val($(this).text().trim());
+          ulElement.empty();
+        });
+      }
 
-        // Check if data isn't empty
-        if (!$.isEmptyObject(data)) {
-          // Create autocomplete element
+      // highlight elements
+      function highlight(string, $el) {
+        var img = $el.find('img');
+        var matchStart = $el.text().toLowerCase().indexOf("" + string.toLowerCase() + ""),
+        matchEnd = matchStart + string.length - 1,
+        beforeMatch = $el.text().slice(0, matchStart),
+        matchText = $el.text().slice(matchStart, matchEnd + 1),
+        afterMatch = $el.text().slice(matchEnd + 1);
+        $el.html("<span>" + beforeMatch + "<span class='highlight'>" + matchText + "</span>" + afterMatch + "</span>");
+        if (img.length) {
+          $el.prepend(img);
+        }
+      }
+
+      // function on keyUp
+      function keyUp(e, data, $input, $autocomplete) {
+        var val = $input.val().toLowerCase();
+
+        // Capture Enter
+        if (e.which === 13) {
+          $autocomplete.find('li')[currentLi].click();
+          return;
+        }
+
+        // hide list on ESC button
+        if (e.which === 27) {
+          $input.blur();
+        }
+
+        // Check if the input isn't empty and it's not equal to old option
+        if (val !== '' && currentAutocompleteVal !== val) {
+          var maxElementsAmount = options.maxElementsAmount;
+          $autocomplete.empty();
+
+          for (var key in data) {
+            if (maxElementsAmount === 0) {
+              break;
+            }
+
+            if (data.hasOwnProperty(key) &&
+            key.toLowerCase().indexOf(val) !== -1 &&
+            key.toLowerCase() !== val) {
+              if (maxElementsAmount !== null) {
+                maxElementsAmount--;
+              }
+
+              autocompleteOption = $('<li></li>');
+              if (!!data[key]) {
+                autocompleteOption.append('<img src="' + data[key] + '" class="right circle"><span>' + key + '</span>');
+              } else {
+                autocompleteOption.append('<span>' + key + '</span>');
+              }
+              $autocomplete.append(autocompleteOption);
+
+              highlight(val, autocompleteOption);
+
+            }
+          }
+
+          currentAutocompleteVal = val;
+          autocompleteOption = $autocomplete.find('li');
+          currentLi = 0;
+          $(autocompleteOption[currentLi]).addClass('active');
+        }
+      }
+
+      // arrow usage - on key down
+      function arrowUsage(e, $autocomplete) {
+        // Capture up and down key
+        if (
+        e.which === 38
+        || e.which === 40
+        ) {
+          e.preventDefault();
+
+          if (currentLi > 0 && e.which === 38) {
+            currentLi--;
+          }
+
+          if (currentLi < (autocompleteOption.length - 1) && e.which === 40) {
+            currentLi++;
+          }
+
+          $autocomplete.find('.active').removeClass('active');
+          $(autocompleteOption[currentLi]).addClass('active');
+        }
+      }
+
+      // reset current element position
+      function resetCurrentElement($autocomplete) {
+        currentLi = 0;
+        $autocomplete.find('.active').removeClass('active');
+        $(autocompleteOption[currentLi]).addClass('active');
+      }
+
+
+      // initialization for each element
+      return this.each(function () {
+        var $input = $(this),
+        data = options.data,
+        $inputDiv = $input.closest('.input-field');
+
+        // Check if data isn't empty and append autocomplete element if doesn't exist yet - run only once
+        if
+        (!$.isEmptyObject(data)
+        && $inputDiv.find('.autocomplete-content').length === 0) {
           var $autocomplete = $('<ul class="autocomplete-content dropdown-content"></ul>');
 
-          // Append autocomplete element
           if ($inputDiv.length) {
             $inputDiv.append($autocomplete); // Set ul in body
           } else {
             $input.after($autocomplete);
           }
 
-          var highlight = function(string, $el) {
-            var img = $el.find('img');
-            var matchStart = $el.text().toLowerCase().indexOf("" + string.toLowerCase() + ""),
-                matchEnd = matchStart + string.length - 1,
-                beforeMatch = $el.text().slice(0, matchStart),
-                matchText = $el.text().slice(matchStart, matchEnd + 1),
-                afterMatch = $el.text().slice(matchEnd + 1);
-            $el.html("<span>" + beforeMatch + "<span class='highlight'>" + matchText + "</span>" + afterMatch + "</span>");
-            if (img.length) {
-              $el.prepend(img);
-            }
-          };
-
-          // Perform search
+          // Perform key button
           $input.on('keyup', function (e) {
-            // Capture Enter
-            if (e.which === 13) {
-              $autocomplete.find('li').first().click();
-              return;
-            }
-
-            var val = $input.val().toLowerCase();
-            $autocomplete.empty();
-
-            // Check if the input isn't empty
-            if (val !== '') {
-              for(var key in data) {
-                if (data.hasOwnProperty(key) &&
-                    key.toLowerCase().indexOf(val) !== -1 &&
-                    key.toLowerCase() !== val) {
-                  var autocompleteOption = $('<li></li>');
-                  if(!!data[key]) {
-                    autocompleteOption.append('<img src="'+ data[key] +'" class="right circle"><span>'+ key +'</span>');
-                  } else {
-                    autocompleteOption.append('<span>'+ key +'</span>');
-                  }
-                  $autocomplete.append(autocompleteOption);
-
-                  highlight(val, autocompleteOption);
-                }
-              }
-            }
+            keyUp(e, data, $input, $autocomplete);
           });
 
-          // Set input value
-          $autocomplete.on('click', 'li', function () {
-            $input.val($(this).text().trim());
-            $input.trigger('change');
-            $autocomplete.empty();
+          // arrow key usage
+          $input.on('keydown', function (e) {
+            arrowUsage(e, $autocomplete);
           });
+
+          // reset selected element on the list
+          $input.blur(function () {
+            resetCurrentElement($autocomplete);
+          });
+
+          // updating input value
+          setIputValue($autocomplete, $input);
         }
       });
     };
 
-  }); // End of $(document).ready
+  });
+  // End of autocomplete function
 
   /*******************
    *  Select Plugin  *

--- a/js/init.js
+++ b/js/init.js
@@ -148,7 +148,8 @@
     $('.datepicker').pickadate({selectYears: 20});
     $('select').not('.disabled').material_select();
     $('input.autocomplete').autocomplete({
-      data: {"Apple": null, "Microsoft": null, "Google": 'http://placehold.it/250x250'}
+      data: {"Apple": null, "Microsoft": null, "Micro Center": null, "Micro Mobility": null, "Micro Systems": null, "Google": 'http://placehold.it/250x250'},
+      maxElementsAmount: 3
     });
 
     $('.chips-initial').material_chip({

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -270,9 +270,14 @@ textarea {
 /* Autocomplete */
 .autocomplete-content {
   margin-top: -15px;
-  display: block;
+  display: none;
   opacity: 1;
-  position: static;
+  position: absolute;
+
+  & ~ .autocomplete-content,
+  &:hover {
+    display: block;
+  }
 
   li {
     .highlight { color: #444; }
@@ -283,4 +288,8 @@ textarea {
       margin: 5px 15px;
     }
   }
+}
+
+.autocomplete:focus ~ .autocomplete-content {
+  display: block;
 }


### PR DESCRIPTION
Hi,
aoutocomplete in official version doesn't have a lot of crucial features so I decided to add:
-up and down arrow usage
-updating data for autocomplete - for instance for AJAX request
-if see auto complete list and you will make focusout action, whole list disapper. I think in most cases we don't want to display this list if we do something else. It's rather bug than feature.
-when you write something in auto complete field and press "Esc" button whole list will disappear
-whole content after autocomplete list go down when this list appear. I changed that to absolute position and now it doesn't affect other elements
-in my opinion this list is sometimes too long - for example if we have 100 elements. Because of that, I decided to extend default object with "maxElementsAmount". If you set that for example on 5 during initializtion, you will see only 5 elements from the begining of this list. If you skip that, you will see all matching elements.

Please check that, if you have any questions or comments just write. I'm hope so we can marge that soon because I use that in my project ;)

Cheers,
Adam