### PR TITLE
Enabled outline on .btn, .btn-flat, .btn-large

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -6,7 +6,6 @@
   display: inline-block;
   height: $button-height;
   line-height: $button-height;
-  outline: 0;
   padding: $button-padding;
   text-transform: uppercase;
   vertical-align: middle;


### PR DESCRIPTION
Inconsistent behavior in styles, normal anchors and btn-floating receive an outline, 
HOWEVER btn, btn-flat, and btn-large do not receive an outline on focus.

The lack of focus on these three anchor classes violates the WCAG's Focus Visible guideline 2.4.7 and makes it harder for people with mobility handicaps to navigate a site made with MaterializeCSS.

I have made a codepen demonstrating the issue https://codepen.io/anon/pen/xEmaJk

The fix is simply removing **outline:0** from line 9 in _buttons.scss, this allows the default browser behavior on focus and makes the style consistent across these anchor classes.