### PR TITLE
Added configuration object support for autocomplete plugin

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -333,13 +333,20 @@
                 if (data.hasOwnProperty(key) &&
                     key.toLowerCase().indexOf(val) !== -1 &&
                     key.toLowerCase() !== val) {
+                  var id;
+                  var url;
                   var autocompleteOption = $('<li></li>');
                   if(!!data[key]) {
+                    url = typeof data[key] === 'string' ? data[key] : data[key].url;
+                    id = data[key].id;
+                  }
+                  if(!!url) {
                     autocompleteOption.append('<img src="'+ data[key] +'" class="right circle"><span>'+ key +'</span>');
                   } else {
                     autocompleteOption.append('<span>'+ key +'</span>');
                   }
                   $autocomplete.append(autocompleteOption);
+                  autocompleteOption.data('id', id);
 
                   highlight(val, autocompleteOption);
                 }


### PR DESCRIPTION
# What ?

Kindly provide feedback as necessary 💃 

- **[FORMS]** Enhances the `autocomplete` plugin usage API with an optional configuration object

From:
```
data: {
  Google: null,
  Apple: 'apple.com/logo.png'
}
```

To:
```
data: {
  Google: null,
  Apple: 'apple.com/logo.png',
  Github: {
    url: 'github.com/logo.png',
    id: 1
  }
}
```

# Why?
This makes it easier for developers to provide a configuration object for the autocomplete plugin. In this PR, an `id` field is introduced, so that when we catch the `change` event in our apps, we can easily and accurately map a clicked `<li>` to our corresponding internal data model without parsing a bunch of text 👍 

Example: My autocomplete has options compromised as `firstName lastName (dateOfBirth)`. However, both `firstName` and `lastName` can have spaces, so parsing and mapping back to my data model gets messy and unreliable.

My 2 cents is, there should be a better way to map user selections to the source data.

# Testing done:
- Verified the `id` field is catchable, via `$(evt.target).data('id');` in the `change` event handler
- Verified PR changes are backwards-compatible
- All unit tests pass

