### PR TITLE
Fixed missing modal-trigger class in documentation

### DIFF
--- a/modals.html
+++ b/modals.html
@@ -191,7 +191,7 @@
           <h4>Modals HTML Structure</h4>
           <pre><code class="language-markup">
   &lt;!-- Modal Trigger -->
-  &lt;a class="waves-effect waves-light btn" href="#modal1">Modal&lt;/a>
+  &lt;a class="modal-trigger waves-effect waves-light btn" href="#modal1">Modal&lt;/a>
 
   &lt;!-- Modal Structure -->
   &lt;div id="modal1" class="modal">


### PR DESCRIPTION
First example in documentation of modals was missing the `modal-trigger` class in the Modal Trigger.