### PR TITLE
Parallax speed option

### DIFF
--- a/js/parallax.js
+++ b/js/parallax.js
@@ -1,6 +1,14 @@
 (function ($) {
 
-  $.fn.parallax = function () {
+  $.fn.parallax = function (speed) {
+    var parallaxSpeed = function (speed) {
+      if(isNaN(speed)){
+	      return 1;
+      }else{
+	      return (speed / 100);
+      }
+    };
+    
     var window_width = $(window).width();
     // Parallax Scripts
     return this.each(function(i) {
@@ -24,7 +32,7 @@
         var windowHeight = window.innerHeight;
         var windowBottom = scrollTop + windowHeight;
         var percentScrolled = (windowBottom - top) / (container_height + windowHeight);
-        var parallax = Math.round((parallax_dist * percentScrolled));
+        var parallax = Math.round((parallax_dist * percentScrolled)* parallaxSpeed);
 
         if (initial) {
           $img.css('display', 'block');


### PR DESCRIPTION
Adding a parallax speed option.
Default value is `100`.

If you want only half of the speed of your parallax effect, write 50 as a parameter into the parallax initialization. 
Example:
```
$(document).ready(function(){
  $('.parallax').parallax(50);
}); 
```

If you want double the speed of your parallax effect, write 200 as a parameter into the parallax initialization. 
Example:
```
$(document).ready(function(){
  $('.parallax').parallax(200);
});
```
