### PR TITLE
fix indent mistakes in form example

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -530,9 +530,9 @@
       &lt;input class="with-gap" name="group1" type="radio" id="test3"  />
       &lt;label for="test3">Green&lt;/label>
     &lt;/p>
-      &lt;p>
-        &lt;input name="group1" type="radio" id="test4" disabled="disabled" />
-        &lt;label for="test4">Brown&lt;/label>
+    &lt;p>
+      &lt;input name="group1" type="radio" id="test4" disabled="disabled" />
+      &lt;label for="test4">Brown&lt;/label>
     &lt;/p>
   &lt;/form>
         </code></pre>
@@ -605,9 +605,9 @@
       &lt;input type="checkbox" id="test7" checked="checked" disabled="disabled" />
       &lt;label for="test7">Green&lt;/label>
     &lt;/p>
-      &lt;p>
-        &lt;input type="checkbox" id="test8" disabled="disabled" />
-        &lt;label for="test8">Brown&lt;/label>
+    &lt;p>
+      &lt;input type="checkbox" id="test8" disabled="disabled" />
+      &lt;label for="test8">Brown&lt;/label>
     &lt;/p>
   &lt;/form>
         </code></pre>


### PR DESCRIPTION
Hello
I found some indent mistakes in form example and fix it.
![1](https://cloud.githubusercontent.com/assets/18042906/21002097/4b6a4958-bd67-11e6-9a65-ce2544da9421.png)![2](https://cloud.githubusercontent.com/assets/18042906/21002099/4d652eee-bd67-11e6-920d-3af0810bc756.png)
to
![3](https://cloud.githubusercontent.com/assets/18042906/21002102/53577780-bd67-11e6-826f-d79d696dc0ec.png)![4](https://cloud.githubusercontent.com/assets/18042906/21002104/54ad57d0-bd67-11e6-8dfa-7210abe1718e.png)

I have edited .html page under jade/page-contents/.
Is that right?