### PR TITLE
Remove scrollTo selected element in multiple select

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -560,7 +560,9 @@
           collection.find('li.selected').removeClass('selected');
           var option = $(newOption);
           option.addClass('selected');
-          options.scrollTo(option);
+          if (!multiple) {
+            options.scrollTo(option);
+          }
         }
       };
 


### PR DESCRIPTION
Automatically scrolling to a selected element inside a multiple select causes a frustrating user experience if there are many elements. The current design assumes that a user will make selections from top to bottom.

![enbvxch5tb](https://cloud.githubusercontent.com/assets/20605661/21127671/ecc69b32-c148-11e6-8e53-9182388265ce.gif)
