### PR TITLE
Append the modal-overlay to parent

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -90,7 +90,9 @@
           $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
           $modal.addClass('open');
 
-          $("body").append($overlay);
+          /*$("body").append($overlay);*/
+	  // append the modal-overlay to parent
+	  $(this).parent().append($overlay);
 
           if (options.dismissible) {
             $overlay.click(function() {


### PR DESCRIPTION
I am working in a component based project, and there was a problem in modal-overlay when the modal is appended inside some div. I found a possible [solution](http://stackoverflow.com/questions/34832811/materialize-modal-overlay-the-whole-page-the-modal-popup-was-not-brought-to-for) to my problem on stack, but it will be too messy if I put all the modals in my index. I think its good to have this modal elements inside my component.