### PR TITLE
Improve calendar accessibility

### DIFF
--- a/js/date_picker/picker.date.js
+++ b/js/date_picker/picker.date.js
@@ -1290,12 +1290,11 @@ return _.node(
                                             role: 'gridcell',
                                             label: formattedDate,
                                             selected: isSelected && calendar.$node.val() === formattedDate ? true : null,
-                                            activedescendant: isHighlighted ? true : null,
                                             disabled: isDisabled ? true : null
                                         })
                                     ),
                                     '',
-                                    _.ariaAttr({ role: 'presentation' })
+                                    _.ariaAttr({ role: 'row' })
                                 ] //endreturn
                             }
                         })


### PR DESCRIPTION
Remove aria-activedescendant from active day as it is used wrongly.
Should be set on a widget and should have an ID as a value 
https://www.w3.org/WAI/GL/wiki/Using_aria-activedescendant_to_allow_changes_in_focus_within_widgets_to_be_communicated_to_Assistive_Technology

Replace role `presentation` with `row` as widget with role `grid` should have nested `row`s, and elements with role `gridcell` (days) should have a `row` as a parent.
