### PR TITLE
Fix/Global $ conflicts for Velocity

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -78,11 +78,12 @@ Materialize.elementOrParentIsFixed = function(element) {
 };
 
 // Velocity has conflicts when loaded with jQuery, this will check for it
+// First, check if in noConflict mode
 var Vel;
-if ($) {
-  Vel = $.Velocity;
-} else if (jQuery) {
+if (jQuery) {
   Vel = jQuery.Velocity;
+} else if ($) {
+  Vel = $.Velocity;
 } else {
   Vel = Velocity;
 }


### PR DESCRIPTION
Refactored to check for `noConflict` jQuery first.

This is to counter an issue where if a global `$` is being used by another library, Velocity breaks.

closes #3623 