### PR TITLE
Update _select.scss

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -35,6 +35,9 @@ select {
     padding: 0;
     display: block;
   }
+  input.select-dropdown.active {
+    visibility: hidden;
+  }
 
   span.caret {
     color: initial;


### PR DESCRIPTION
Add below css: 
    input.select-dropdown.active {
        visibility: hidden;
    }

This is to fix a form select issue specific to iPhone. A blue focus cursor will show up when you open form select component.