### PR TITLE
Made `new` badges do not append ` new` to the text

### DIFF
--- a/sass/components/_badges.scss
+++ b/sass/components/_badges.scss
@@ -18,9 +18,6 @@ span.badge {
     background-color: $badge-bg-color;
     border-radius: 2px;
   }
-  &.new:after {
-    content: " new";
-  }
 
   &[data-badge-caption]::after {
     content: " " attr(data-badge-caption);


### PR DESCRIPTION
I think it would be better if it will not be auto-appended. For example, this will be great if it will be used for showing total count of X and changing color (style `new`) when there's new X