### PR TITLE
Renamed the SCSS $secondary-color to $accent-color as this is inline …

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git://github.com/Dogfalo/materialize.git"
   },
   "dependencies": {
+    "grunt-cli": "^1.2.0",
     "hammerjs": "^2.0.4",
     "jquery": "^2.1.4",
     "node-archiver": "^0.3.0"

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -35,6 +35,38 @@ a {
   // Gets rid of tap active state
   -webkit-tap-highlight-color: transparent;
 }
+// Helper classes for Colors
+.primary-color {
+  background-color: $primary-color;
+}
+
+.primary-color-light {
+  background-color: $primary-color-light;
+}
+
+.primary-color-dark {
+  background-color: $primary-color-dark;
+}
+
+.accent-color {
+  background-color: $accent-color;
+}
+
+.primary-color-text {
+  color: $primary-color;
+}
+
+.primary-color-light-text {
+  color: $primary-color-light;
+}
+
+.primary-color-dark-text {
+  color: $primary-color-dark;
+}
+
+.accent-color-text {
+  color: $accent-color;
+}
 
 
 // Positioning
@@ -584,7 +616,7 @@ td, th{
 // Made less specific to allow easier overriding
 .secondary-content {
   float: right;
-  color: $secondary-color;
+  color: $accent-color;
 }
 .collapsible .collection {
   margin: 0;

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -37,7 +37,7 @@ $primary-color: color("materialize-red", "lighten-2") !default;
 $primary-color-light: lighten($primary-color, 15%) !default;
 $primary-color-dark: darken($primary-color, 15%) !default;
 
-$secondary-color: color("teal", "lighten-1") !default;
+$accent-color: color("teal", "lighten-1") !default;
 $success-color: color("green", "base") !default;
 $error-color: color("red", "base") !default;
 $link-color: color("light-blue", "darken-1") !default;
@@ -46,7 +46,7 @@ $link-color: color("light-blue", "darken-1") !default;
 // 2. Badges
 // ==========================================================================
 
-$badge-bg-color: $secondary-color !default;
+$badge-bg-color: $accent-color !default;
 $badge-height: 22px !default;
 
 
@@ -55,7 +55,7 @@ $badge-height: 22px !default;
 
 // Shared styles
 $button-border: none !default;
-$button-background-focus: lighten($secondary-color, 4%) !default;
+$button-background-focus: lighten($accent-color, 4%) !default;
 $button-font-size: 1.3rem !default;
 $button-height: 36px !default;
 $button-padding: 0 2rem !default;
@@ -66,7 +66,7 @@ $button-disabled-background: #DFDFDF !default;
 $button-disabled-color: #9F9F9F !default;
 
 // Raised buttons
-$button-raised-background: $secondary-color !default;
+$button-raised-background: $accent-color !default;
 $button-raised-background-hover: lighten($button-raised-background, 5%) !default;
 $button-raised-color: #fff !default;
 
@@ -79,7 +79,7 @@ $button-flat-color: #343434 !default;
 $button-flat-disabled-color: lighten(#999, 10%) !default;
 
 // Floating buttons
-$button-floating-background: $secondary-color !default;
+$button-floating-background: $accent-color !default;
 $button-floating-background-hover: $button-floating-background !default;
 $button-floating-color: #fff !default;
 $button-floating-size: 40px !default;
@@ -117,12 +117,12 @@ $chip-margin: 5px !default;
 // 7. Date Picker
 // ==========================================================================
 
-$datepicker-weekday-bg: darken($secondary-color, 7%) !default;
-$datepicker-date-bg: $secondary-color !default;
+$datepicker-weekday-bg: darken($accent-color, 7%) !default;
+$datepicker-date-bg: $accent-color !default;
 $datepicker-year: rgba(255, 255, 255, .4) !default;
 $datepicker-focus: rgba(0,0,0, .05) !default;
-$datepicker-selected: $secondary-color !default;
-$datepicker-selected-outfocus: desaturate(lighten($secondary-color, 35%), 15%) !default;
+$datepicker-selected: $accent-color !default;
+$datepicker-selected-outfocus: desaturate(lighten($accent-color, 35%), 15%) !default;
 
 
 // 8. Dropdown
@@ -130,7 +130,7 @@ $datepicker-selected-outfocus: desaturate(lighten($secondary-color, 35%), 15%) !
 
 $dropdown-bg-color: #fff !default;
 $dropdown-hover-bg-color: #eee !default;
-$dropdown-color: $secondary-color !default;
+$dropdown-color: $accent-color !default;
 $dropdown-item-height: 50px !default;
 
 
@@ -150,7 +150,7 @@ $input-border: 1px solid $input-border-color !default;
 $input-background: #fff !default;
 $input-error-color: $error-color !default;
 $input-success-color: $success-color !default;
-$input-focus-color: $secondary-color !default;
+$input-focus-color: $accent-color !default;
 $input-font-size: 1rem !default;
 $input-margin: 0 0 20px 0 !default;
 $input-padding: 0 !default;
@@ -163,7 +163,7 @@ $input-invalid-border: 1px solid $input-error-color !default;
 $placeholder-text-color: lighten($input-border-color, 20%) !default;
 
 // Radio Buttons
-$radio-fill-color: $secondary-color !default;
+$radio-fill-color: $accent-color !default;
 $radio-empty-color: #5a5a5a !default;
 $radio-border: 2px solid $radio-fill-color !default;
 
@@ -175,14 +175,14 @@ $track-height: 3px !default;
 // Select
 $select-border: 1px solid #f2f2f2 !default;
 $select-background: rgba(255, 255, 255, 0.90) !default;
-$select-focus: 1px solid lighten($secondary-color, 47%) !default;
+$select-focus: 1px solid lighten($accent-color, 47%) !default;
 $select-padding: 5px !default;
 $select-radius: 2px !default;
 $select-disabled-color: rgba(0,0,0,.3) !default;
 
 // Switches
-$switch-bg-color: $secondary-color !default;
-$switch-checked-lever-bg: desaturate(lighten($secondary-color, 25%), 25%) !default;
+$switch-bg-color: $accent-color !default;
+$switch-checked-lever-bg: desaturate(lighten($accent-color, 25%), 25%) !default;
 $switch-unchecked-bg: #F1F1F1 !default;
 $switch-unchecked-lever-bg: #818181 !default;
 $switch-radius: 15px !default;
@@ -248,7 +248,7 @@ $slider-indicator-color: color('green', 'base') !default;
 // 16. Spinners | Loaders
 // ==========================================================================
 
-$spinner-default-color: $secondary-color !default;
+$spinner-default-color: $accent-color !default;
 
 
 // 17. Tabs
@@ -306,14 +306,14 @@ $interval-size: $range / $intervals !default;
 
 $collection-border-color: #e0e0e0 !default;
 $collection-bg-color: #fff !default;
-$collection-active-bg-color: $secondary-color !default;
-$collection-active-color: lighten($secondary-color, 55%) !default;
+$collection-active-bg-color: $accent-color !default;
+$collection-active-color: lighten($accent-color, 55%) !default;
 $collection-hover-bg-color: #ddd !default;
-$collection-link-color: $secondary-color !default;
+$collection-link-color: $accent-color !default;
 $collection-line-height: 1.5rem !default;
 
 
 // 24. Progress Bar
 // ==========================================================================
 
-$progress-bar-color: $secondary-color !default;
+$progress-bar-color: $accent-color !default;

--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -179,8 +179,8 @@ form p:last-child {
       top: 0;
       width: 20px;
       height: 20px;
-      border: 2px solid $secondary-color;
-      background-color: $secondary-color;
+      border: 2px solid $accent-color;
+      background-color: $accent-color;
       z-index: 0;
     }
   }
@@ -194,8 +194,8 @@ form p:last-child {
 
   &.tabbed:checked:focus + label:after {
     border-radius: 2px;
-    background-color: $secondary-color;
-    border-color: $secondary-color;
+    background-color: $accent-color;
+    border-color: $accent-color;
   }
 
   // Disabled style


### PR DESCRIPTION
…with Material Design Guidelines. Added global classes for primary-color, primary-color, primary-color-light, primary-color-dark, accent-color along with their text equivalents.