### PR TITLE
Making sure that the indicator is always last

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -88,6 +88,8 @@
         $this.append('<div class="indicator"></div>');
       }
       $indicator = $this.find('.indicator');
+      // we make sure that the indicator is at the end of the tabs
+      $this.append($indicator);
       if ($this.is(":visible")) {
         // $indicator.css({"right": $tabs_width - ((index + 1) * $tab_width)});
         // $indicator.css({"left": index * $tab_width});


### PR DESCRIPTION
Hi,

In order to be sure that the indicator is always the last element of the ul group, we append it each time.

This is useful for example when you are looking for the next/prev tab using jquery.prev/next

If the indicator is left in the middle of the ul group, using jquery.prev could lead to a selection of the indicator instead of the li tag, thus making the selection more complicated.

Benjamin