### PR TITLE
Add 'select' event to autocomplete

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -349,8 +349,10 @@
 
           // Set input value
           $autocomplete.on('click', 'li', function () {
-            $input.val($(this).text().trim());
+            var val = $(this).text().trim();
+            $input.val(val);
             $input.trigger('change');
+            $input.trigger('select', [val]);
             $autocomplete.empty();
           });
         }


### PR DESCRIPTION
The 'change' event fires on every keystroke.

It would be nice to have another event for when the user clicks an item in in the autocomplete dropdown or hits enter on the keyboard.

What do you think?
Is "select" a good event name?
