### PR TITLE
Remove overflow: hidden after animation done

### DIFF
--- a/js/cards.js
+++ b/js/cards.js
@@ -10,7 +10,10 @@
               duration: 225,
               queue: false,
               easing: 'easeInOutQuad',
-              complete: function() { $(this).css({ display: 'none'}); }
+              complete: function() { 
+                $(this).css({ display: 'none'}); 
+                $(e.target).closest('.card').css('overflow', 'visible');
+              }
             }
           );
         }


### PR DESCRIPTION
Removing overflow:hidden on .card after the animation to close the reveal card is done. This solves the issue that for example dropdowns are cut of after using the reveal card via an activator for the first time.