### PR TITLE
Reimplement closeOnSelect functionality and set default to false

### DIFF
--- a/forms.html
+++ b/forms.html
@@ -882,6 +882,7 @@
   $('.datepicker').pickadate({
     selectMonths: true, // Creates a dropdown to control month
     selectYears: 15 // Creates a dropdown of 15 years to control year
+    closeOnSelect: true // Automatically closes picker when date selected
   });
         </code></pre>
       </div>

--- a/js/date_picker/picker.date.js
+++ b/js/date_picker/picker.date.js
@@ -1359,7 +1359,8 @@ DatePicker.defaults = (function( prefix ) {
 
         // Materialize modified
         weekdaysLetter: [ 'S', 'M', 'T', 'W', 'T', 'F', 'S' ],
-
+        closeOnSelect: false,
+      
         // Today and clear
         today: 'Today',
         clear: 'Clear',
@@ -1367,7 +1368,8 @@ DatePicker.defaults = (function( prefix ) {
 
         // The format to show on the `input` element
         format: 'd mmmm, yyyy',
-
+        
+      
         // Classes
         klass: {
 

--- a/js/date_picker/picker.js
+++ b/js/date_picker/picker.js
@@ -300,6 +300,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                             // On “enter”, if the highlighted item isn’t disabled, set the value and close.
                             else if ( !P.$root.find( '.' + CLASSES.highlighted ).hasClass( CLASSES.disabled ) ) {
                                 P.set( 'select', P.component.item.highlight ).close()
+                                if ( SETTINGS.closeOnSelect ) {
+                                    P.close( true )
+                                }
                             }
                         }
 
@@ -716,6 +719,9 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                 // If something is picked, set `select` then close with focus.
                 else if ( !targetDisabled && 'pick' in targetData ) {
                     P.set( 'select', targetData.pick )
+                    if ( SETTINGS.closeOnSelect ) {
+                        P.close( true )
+                    }
                 }
 
                 // If a “clear” button is pressed, empty the values and close with focus.

--- a/js/date_picker/picker.js
+++ b/js/date_picker/picker.js
@@ -299,7 +299,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
 
                             // On “enter”, if the highlighted item isn’t disabled, set the value and close.
                             else if ( !P.$root.find( '.' + CLASSES.highlighted ).hasClass( CLASSES.disabled ) ) {
-                                P.set( 'select', P.component.item.highlight ).close()
+                                P.set( 'select', P.component.item.highlight )
                                 if ( SETTINGS.closeOnSelect ) {
                                     P.close( true )
                                 }


### PR DESCRIPTION
This has been an issue that has been hanging around for a while and the fix is super easy.

To align with material design principles, default has been set to false but allows people to enable it without the `for ('select' in args)` hacky workaround that exists.

#870 

