### PR TITLE
Fixed content's max-height on horizontal cards with images

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -73,6 +73,9 @@
           height: 100%;
         }
       }
+      .card-content {
+        max-height: 100%;
+      }
     }
 
     display: flex;


### PR DESCRIPTION
Horizontal cards that have images have their contents' height restricted to 40% for no apparent reason.

[Example codepen](http://codepen.io/aisamu/pen/JbYvzj)

Vertical cards have their `.card-content` max-height set to 40% because `.card-image`, set at 60%, is right above them.
Horizontal cards have the image on a separate column, leaving 100% of the height available for the contents.

The new rule has exactly the same specificity `(0, 4, 0)` as the offending rule, but comes afterwards and overwrites it.