### PR TITLE
Changes modal _durations for consistency.

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -10,8 +10,8 @@
     init : function(options) {
       var defaults = {
         opacity: 0.5,
-        in_duration: 350,
-        out_duration: 250,
+        inDuration: 350,
+        outDuration: 250,
         ready: undefined,
         complete: undefined,
         dismissible: true,
@@ -40,12 +40,12 @@
           $modal.find('.modal-close').off('click.close');
           $(document).off('keyup.modal' + overlayID);
 
-          $overlay.velocity( { opacity: 0}, {duration: options.out_duration, queue: false, ease: "easeOutQuart"});
+          $overlay.velocity( { opacity: 0}, {duration: options.outDuration, queue: false, ease: "easeOutQuart"});
 
 
           // Define Bottom Sheet animation
           var exitVelocityOptions = {
-            duration: options.out_duration,
+            duration: options.outDuration,
             queue: false,
             ease: "easeOutCubic",
             // Handle modal ready callback
@@ -115,12 +115,12 @@
             opacity: 0
           });
 
-          $overlay.velocity({opacity: options.opacity}, {duration: options.in_duration, queue: false, ease: "easeOutCubic"});
+          $overlay.velocity({opacity: options.opacity}, {duration: options.inDuration, queue: false, ease: "easeOutCubic"});
           $modal.data('associated-overlay', $overlay[0]);
 
           // Define Bottom Sheet animation
           var enterVelocityOptions = {
-            duration: options.in_duration,
+            duration: options.inDuration,
             queue: false,
             ease: "easeOutCubic",
             // Handle modal ready callback

--- a/modals.html
+++ b/modals.html
@@ -283,8 +283,8 @@
   $('.modal').modal({
       dismissible: true, // Modal can be dismissed by clicking outside of the modal
       opacity: .5, // Opacity of modal background
-      in_duration: 300, // Transition in duration
-      out_duration: 200, // Transition out duration
+      inDuration: 300, // Transition in duration
+      outDuration: 200, // Transition out duration
       starting_top: '4%', // Starting top style attribute
       ending_top: '10%', // Ending top style attribute
       ready: function(modal, trigger) { // Callback for Modal open. Modal and trigger parameters available.


### PR DESCRIPTION
Modals use in_duration and out_duration, but dropdowns and materialbox use inDuration and outDuration. JS convention is to use camelCase so this PR updates modals to follow convention of the language and rest of the framework.

Note, this is a breaking change. Anyone using modals and in_duration or out_duration will find their durations stop working. If you want, I can add backwards compatibility too, but I note that the project is not yet version 1, so breaking changes are allowed in semver. Let me know if that is not the case though.
