### PR TITLE
Added activeClass and getActiveElement options to scrollspy

### DIFF
--- a/jade/page-contents/scrollspy_content.html
+++ b/jade/page-contents/scrollspy_content.html
@@ -67,6 +67,19 @@
               <td>activeClass</td>
               <td>Class name to be added to the active link. Default: active</td>
             </tr>
+            <tr>
+              <td>getActiveElement</td>
+              <td>
+                Function that returns an element / jquery selector to add <code>activeClass<code> to.
+                It is called with the section id.
+
+                Default: <code class="language-javascript">
+  function(id) {
+    return 'a[href=#' + id + ']';
+  }
+                </code>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/jade/page-contents/scrollspy_content.html
+++ b/jade/page-contents/scrollspy_content.html
@@ -63,6 +63,10 @@
               <td>scrollOffset</td>
               <td>Offset for centering element when scrolled to. Default: 200</td>
             </tr>
+            <tr>
+              <td>activeClass</td>
+              <td>Class name to be added to the active link. Default: active</td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -89,4 +93,3 @@
 
   </div>
 </div>
-

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -167,12 +167,14 @@
         offsetRight : number -> offset from right. Default: 0
         offsetBottom : number -> offset from bottom. Default: 0
         offsetLeft : number -> offset from left. Default: 0
+				activeClass : string -> Class name to be added to the active link. Default: active
 	 * @returns {jQuery}
 	 */
 	$.scrollSpy = function(selector, options) {
 	  var defaults = {
 			throttle: 100,
-			scrollOffset: 200 // offset - 200 allows elements near bottom of page to scroll
+			scrollOffset: 200, // offset - 200 allows elements near bottom of page to scroll
+			activeClass: 'active'
     };
     options = $.extend(defaults, options);
 
@@ -217,7 +219,7 @@
 			var $this = $(this);
 
 			if (visible[0]) {
-				$('a[href="#' + visible[0].attr('id') + '"]').removeClass('active');
+				$('a[href="#' + visible[0].attr('id') + '"]').removeClass(options.activeClass);
 				if ($this.data('scrollSpy:id') < visible[0].data('scrollSpy:id')) {
 					visible.unshift($(this));
 				}
@@ -230,7 +232,7 @@
 			}
 
 
-			$('a[href="#' + visible[0].attr('id') + '"]').addClass('active');
+			$('a[href="#' + visible[0].attr('id') + '"]').addClass(options.activeClass);
 		});
 		selector.on('scrollSpy:exit', function() {
 			visible = $.grep(visible, function(value) {
@@ -238,13 +240,13 @@
 	    });
 
 			if (visible[0]) {
-				$('a[href="#' + visible[0].attr('id') + '"]').removeClass('active');
+				$('a[href="#' + visible[0].attr('id') + '"]').removeClass(options.activeClass);
 				var $this = $(this);
 				visible = $.grep(visible, function(value) {
 	        return value.attr('id') != $this.attr('id');
 	      });
 	      if (visible[0]) { // Check if empty
-					$('a[href="#' + visible[0].attr('id') + '"]').addClass('active');
+					$('a[href="#' + visible[0].attr('id') + '"]').addClass(options.activeClass);
 	      }
 			}
 		});

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -174,7 +174,10 @@
 	  var defaults = {
 			throttle: 100,
 			scrollOffset: 200, // offset - 200 allows elements near bottom of page to scroll
-			activeClass: 'active'
+			activeClass: 'active',
+			getActiveElement: function(id) {
+				return 'a[href=#' + id + ']';
+			}
     };
     options = $.extend(defaults, options);
 
@@ -219,7 +222,7 @@
 			var $this = $(this);
 
 			if (visible[0]) {
-				$('a[href="#' + visible[0].attr('id') + '"]').removeClass(options.activeClass);
+				$(options.getActiveElement(visible[0].attr('id'))).removeClass(options.activeClass);
 				if ($this.data('scrollSpy:id') < visible[0].data('scrollSpy:id')) {
 					visible.unshift($(this));
 				}
@@ -232,7 +235,7 @@
 			}
 
 
-			$('a[href="#' + visible[0].attr('id') + '"]').addClass(options.activeClass);
+			$(options.getActiveElement(visible[0].attr('id'))).addClass(options.activeClass);
 		});
 		selector.on('scrollSpy:exit', function() {
 			visible = $.grep(visible, function(value) {
@@ -240,13 +243,13 @@
 	    });
 
 			if (visible[0]) {
-				$('a[href="#' + visible[0].attr('id') + '"]').removeClass(options.activeClass);
+				$(options.getActiveElement(visible[0].attr('id'))).removeClass(options.activeClass);
 				var $this = $(this);
 				visible = $.grep(visible, function(value) {
 	        return value.attr('id') != $this.attr('id');
 	      });
 	      if (visible[0]) { // Check if empty
-					$('a[href="#' + visible[0].attr('id') + '"]').addClass(options.activeClass);
+					$(options.getActiveElement(visible[0].attr('id'))).addClass(options.activeClass);
 	      }
 			}
 		});


### PR DESCRIPTION
This is a rewrite of #2300
Both the options have been split into separate commits and the getActiveElement is updated to take section id instead of base which makes it more flexible.
