### PR TITLE
Add showSingleMatch option to autocomplete.

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -281,7 +281,8 @@
     $.fn.autocomplete = function (options) {
       // Defaults
       var defaults = {
-        data: {}
+        data: {},
+        showSingleMatch: false
       };
 
       options = $.extend(defaults, options);
@@ -290,6 +291,8 @@
         var $input = $(this);
         var data = options.data,
             $inputDiv = $input.closest('.input-field'); // Div to append on
+
+        var showSingleMatch = options.showSingleMatch;
 
         // Check if data isn't empty
         if (!$.isEmptyObject(data)) {
@@ -329,10 +332,12 @@
 
             // Check if the input isn't empty
             if (val !== '') {
+              var lowerKey;
               for(var key in data) {
+                lowerKey = key.toLowerCase();
                 if (data.hasOwnProperty(key) &&
-                    key.toLowerCase().indexOf(val) !== -1 &&
-                    key.toLowerCase() !== val) {
+                    lowerKey.indexOf(val) !== -1 &&
+                    (showSingleMatch || lowerKey !== val)) {
                   var autocompleteOption = $('<li></li>');
                   if(!!data[key]) {
                     autocompleteOption.append('<img src="'+ data[key] +'" class="right circle"><span>'+ key +'</span>');


### PR DESCRIPTION
Currently, if the autocomplete text exactly matches a data key, the autocomplete is hidden.

With this option, the single match is displayed and the user will now be able to hit enter on the keyboard to fire the 'change' event for a single matching data entry.

Default is **showSingleMatch: false** so behavior will not change unless developers opt-in by adding **showSingleMatch: true**

One issue is that a single match is not highlighted, but I don't think it's worth modifying the highlighting code just to highlight the whole thing in blue.

Let me know if you like this feature and want me to update the Materialize documentation too.
