### PR TITLE
Remove horizontal scroll of side-nav

### DIFF
--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -947,7 +947,6 @@ body.parallax-demo footer {
       width: 100%;
       height: 45px;
       margin: 0;
-      padding: 0 45px 0 15px;
       border: 0;
     }
 


### PR DESCRIPTION
The line "padding: 0 45px 0 15px" caused horizontal scroll of the whole side-nav on desktop and mobile.