### PR TITLE
Avoid TextField labels from getting pointer events

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -160,6 +160,7 @@ textarea.materialize-textarea {
     font-size: 1rem;
     cursor: text;
     transition: .2s ease-out;
+    pointer-events: none;
 
     &:not(.label-icon).active {
       font-size: $label-font-size;


### PR DESCRIPTION
Currently, the text fields labels can be selected. It also prevents the user from focusing the input when they click directly on the label, because it receives the pointer events.