### PR TITLE
Update JQuery version from 2.1.4 to 2.2.4 because webpack problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "hammerjs": "^2.0.4",
-    "jquery": "^2.1.4",
+    "jquery": "^2.2.4",
     "node-archiver": "^0.3.0"
   },
   "engine": "node >= 0.10",
@@ -39,7 +39,7 @@
     "grunt-text-replace": "^0.4.0",
     "jasmine": "^2.3.2",
     "jasmine-jquery": "^2.1.1",
-    "jquery": "^2.1.4",
+    "jquery": "^2.2.4",
     "node-sass": "^3.4.2",
     "phantomjs": "^1.9.18"
   },


### PR DESCRIPTION
jQuery 2.1.4 is a major problem when you install Materialize from npm and use it in webpack bundle:
```js
require('materialize-css')
```

The workaround is deleting manually the node_modules folder.  
I think jQuery dependency needs to be updated
