### PR TITLE
Added text-align justify property and removed the error of disabled links can be clicked. #3835

### DIFF
--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -2682,6 +2682,7 @@ video.responsive-video {
 .pagination li.disabled a {
   cursor: default;
   color: #999;
+  pointer-events: none !important;
 }
 
 .pagination li i {

--- a/bin/materialize.css
+++ b/bin/materialize.css
@@ -8537,3 +8537,7 @@ button.picker__today:focus, button.picker__clear:focus, button.picker__close:foc
     margin-bottom: 5em;
   }
 }
+/* ADDED CLASS FOR TEXT-ALIGN JUSTIFY PROPERTY */
+.text-justify {
+  text-align:justify;
+}


### PR DESCRIPTION
There is no option to justify align text.
There is kinda class named "toast" which justifies text but gives a black background.
So I added a simple class named "text-justify" to align text to justify.