### PR TITLE
Enable custom checkbox fill colors using built-in color classing system

### DIFF
--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -218,3 +218,23 @@ form p:last-child {
     border-color: $input-disabled-solid-color;
   }
 }
+
+/* -- Generate Color Classes for fill color on .filled-in -- */
+@each $color_name,
+$color in $colors {
+  @each $color_type,
+  $color_value in $color {
+    @if $color_type=="base" {
+      [type="checkbox"].filled-in:checked.#{$color_name} + label::after {
+        border: 2px solid $color_value;
+        background-color: $color_value;
+      }
+    }
+    @else if $color_name !="shades" {
+      [type="checkbox"].filled-in:checked.#{$color_name}.#{$color_type} + label::after {
+        border: 2px solid $color_value;
+        background-color: $color_value;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This feature adds the color classing ability already set up (ex: purple lighten-1) in the framework to checkboxes so people aren't stuck with the default teal anymore.

I thought this had a fairly large use case as I frequently found myself changing the fill colors to match the theme I'd chosen. I already had the code made and figured others could benefit as well.

[CodePen Demo](http://codepen.io/mynamesbg/pen/aBdpMY)