### PR TITLE
mobile issues with touchstart on dropdown.js

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -237,10 +237,10 @@
             }
             // If menu open, add click close handler to document
             if (activates.hasClass('active')) {
-              $(document).bind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'), function (e) {
+              $(document).bind('click.'+ activates.attr('id') + ' tap.' + activates.attr('id'), function (e) {
                 if (!activates.is(e.target) && !origin.is(e.target) && (!origin.find(e.target).length) ) {
                   hideDropdown();
-                  $(document).unbind('click.'+ activates.attr('id') + ' touchstart.' + activates.attr('id'));
+                  $(document).unbind('click.'+ activates.attr('id') + ' tap.' + activates.attr('id'));
                 }
               });
             }


### PR DESCRIPTION
We had a dropdown on mobile that was large, and found out it wasn't possible to scroll down the entries without closing the dropdown. This seemed to resolve it. Not extensively tested - thoughts?