### PR TITLE
Introduce responsive horizontal cards

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -98,6 +98,45 @@
     }
   }
 
+  // Responsive Horizontal Cards
+  @media #{$medium-and-up} {
+    &.responsive-horizontal {
+      &.small, &.medium, &.large {
+        .card-image {
+          height: 100%;
+          max-height: none;
+          overflow: visible;
+
+          img {
+            height: 100%;
+          }
+        }
+      }
+
+      display: flex;
+
+      .card-image {
+        max-width: 50%;
+        img {
+          border-radius: 2px 0 0 2px;
+          max-width: 100%;
+          width: auto;
+        }
+      }
+
+      .card-stacked {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        position: relative;
+
+        .card-content {
+          flex-grow: 1;
+        }
+      }
+    }
+  }
+  
   // Sticky Action Section
   &.sticky-action {
     .card-action {


### PR DESCRIPTION
By using the markup of the normal horizontal card with the new class "responsive-horizontal" the card will display as a horizontal card only on medium an up devices. On small devices the card will be displayed as a regular card since horziontal cards do not make much sense on small devices anyway.