### PR TITLE
Add options for range selector

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -180,7 +180,7 @@
     *  Range Input  *
     ****************/
 
-    var range_type = 'input[type=range]';
+    var range_type = Materialize.options.rangeSelector;
     var range_mousedown = false;
     var left;
 

--- a/js/global.js
+++ b/js/global.js
@@ -1,9 +1,19 @@
 // Required for Meteor package, the use of window prevents export by Meteor
 (function(window){
-  if(window.Package){
-    Materialize = {};
+  var defaultOptions = {
+    options: {
+      rangeSelector: 'input[type=range]'
+    }
+  };
+  
+  if (typeof Materialize === 'object') {
+    $.extend(true, defaultOptions, Materialize);
+  }
+  
+  if (window.Package) {
+    Materialize = defaultOptions;
   } else {
-    window.Materialize = {};
+    window.Materialize = defaultOptions;
   }
 })(window);
 


### PR DESCRIPTION
`Materialize` range thumb make other UI (like `plyr`) has a unexpected thumb, see [This Demo](http://codepen.io/steelywing/pen/JWLvOP) (drag the seek bar or volume).
