### PR TITLE
Optimization and refactor of scrollFire

### DIFF
--- a/js/scrollFire.js
+++ b/js/scrollFire.js
@@ -1,48 +1,66 @@
 (function($) {
 
-  // Input: Array of JSON objects {selector, offset, callback}
+  var timerInterval = 100;
+  var handlers = [];
+  var listening = false;
 
-  Materialize.scrollFire = function(options) {
-
+  function startScrollListener() {
     var didScroll = false;
-
-    window.addEventListener("scroll", function() {
+    var scrollListener = function () {
       didScroll = true;
-    });
+    };
+    var timer = setInterval(funciton () {
+      if (didScroll) {
+        didScroll = false;
 
-    // Rate limit to 100ms
-    setInterval(function() {
-      if(didScroll) {
-          didScroll = false;
+        var windowScroll = window.pageYOffset + window.innerHeight;
 
-          var windowScroll = window.pageYOffset + window.innerHeight;
+        for (var i = 0, len = handlers.length; i < len; ++i) {
+          // Get options from each line
+          var value = handlers[i];
+          var selector = value.selector,
+              offset = value.offset || 0,
+              callback = value.callback;
+          var currentElement = document.querySelector(selector);
 
-          for (var i = 0 ; i < options.length; i++) {
-            // Get options from each line
-            var value = options[i];
-            var selector = value.selector,
-                offset = value.offset,
-                callback = value.callback;
+          if (currentElement !== null) {
+            var elementOffset = currentElement.getBoundingClientRect().top + window.pageYOffset;
 
-            var currentElement = document.querySelector(selector);
-            if ( currentElement !== null) {
-              var elementOffset = currentElement.getBoundingClientRect().top + window.pageYOffset;
-
-              if (windowScroll > (elementOffset + offset)) {
-                if (value.done !== true) {
-                  if (typeof(callback) === 'function') {
-                    callback.call(this, currentElement);
-                  } else if (typeof(callback) === 'string') {
-                    var callbackFunc = new Function(callback);
-                    callbackFunc(currentElement);
-                  }
-                  value.done = true;
-                }
+            if (windowScroll > (elementOffset + offset)) {
+              if (typeof(callback) === 'function') {
+                callback.call(this, currentElement);
+              } else if (typeof(callback) === 'string') {
+                var callbackFunc = new Function(callback);
+                callbackFunc(currentElement);
               }
+
+              handlers.splice(i, 1);
+              len = len - 1;
+              i = i - 1;
             }
           }
+        }
+
+        if (!handlers.length) {
+          // stop listening if no more handlers
+          clearTimeout(timer);
+          window.removeEventListener('scroll', scrollListener);
+        }
       }
-    }, 100);
+    }, timerInterval);
+
+    window.addEventListener('scroll', scrollListener);
+
+    listening = true;
+  }
+
+
+  // Input: Array of JSON objects {selector, offset, callback}
+
+  Materialize.scrollFire = function scrollFire(options) {
+    handlers.push.apply(handlers, options || []);
+
+    listening || startScrollListener();
   };
 
 })(jQuery);

--- a/js/scrollFire.js
+++ b/js/scrollFire.js
@@ -9,7 +9,7 @@
     var scrollListener = function () {
       didScroll = true;
     };
-    var timer = setInterval(funciton () {
+    var timer = setInterval(function () {
       if (didScroll) {
         didScroll = false;
 
@@ -27,9 +27,9 @@
             var elementOffset = currentElement.getBoundingClientRect().top + window.pageYOffset;
 
             if (windowScroll > (elementOffset + offset)) {
-              if (typeof(callback) === 'function') {
-                callback.call(this, currentElement);
-              } else if (typeof(callback) === 'string') {
+              if (typeof callback === 'function') {
+                callback(currentElement);
+              } else if (typeof callback === 'string') {
                 var callbackFunc = new Function(callback);
                 callbackFunc(currentElement);
               }
@@ -54,7 +54,6 @@
 
     listening = true;
   }
-
 
   // Input: Array of JSON objects {selector, offset, callback}
 

--- a/js/scrollFire.js
+++ b/js/scrollFire.js
@@ -45,6 +45,7 @@
           // stop listening if no more handlers
           clearTimeout(timer);
           window.removeEventListener('scroll', scrollListener);
+          listening = false;
         }
       }
     }, timerInterval);


### PR DESCRIPTION
This commit solves issue #3916 and allow `Materialize.scrollFire` to be called any number of times. The component will always use a single timer and a single scroll listener. The component will also cleanup itself if it becomes inactive, and free any unused resources.

Code review welcome!