### PR TITLE
Add style field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "url": "http://materializecss.com/",
   "version": "0.97.7",
   "main": "bin/materialize.js",
+  "style": "dist/css/materialize.css",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Users of https://github.com/postcss/postcss-import and similar tools need this. This allows us to do `@import "materialize-css";` in our css, and materialize's css will be inlined during the build step.

Bootstrap has this: https://github.com/twbs/bootstrap/blob/master/package.json#L21, materialize should too!
