### PR TITLE
Fixed nav extended class name in description

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -237,7 +237,7 @@
 
         <h2 class="header">Extended Navbar with Tabs</h2>
         <p>
-          To add extended components to the navbar, add the class <code class="language-markup">extended-nav</code> to the outer <span class="language-markup">nav</span> tag. This will allow your navbar height to be variable. Then you can just include a tabs component inside the <span class="language-markup">nav-wrapper</span>.
+          To add extended components to the navbar, add the class <code class="language-markup">nav-extended</code> to the outer <span class="language-markup">nav</span> tag. This will allow your navbar height to be variable. Then you can just include a tabs component inside the <span class="language-markup">nav-wrapper</span>.
         </p>
 
         <nav class="nav-extended">


### PR DESCRIPTION
Extended Navbar with Tabs section, under Navbar page; had wrong class name (extended-nav), corrected it to the one included in materializecss class list.