### PR TITLE
[Chips] Fixing placeholder order

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -211,11 +211,11 @@
     };
 
     this.setPlaceholder = function($chips) {
-      if ($chips.data('chips').length && curr_options.placeholder) {
-        $chips.find('input').prop('placeholder', curr_options.placeholder);
-
-      } else if (!$chips.data('chips').length && curr_options.secondaryPlaceholder) {
+      if ($chips.data('chips').length && curr_options.secondaryPlaceholder) {
         $chips.find('input').prop('placeholder', curr_options.secondaryPlaceholder);
+
+      } else if (!$chips.data('chips').length && curr_options.placeholder) {
+        $chips.find('input').prop('placeholder', curr_options.placeholder);
       }
     };
 


### PR DESCRIPTION
Currently, primary and secondary placeholder on chip inputs are inverted, showing `secondaryPlaceholder` when there is no chip and default `placeholder` when there is 1+ chips added

This commit fixes it