### PR TITLE
Fixes #2217 

### DIFF
--- a/package.js
+++ b/package.js
@@ -51,6 +51,7 @@ Package.onUse(function (api) {
     'sass/components/forms/_range.scss',
     'sass/components/forms/_select.scss',
     'sass/components/forms/_switches.scss',
+    'sass/components/_badges.scss',
     'sass/components/_buttons.scss',
     'sass/components/_cards.scss',
     'sass/components/_carousel.scss',

--- a/package.js
+++ b/package.js
@@ -16,21 +16,21 @@ Package.onUse(function (api) {
   api.imply('jquery', 'client');
 
   var assets = [
-    'dist/fonts/roboto/Roboto-Bold.ttf',
-    'dist/fonts/roboto/Roboto-Bold.woff',
-    'dist/fonts/roboto/Roboto-Bold.woff2',
-    'dist/fonts/roboto/Roboto-Light.ttf',
-    'dist/fonts/roboto/Roboto-Light.woff',
-    'dist/fonts/roboto/Roboto-Light.woff2',
-    'dist/fonts/roboto/Roboto-Medium.ttf',
-    'dist/fonts/roboto/Roboto-Medium.woff',
-    'dist/fonts/roboto/Roboto-Medium.woff2',
-    'dist/fonts/roboto/Roboto-Regular.ttf',
-    'dist/fonts/roboto/Roboto-Regular.woff',
-    'dist/fonts/roboto/Roboto-Regular.woff2',
-    'dist/fonts/roboto/Roboto-Thin.ttf',
-    'dist/fonts/roboto/Roboto-Thin.woff',
-    'dist/fonts/roboto/Roboto-Thin.woff2',
+    'fonts/roboto/Roboto-Bold.ttf',
+    'fonts/roboto/Roboto-Bold.woff',
+    'fonts/roboto/Roboto-Bold.woff2',
+    'fonts/roboto/Roboto-Light.ttf',
+    'fonts/roboto/Roboto-Light.woff',
+    'fonts/roboto/Roboto-Light.woff2',
+    'fonts/roboto/Roboto-Medium.ttf',
+    'fonts/roboto/Roboto-Medium.woff',
+    'fonts/roboto/Roboto-Medium.woff2',
+    'fonts/roboto/Roboto-Regular.ttf',
+    'fonts/roboto/Roboto-Regular.woff',
+    'fonts/roboto/Roboto-Regular.woff2',
+    'fonts/roboto/Roboto-Thin.ttf',
+    'fonts/roboto/Roboto-Thin.woff',
+    'fonts/roboto/Roboto-Thin.woff2',
   ];
 
   addAssets(api, assets);


### PR DESCRIPTION
Changed fonts path in packages.js , so meteor can work properly again with v0.97.8
The error appeard after the font directory path changed in v0.97.6 
```
(index):1 OTS parsing error: invalid version tag
(index):1 Failed to decode downloaded font: http://localhost:3000/packages/materialize_materialize/fonts/roboto/Roboto-Regular.ttf
```
https://github.com/Dogfalo/materialize/issues/2217#issuecomment-266815687

Also added 'sass/components/_badges.scss', to packages.js
