### PR TITLE
Added data-external for external source of materialboxed image showed…

### DIFF
--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -56,8 +56,15 @@
             progressWrapper.remove();
           }).attr("src",origin.data("external")); // switch src of thumbnail with original
           imageChanged = true; // now the image is switched
-        }else
+        }else{
+          originalWidth = origin.width(); // remember fullsize file size
+          originalHeight = origin.height();
+          placeholder.css({
+            width: placeholder[0].getBoundingClientRect().width,
+            height: placeholder[0].getBoundingClientRect().height,
+          })
           enlargeImage(); // works like before
+        }
       }); // End origin on click
 
 
@@ -85,8 +92,6 @@
 
         // Set positioning for placeholder
         placeholder.css({
-          width: originalSrcWidth,
-          height: originalSrcHeight,
           position: 'relative',
           top: 0,
           left: 0

--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -16,9 +16,9 @@
       var outDuration = 200;
       var origin = $(this);
       var placeholder = $('<div></div>').addClass('material-placeholder');
-      placeholder.css("display","table"); // for the progress bar to be same width of img
-      var progressWrapper = $("<div style='position: relative;bottom: 12px;'></div>");
-      var progress = $('<div></div>').addClass('progress');
+      placeholder.css({ display:" table", position: "relative", width: origin.css("width"), height: origin.css("height") }); // for the progress bar to be same width of img
+      var progressWrapper = $("<div style='position: absolute;bottom: 6px; width:100%'></div>");
+      var progress = $('<div style="margin:0;"></div>').addClass('progress');
       var indeterminateProgress = $('<div></div>').addClass('indeterminate');
       progress.append(indeterminateProgress);
       progressWrapper.append(progress);
@@ -42,6 +42,16 @@
           // if thumbnail has original version of image
           progressWrapper.insertAfter(origin); // show progress while new src loads
           origin.load(function(){ // will enlarge image once new src is loaded
+            originalWidth = origin.width(); // remember fullsize file size
+            originalHeight = origin.height();
+            placeholder.css({
+              width: originalSrcWidth,
+              height: originalSrcHeight
+            })
+            origin.css({ // resize new image to thumnail for smoother animation
+              width: originalSrcWidth,
+              height: originalSrcHeight
+            });
             enlargeImage(); // enlarge loaded src as normal
             progressWrapper.remove();
           }).attr("src",origin.data("external")); // switch src of thumbnail with original
@@ -55,8 +65,6 @@
         var placeholder = origin.parent('.material-placeholder');
         var windowWidth = window.innerWidth;
         var windowHeight = window.innerHeight;
-        var originalWidth = origin.width();
-        var originalHeight = origin.height();
 
 
         // If already modal, return to original
@@ -77,8 +85,8 @@
 
         // Set positioning for placeholder
         placeholder.css({
-          width: placeholder[0].getBoundingClientRect().width,
-          height: placeholder[0].getBoundingClientRect().height,
+          width: originalSrcWidth,
+          height: originalSrcHeight,
           position: 'relative',
           top: 0,
           left: 0
@@ -267,7 +275,6 @@
               placeholder.css({
                 height: '',
                 width: '',
-                position: '',
                 top: '',
                 left: ''
               });

--- a/media.html
+++ b/media.html
@@ -140,6 +140,13 @@
           <pre><code class="language-markup">
   &lt;img class="materialboxed" data-caption="A picture of some deer and tons of trees" width="250" src="http://th01.deviantart.net/fs70/PRE/i/2013/126/1/e/nature_portrait_by_pw_fotografie-d63tx0n.jpg">
           </code></pre>
+
+        <h4>External image source</h4>
+        <p>You can also load external image instead of simply enlarging materialboxed image. It is mostly useful for showing thumbnails and providing external, larger files as full size images. To do so add external image url as a <code class="language-markup">data-external</code> attribute.</p>
+        <img class="materialboxed" data-external="images/sample-1.jpg" data-caption="A picture of tons of trees instead of deer in thumbnail" width="250" src="http://th01.deviantart.net/fs70/PRE/i/2013/126/1/e/nature_portrait_by_pw_fotografie-d63tx0n.jpg">
+          <pre><code class="language-markup">
+  &lt;img class="materialboxed" data-external="images/sample-1.jpg" data-caption="A picture of tons of trees instead of deer in thumbnail" width="250" src="http://th01.deviantart.net/fs70/PRE/i/2013/126/1/e/nature_portrait_by_pw_fotografie-d63tx0n.jpg"&gt;
+          </code></pre>
       </div>
 
       <br>


### PR DESCRIPTION
… with overlay; Also added example to documentation;

Materialbox does not support external source, so showing thumnails that will display overlayed full-size image once clicked is impossible. 

I found PR with concept of solution for that: https://github.com/Dogfalo/materialize/pull/2798
But the commit contains some bugs (like it does not change src to thumbnail in returnToOriginal) and is based on the older version of materialize repo.

I used that version to create one that actually works. I added `data-external` as the attribute for img with url to the full-size image. As in the PR above, it uses progress bar while loading full-sized image. 

Also I fixed a bug, where `data-caption` was checked against `!== ""` (old line 113) so when it is not set at all (i.e. `undefined`) it was created anyway and moved it's hiding complete event code regarding origin `img` to origin `complete` event function (new lines 265-296 are moved from old 246-273).

Click event was moved to new function `enlargeImage` and now click checks if the image has external source (in which casse loads it in place of thumbnail) or just launches `enlargeImage` and works as it used to previously. 

I added example section called External image source into documentation after Caption section on JavaScript -> Media page. 

Hope someone will find it useful. 

**Known issues (maybe someone can help with these):** 
- preferably image should do some fadeOut/In animation when returnToOriginal (and maybe while enlarging)
- related to the one above - when image is loaded for a short moment `img` element is being resized, but then size is changed to thumbnail and animation starts. Maybe there's a way to load image in the element of contant size. 

I think it is a good start to this feature. If you can help with the issues above, please contribute. 