### PR TITLE
Show result in autocomplete even if equal to query

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -363,8 +363,7 @@
               if (val.length >= options.minLength) {
                 for(var key in data) {
                   if (data.hasOwnProperty(key) &&
-                      key.toLowerCase().indexOf(val) !== -1 &&
-                      key.toLowerCase() !== val) {
+                      key.toLowerCase().indexOf(val) !== -1) {
                     // Break if past limit
                     if (count >= options.limit) {
                       break;


### PR DESCRIPTION
In the autocomplete plugin, when you type the whole word you want to select, it just disappears form the suggestions, making it impossible to select.

Check out [this jsFiddle](https://jsfiddle.net/gfa496sj/) for a full example with a more detailed explanation.