### PR TITLE
adjust height of extended fixed nav

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -195,6 +195,15 @@ nav {
     position: fixed;
   }
 }
+.navbar-extended-fixed {
+  position: relative;
+  height: $navbar-height-mobile + $tabs-height;
+  z-index: 997;
+
+  nav {
+    position: fixed;
+  }
+}
 @media #{$medium-and-up} {
   nav.nav-extended .nav-wrapper {
     min-height: $navbar-height;
@@ -205,5 +214,8 @@ nav {
   }
   .navbar-fixed {
     height: $navbar-height;
+  }
+  .navbar-extended-fixed{
+    height: $navbar-height + $tabs-height;
   }
 }

--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -32,7 +32,7 @@
   position: relative;
   overflow-x: auto;
   overflow-y: hidden;
-  height: 48px;
+  height: $tabs-height;
   width: 100%;
   background-color: $tabs-bg-color;
   margin: 0 auto;
@@ -42,7 +42,7 @@
     display: inline-block;
     text-align: center;
     line-height: 48px;
-    height: 48px;
+    height: $tabs-height;
     padding: 0;
     margin: 0;
     text-transform: uppercase;

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -257,6 +257,7 @@ $spinner-default-color: $secondary-color !default;
 $tabs-underline-color: $primary-color-light !default;
 $tabs-text-color: $primary-color !default;
 $tabs-bg-color: #fff !default;
+$tabs-height: 48px !default;
 
 
 // 18. Tables


### PR DESCRIPTION
problem: when i want to use fixed navbar with Extended Navbar with Tabs,
tab contents are covered by tab buttons. Because .navbar-fixed is just set to $navbar-height or $navbar-height-mobile without tab's height.(content's div tag goes up to bottom of navbar)

code: http://codepen.io/anon/pen/egBqZR

So i make new class, navbar-extended-fixed. Its height is set $ navbar-height + $tabs-height to widen the height and cover all the tab area.
In variables.scss file i add new variable, $tabs-height. Because tabs-height is accessed in navbar.
It is possible that some changes in tab height can break nav's css.
This tag can be used exactly same way like navbar-fixed.

after code: http://codepen.io/anon/pen/mRONQy