### PR TITLE
Fixes Issue #4118 - fixed side-nav is hidden with "closeOnClick" in large browser window

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -80,7 +80,12 @@
         // if closeOnClick, then add close event for all a tags in side sideNav
         if (options.closeOnClick === true) {
           menu.on("click.itemclick", "a:not(.collapsible-header)", function(){
-            removeMenu();
+            // only close on click if this isn't a fixed sidebar in a large browser window
+            if (menu.hasClass('fixed')) {
+              if (window.innerWidth <= 992) {
+                removeMenu();
+              }
+            }
           });
         }
 


### PR DESCRIPTION
Fixes Issue #4118 - For a fixed side-nav, "closeOnClick" hides the side-nav even in a large browser window

Description:

When you have a fixed side nav it is hidden only in med and lower browser windows. If you use closeOnClick = true, then selecting a link in the sidenav will close the side nav (translate it off screen). The problem is that when you have a large browser window, the side nav is not hidden (it is fixed on the side and always displayed), but clicking a link on it still causes it to be hidden.

Repro Steps:

- Init a side nave with closeOnClick = true
- Use the "fixed" class in your side-nav
- Make your browser window larger than 992px
- The side nav becomes fixed and always visible
- Click a link in the side nav
- The side nav is hidden even though it should remain fixed