### PR TITLE
Zombie.js headless browser support.

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -5,8 +5,15 @@
     Materialize.updateTextFields = function() {
       var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
       $(input_selector).each(function(index, element) {
-        if ($(element).val().length > 0 || element.autofocus ||$(this).attr('placeholder') !== undefined || $(element)[0].validity.badInput === true) {
+        if ($(element).val().length > 0 || element.autofocus || $(this).attr('placeholder') !== undefined) {
           $(this).siblings('label').addClass('active');
+        } else if ($(element)[0].validity) {
+          if ($(element)[0].validity.badInput === true) {
+            $(this).siblings('label').addClass('active');
+          }
+          else {
+            $(this).siblings('label').removeClass('active');
+          }
         }
         else {
           $(this).siblings('label').removeClass('active');


### PR DESCRIPTION
Handling of undefined input.validity. This is the case for Zombie.js headless browser. 
Original issue: http://stackoverflow.com/questions/40634842/materialize-cannot-read-property-badinput-of-undefined.