### PR TITLE
Update _input-forms.scss to work on FireFox

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -116,6 +116,7 @@ textarea.materialize-textarea {
     content: "";
     position: absolute;
     top: 60px;
+    left: 0;
     opacity: 0;
     transition: .2s opacity ease-out, .2s color ease-out;
   }


### PR DESCRIPTION
On FireFox v49.0.1, the `label` gets fixed incorrectly to the right of the input field, instead of flushed with the input field at the left margin. 
Adding `left: 0` fixes this immediately, with no foreseeable consequences.
