### PR TITLE
Correct flat-btn and wave effect combination

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -1,6 +1,5 @@
 // shared styles
-.btn,
-.btn-flat {
+.btn {
   border: $button-border;
   border-radius: $button-radius;
   display: inline-block;
@@ -231,6 +230,20 @@ button.btn-floating {
   color: $button-flat-color;
   cursor: pointer;
   transition: background-color .2s;
+  border: $button-border;
+  border-radius: $button-radius;
+  display: inline-block;
+  outline: 0;
+  text-transform: uppercase;
+  vertical-align: middle;
+  // Gets rid of tap active state
+  -webkit-tap-highlight-color: transparent;
+
+  input {
+    height: $button-height;
+    line-height: $button-height;
+    padding: $button-padding;
+  }
 
   &:focus,
   &:active {
@@ -246,6 +259,14 @@ button.btn-floating {
     background-color: transparent !important;
     color: $button-flat-disabled-color !important;
     cursor: default;
+  }
+}
+
+a, button {
+  &.btn-flat {
+    height: $button-height;
+    line-height: $button-height;
+    padding: $button-padding;
   }
 }
 

--- a/sass/components/date_picker/_default.date.scss
+++ b/sass/components/date_picker/_default.date.scss
@@ -408,7 +408,7 @@
 }
 
 // Materialize modified
-.picker__close, .picker__today {
+.picker__close.btn-flat, .picker__today.btn-flat {
   font-size: 1.1rem;
   padding: 0 1rem;
   color: $datepicker-selected;


### PR DESCRIPTION
Currently, if you have a flat-btn with the wave effect, then you must click directly on the button's words whereas the wave effect extends a bit outside the button. This can lead the user to think they clicked the button (thanks to the wave effect) when they really did not click the button at all. This change makes it so the clickable area includes the full wave effect area.
