### PR TITLE
autocomplete event rename

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -350,7 +350,7 @@
           // Set input value
           $autocomplete.on('click', 'li', function () {
             $input.val($(this).text().trim());
-            $input.trigger('change');
+            $input.trigger('change').trigger('ac.select');
             $autocomplete.empty();
           });
         }


### PR DESCRIPTION
The "change" event is common for inputs, the better way to have special event name for "select" event.
