### PR TITLE
RTL Support

### DIFF
--- a/sass/components/rtl_support/_badges.scss
+++ b/sass/components/rtl_support/_badges.scss
@@ -1,0 +1,17 @@
+// RTL Badges
+.rtl {
+	span.badge {
+		margin-left: initial;
+		margin-right: 14px;
+		float: left;
+
+		&.new:after {
+			content: " جدید";
+		}
+	}
+
+	nav ul a span.badge {
+		margin-left: initial;
+		margin-right: 4px;
+	}
+}

--- a/sass/components/rtl_support/_badges.scss
+++ b/sass/components/rtl_support/_badges.scss
@@ -4,10 +4,6 @@
 		margin-left: initial;
 		margin-right: 14px;
 		float: left;
-
-		&.new:after {
-			content: " جدید";
-		}
 	}
 
 	nav ul a span.badge {

--- a/sass/components/rtl_support/_buttons.scss
+++ b/sass/components/rtl_support/_buttons.scss
@@ -1,0 +1,40 @@
+// RTL Buttons
+.rtl {
+	// Floating button
+	.btn-floating {
+		&.halfway-fab {
+			&.left {
+				left: auto;
+				right: 24px;
+			}
+			left: 24px;
+			right: initial;
+		}
+	}
+	// Fixed Action Button
+	.fixed-action-btn {
+
+		&.horizontal {
+			padding: 0 15px 0 0;
+
+			ul {
+				text-align: left;
+				right: auto;
+				left: 64px;
+				transform: translateY(50%);
+				/*width 100% only goes to width of button container */
+				li {
+					margin: 15px 0 0 15px;
+				}
+			}
+		}
+
+		left: 23px;
+		right: initial;
+
+		.fab-backdrop {
+			left: initial;
+			right: 0;
+		}
+	}
+}

--- a/sass/components/rtl_support/_cards.scss
+++ b/sass/components/rtl_support/_cards.scss
@@ -1,0 +1,30 @@
+// RTL Cards
+.card.rtl, .rtl .card {
+	// Horizontal Cards
+	&.horizontal {
+		.card-image {
+			img {
+				border-radius: 0 2px 2px 0;
+			}
+		}
+	}
+
+	.card-image {
+		.card-title {
+			left: initial;
+			right: 0;
+		}
+	}
+
+	.card-action {
+		a:not(.btn):not(.btn-large):not(.btn-floating) {
+			margin-left: $card-padding;
+			margin-right: initial;
+		}
+	}
+
+	.card-reveal {
+		left: initial;
+		right: 0;
+	}
+}

--- a/sass/components/rtl_support/_chips.scss
+++ b/sass/components/rtl_support/_chips.scss
@@ -1,0 +1,25 @@
+// RTL Chips
+.rtl {
+	.chip {
+		margin-left: $chip-margin;
+		margin-right: initial;
+
+		img {
+			float: right;
+			margin: 0 -12px 0 8px;
+		}
+
+		.close,
+		.icon {
+			float: left;
+			padding-left: initial;
+			padding-right: 8px;
+		}
+	}
+
+	// Form prefix
+	.prefix ~ .chips {
+		margin-left: initial;
+		margin-right: 3rem;
+	}
+}

--- a/sass/components/rtl_support/_collapsible.scss
+++ b/sass/components/rtl_support/_collapsible.scss
@@ -1,0 +1,20 @@
+// RTL Collapsible
+.rtl {
+	.collapsible-header {
+		i {
+			float: right;
+			margin-left: 1rem;
+			margin-right: initial;
+		}
+	}
+
+	// sideNav collapsible styling
+	.side-nav,
+	.side-nav.fixed {
+		.collapsible-body {
+			li a {
+				padding: 0 (15px + $sidenav-padding) 0 (7.5px + $sidenav-padding);
+			}
+		}
+	}
+}

--- a/sass/components/rtl_support/_dropdown.scss
+++ b/sass/components/rtl_support/_dropdown.scss
@@ -1,0 +1,22 @@
+// RTL Dropdown
+.rtl {
+	.dropdown-content {
+		li {
+			text-align: right;
+
+			& > span > label {
+				right: 0;
+			}
+			// Icon alignment override
+			& > a > i {
+				float: right;
+				margin: 0 0 0 24px;
+			}
+		}
+	}
+
+	// Input field specificity bugfix
+	.input-field.col .dropdown-content [type="checkbox"] + label {
+		right: 0;
+	}
+}

--- a/sass/components/rtl_support/_global.scss
+++ b/sass/components/rtl_support/_global.scss
@@ -48,6 +48,8 @@
 		}
 
 		thead {
+			float: right;
+
 			tr {
 				padding: 0 0 0 10px;
 			}

--- a/sass/components/rtl_support/_global.scss
+++ b/sass/components/rtl_support/_global.scss
@@ -1,0 +1,119 @@
+//Default styles
+.rtl {
+	ul {
+		&:not(.browser-default) {
+			padding-left: initial;
+			padding-right: 0;
+		}
+	}
+}
+
+//  Blockquote
+.rtl {
+	blockquote {
+		padding-left: initial;
+		padding-right: 1.5rem;
+		border-left: initial;
+		border-right: 5px solid $primary-color;
+	}
+}
+
+// Breadcrumbs
+.breadcrumb.rtl, .rtl .breadcrumb {
+	[class*="mdi-"],
+	[class^="mdi-"],
+	i,
+	i.material-icons {
+		float: right;
+	}
+
+	&:before {
+		content: '\E408';
+		margin: 0 8px 0 10px;
+	}
+}
+
+// Tables
+.rtl {
+	td,
+	th {
+		text-align: right;
+	}
+}
+// Responsive Table
+@media #{$medium-and-down} {
+	table.rtl.responsive-table, .rtl table.responsive-table {
+		th {
+			text-align: right;
+		}
+
+		thead {
+			tr {
+				padding: 0 0 0 10px;
+			}
+		}
+
+		th {
+			text-align: left;
+		}
+
+		td {
+			text-align: right;
+		}
+
+		/* sort out borders */
+		thead {
+			border-left: 1px solid $table-border-color;
+			border-right: initial;
+		}
+
+		&.bordered {
+			th {
+				border-left: initial;
+				border-right: 0;
+			}
+
+			tbody tr {
+				border-left: 1px solid $table-border-color;
+				border-right: initial;
+			}
+		}
+	}
+}
+
+// Collections
+.collection.rtl, .rtl .collection {
+	.collection-item {
+		// Avatar Collection
+		&.avatar {
+			padding-left: initial;
+			padding-right: 72px;
+
+			.circle {
+				left: initial;
+				right: 15px;
+			}
+
+			.secondary-content {
+				left: 16px;
+				right: initial;
+			}
+		}
+	}
+	&.with-header {
+		.collection-item {
+			padding-left: initial;
+			padding-right: 30px;
+		}
+
+		.collection-item.avatar {
+			padding-left: initial;
+			padding-right: 72px;
+		}
+	}
+}
+
+// Made less specific to allow easier overriding
+.secondary-content.rtl, .rtl .secondary-content {
+	float: left;
+}

--- a/sass/components/rtl_support/_grid.scss
+++ b/sass/components/rtl_support/_grid.scss
@@ -1,0 +1,93 @@
+// RTL Grid
+.row.rtl, .rtl .row {
+	.col {
+		float: right;
+		$i: 1;
+		@while $i <= $num-cols {
+			$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+			&.s#{$i} {
+				margin-right: auto;
+			}
+			$i: $i + 1;
+		}
+		$i: 1;
+		@while $i <= $num-cols {
+			$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+			&.offset-s#{$i} {
+				margin-right: $perc;
+			}
+
+			&.pull-s#{$i} {
+				left: $perc;
+			}
+
+			&.push-s#{$i} {
+				right: $perc;
+			}
+			$i: $i + 1;
+		}
+		@media #{$medium-and-up} {
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.m#{$i} {
+					margin-right: auto;
+				}
+				$i: $i + 1;
+			}
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.offset-m#{$i} {
+					margin-right: $perc;
+				}
+
+				&.pull-m#{$i} {
+					left: $perc;
+				}
+
+				&.push-m#{$i} {
+					right: $perc;
+				}
+				$i: $i + 1;
+			}
+		}
+		@media #{$large-and-up} {
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.l#{$i} {
+					margin-right: auto;
+				}
+				$i: $i + 1;
+			}
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.offset-l#{$i} {
+					margin-right: $perc;
+				}
+
+				&.pull-l#{$i} {
+					left: $perc;
+				}
+
+				&.push-l#{$i} {
+					right: $perc;
+				}
+				$i: $i + 1;
+			}
+		}
+	}
+	&.reverse > {
+		.col {
+			float: left;
+		}
+	}
+}

--- a/sass/components/rtl_support/_grid.scss
+++ b/sass/components/rtl_support/_grid.scss
@@ -1,118 +1,92 @@
 // RTL Grid
-.row.rtl, .rtl .row {
+// Mixins to eliminate code repitition
+@mixin reset-offset {
+	margin-right: auto;
+}
+@mixin grid-classes($size, $i, $perc) {
+	&.offset-#{$size}#{$i} {
+		margin-right: $perc;
+	}
+
+	&.pull-#{$size}#{$i} {
+		left: $perc;
+	}
+
+	&.push-#{$size}#{$i} {
+		right: $perc;
+	}
+}
+
+.row.rtl,
+.rtl .row {
+
 	.col {
 		float: right;
+
 		$i: 1;
 		@while $i <= $num-cols {
-			$perc: unquote((100 / ($num-cols / $i)) + "%");
 
 			&.s#{$i} {
-				margin-right: auto;
+				@include reset-offset;
 			}
 			$i: $i + 1;
 		}
 		$i: 1;
 		@while $i <= $num-cols {
 			$perc: unquote((100 / ($num-cols / $i)) + "%");
-
-			&.offset-s#{$i} {
-				margin-right: $perc;
-			}
-
-			&.pull-s#{$i} {
-				left: $perc;
-			}
-
-			&.push-s#{$i} {
-				right: $perc;
-			}
+			@include grid-classes("s", $i, $perc);
 			$i: $i + 1;
 		}
 		@media #{$medium-and-up} {
 			$i: 1;
 			@while $i <= $num-cols {
-				$perc: unquote((100 / ($num-cols / $i)) + "%");
 
 				&.m#{$i} {
-					margin-right: auto;
+					@include reset-offset;
 				}
 				$i: $i + 1;
 			}
 			$i: 1;
 			@while $i <= $num-cols {
 				$perc: unquote((100 / ($num-cols / $i)) + "%");
-
-				&.offset-m#{$i} {
-					margin-right: $perc;
-				}
-
-				&.pull-m#{$i} {
-					left: $perc;
-				}
-
-				&.push-m#{$i} {
-					right: $perc;
-				}
+				@include grid-classes("m", $i, $perc);
 				$i: $i + 1;
 			}
 		}
 		@media #{$large-and-up} {
 			$i: 1;
 			@while $i <= $num-cols {
-				$perc: unquote((100 / ($num-cols / $i)) + "%");
 
 				&.l#{$i} {
-					margin-right: auto;
+					@include reset-offset;
 				}
 				$i: $i + 1;
 			}
 			$i: 1;
 			@while $i <= $num-cols {
 				$perc: unquote((100 / ($num-cols / $i)) + "%");
-
-				&.offset-l#{$i} {
-					margin-right: $perc;
-				}
-
-				&.pull-l#{$i} {
-					left: $perc;
-				}
-
-				&.push-l#{$i} {
-					right: $perc;
-				}
+				@include grid-classes("l", $i, $perc);
 				$i: $i + 1;
 			}
 		}
 		@media #{$extra-large-and-up} {
 			$i: 1;
 			@while $i <= $num-cols {
-				$perc: unquote((100 / ($num-cols / $i)) + "%");
 
 				&.xl#{$i} {
-					margin-right: auto;
+					@include reset-offset;
 				}
 				$i: $i + 1;
 			}
 			$i: 1;
 			@while $i <= $num-cols {
 				$perc: unquote((100 / ($num-cols / $i)) + "%");
-
-				&.offset-xl#{$i} {
-					margin-right: $perc;
-				}
-
-				&.pull-xl#{$i} {
-					left: $perc;
-				}
-
-				&.push-xl#{$i} {
-					right: $perc;
-				}
+				@include grid-classes("xl", $i, $perc);
 				$i: $i + 1;
 			}
 		}
 	}
+
 	&.reverse > {
 		.col {
 			float: left;

--- a/sass/components/rtl_support/_grid.scss
+++ b/sass/components/rtl_support/_grid.scss
@@ -84,6 +84,34 @@
 				$i: $i + 1;
 			}
 		}
+		@media #{$extra-large-and-up} {
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.xl#{$i} {
+					margin-right: auto;
+				}
+				$i: $i + 1;
+			}
+			$i: 1;
+			@while $i <= $num-cols {
+				$perc: unquote((100 / ($num-cols / $i)) + "%");
+
+				&.offset-xl#{$i} {
+					margin-right: $perc;
+				}
+
+				&.pull-xl#{$i} {
+					left: $perc;
+				}
+
+				&.push-xl#{$i} {
+					right: $perc;
+				}
+				$i: $i + 1;
+			}
+		}
 	}
 	&.reverse > {
 		.col {

--- a/sass/components/rtl_support/_modal.scss
+++ b/sass/components/rtl_support/_modal.scss
@@ -1,0 +1,9 @@
+// RTL Modal
+.modal.rtl {
+	.modal-footer {
+		.btn,
+		.btn-flat {
+			float: left;
+		}
+	}
+}

--- a/sass/components/rtl_support/_navbar.scss
+++ b/sass/components/rtl_support/_navbar.scss
@@ -16,6 +16,11 @@ nav.rtl, .rtl nav {
             margin-right: initial;
         }
 
+		@media #{$medium-and-down} {
+			right: 50%;
+			transform: translateX(50%);
+		}
+
         &.left {
             left: 0.5rem;
             right: auto;

--- a/sass/components/rtl_support/_navbar.scss
+++ b/sass/components/rtl_support/_navbar.scss
@@ -1,0 +1,30 @@
+// RTL Navbar
+nav.rtl, .rtl nav {
+    // Collapse button
+    .button-collapse {
+        float: right;
+    }
+    // Logo
+    .brand-logo {
+        [class*="mdi-"],
+        [class^="mdi-"],
+        i,
+        i.material-icons {
+            float: right;
+            margin-left: 15px;
+            margin-right: initial;
+        }
+    }
+    // Navbar Search Form
+    .input-field {
+        input {
+            padding-left: initial;
+            padding-right: 2rem;
+        }
+
+        label {
+            left: initial;
+            right: 0;
+        }
+    }
+}

--- a/sass/components/rtl_support/_navbar.scss
+++ b/sass/components/rtl_support/_navbar.scss
@@ -6,6 +6,7 @@ nav.rtl, .rtl nav {
     }
     // Logo
     .brand-logo {
+
         [class*="mdi-"],
         [class^="mdi-"],
         i,
@@ -15,8 +16,16 @@ nav.rtl, .rtl nav {
             margin-right: initial;
         }
     }
+    // Navbar Links
+    ul {
+
+        li {
+            float: right;
+        }
+    }
     // Navbar Search Form
     .input-field {
+
         input {
             padding-left: initial;
             padding-right: 2rem;

--- a/sass/components/rtl_support/_navbar.scss
+++ b/sass/components/rtl_support/_navbar.scss
@@ -15,6 +15,11 @@ nav.rtl, .rtl nav {
             margin-left: 15px;
             margin-right: initial;
         }
+
+        &.left {
+            left: 0.5rem;
+            right: auto;
+        }
     }
     // Navbar Links
     ul {

--- a/sass/components/rtl_support/_rtl.scss
+++ b/sass/components/rtl_support/_rtl.scss
@@ -1,0 +1,29 @@
+// Direction Helpers
+.rtl {
+	direction: rtl;
+}
+
+.ltr {
+	direction: ltr;
+}
+
+// components
+@import "global";
+@import "badges";
+@import "grid";
+@import "navbar";
+@import "typography";
+@import "cards";
+@import "buttons";
+@import "dropdown";
+@import "modal";
+@import "collapsible";
+@import "chips";
+@import "forms/forms";
+@import "table_of_contents";
+@import "sideNav";
+//@import "slider";
+//@import "carousel";
+//@import "date_picker/default";
+//@import "date_picker/default.date";
+//@import "date_picker/default.time";

--- a/sass/components/rtl_support/_sideNav.scss
+++ b/sass/components/rtl_support/_sideNav.scss
@@ -1,0 +1,10 @@
+// RTL SideNav
+.side-nav.rtl, .rtl .side-nav {
+	li > a > [class*="mdi-"],
+	li > a > [class^="mdi-"],
+	li > a > i,
+	li > a > i.material-icons {
+		float: right;
+		margin: 0 0 0 ($sidenav-padding * 2);
+	}
+}

--- a/sass/components/rtl_support/_sideNav.scss
+++ b/sass/components/rtl_support/_sideNav.scss
@@ -1,5 +1,8 @@
 // RTL SideNav
 .side-nav.rtl, .rtl .side-nav {
+	li {
+		float: none;
+	}
 	li > a > [class*="mdi-"],
 	li > a > [class^="mdi-"],
 	li > a > i,

--- a/sass/components/rtl_support/_table_of_contents.scss
+++ b/sass/components/rtl_support/_table_of_contents.scss
@@ -1,0 +1,21 @@
+// RTL Table of Contents
+.table-of-contents.rtl, .rtl .table-of-contents {
+	a {
+		padding-left: initial;
+		padding-right: 20px;
+
+		&:hover {
+			padding-left: initial;
+			padding-right: 19px;
+			border-left: initial;
+			border-right: 1px solid $primary-color;
+		}
+
+		&.active {
+			padding-left: initial;
+			padding-right: 18px;
+			border-left: initial;
+			border-right: 2px solid $primary-color;
+		}
+	}
+}

--- a/sass/components/rtl_support/_typography.scss
+++ b/sass/components/rtl_support/_typography.scss
@@ -1,0 +1,28 @@
+// RTL Typography (Smaller Text)
+html {
+    line-height: 1.5;
+    @media only screen and (min-width: 0) {
+        font-size: 12.5px;
+    }
+    @media only screen and (min-width: $medium-screen) {
+        font-size: 13px;
+    }
+    @media only screen and (min-width: $large-screen) {
+        font-size: 14.5px;
+    }
+}
+
+.flow-text {
+    font-weight: 300;
+    $i: 0;
+    @while $i <= $intervals {
+         @media only screen and (min-width : 360 + ($i * $interval-size)){
+            font-size: 1.1rem * (1 + (.02 * $i));
+        }
+        $i: $i + 1;
+    }
+    // Handle below 360px screen
+    @media only screen and (max-width: 360px) {
+        font-size: 1.1rem;
+    }
+}

--- a/sass/components/rtl_support/forms/_checkboxes.scss
+++ b/sass/components/rtl_support/forms/_checkboxes.scss
@@ -26,14 +26,7 @@
 	[type="checkbox"]:checked {
 		+ label:before {
 			left: initial;
-			right: -5px;
-			border-left: $radio-border;
-			border-right: 2px solid transparent;
-			transform: rotate(40deg);
-		}
-
-		&:disabled + label:before {
-			border-left: 2px solid $input-disabled-color;
+			right: 5px;
 		}
 	}
 	/* Indeterminate checkbox */
@@ -41,9 +34,6 @@
 		+label:before {
 			left: initial;
 			right: -12px;
-			border-left: $radio-border;
-			border-right: none;
-			transform: rotate(90deg);
 		}
 		// Disabled indeterminate
 		&:disabled + label:before {
@@ -62,10 +52,6 @@
 		&:not(:checked) + label:before {
 			left: initial;
 			right: 6px;
-			-webkit-transform: rotateZ(37deg);
-			transform: rotateZ(37deg);
-			-webkit-transform-origin: 20% 40%;
-			transform-origin: 100% 100%;
 		}
 
 		// Checked style
@@ -73,10 +59,6 @@
 			+ label:before {
 				left: initial;
 				right: 1px;
-				border-left: 2px solid $input-background;
-				border-right: 2px solid transparent;
-				-webkit-transform: rotateZ(37deg);
-				transform: rotateZ(37deg);
 			}
 		}
 	}

--- a/sass/components/rtl_support/forms/_checkboxes.scss
+++ b/sass/components/rtl_support/forms/_checkboxes.scss
@@ -1,0 +1,83 @@
+/* Checkboxes
+   ========================================================================== */
+
+.rtl {
+	/* CUSTOM CSS CHECKBOXES */
+	form p {
+		text-align: right;
+	}
+
+	// Checkbox Styles
+	[type="checkbox"] {
+		// Text Label Style
+		+ label {
+			padding-left: initial;
+			padding-right: 35px;
+		}
+
+		/* checkbox aspect */
+		 &:not(.filled-in) + label:after,
+		+ label:before {
+			left: initial;
+			right: 0;
+		}
+	}
+
+	[type="checkbox"]:checked {
+		+ label:before {
+			left: initial;
+			right: -5px;
+			border-left: $radio-border;
+			border-right: 2px solid transparent;
+			transform: rotate(40deg);
+		}
+
+		&:disabled + label:before {
+			border-left: 2px solid $input-disabled-color;
+		}
+	}
+	/* Indeterminate checkbox */
+	[type="checkbox"]:indeterminate {
+		+label:before {
+			left: initial;
+			right: -12px;
+			border-left: $radio-border;
+			border-right: none;
+			transform: rotate(90deg);
+		}
+		// Disabled indeterminate
+		&:disabled + label:before {
+			border-left: 2px solid $input-disabled-color;
+		}
+	}
+	// Filled in Style
+	[type="checkbox"].filled-in {
+		// General
+		+ label:after,
+		+ label:before {
+			left: initial;
+			right: 0;
+		}
+		// Unchecked style
+		&:not(:checked) + label:before {
+			left: initial;
+			right: 6px;
+			-webkit-transform: rotateZ(37deg);
+			transform: rotateZ(37deg);
+			-webkit-transform-origin: 20% 40%;
+			transform-origin: 100% 100%;
+		}
+
+		// Checked style
+		&:checked {
+			+ label:before {
+				left: initial;
+				right: 1px;
+				border-left: 2px solid $input-background;
+				border-right: 2px solid transparent;
+				-webkit-transform: rotateZ(37deg);
+				transform: rotateZ(37deg);
+			}
+		}
+	}
+}

--- a/sass/components/rtl_support/forms/_file-input.scss
+++ b/sass/components/rtl_support/forms/_file-input.scss
@@ -1,0 +1,14 @@
+/* File Input
+   ========================================================================== */
+.rtl {
+	.file-field {
+		.file-path-wrapper {
+			padding-left: initial;
+			padding-right: 10px;
+		}
+
+		.btn {
+			float: right;
+		}
+	}
+}

--- a/sass/components/rtl_support/forms/_forms.scss
+++ b/sass/components/rtl_support/forms/_forms.scss
@@ -1,0 +1,7 @@
+@import 'input-fields';
+@import 'radio-buttons';
+@import 'checkboxes';
+//@import 'switches';
+@import 'select';
+@import 'file-input';
+//@import 'range';

--- a/sass/components/rtl_support/forms/_input-fields.scss
+++ b/sass/components/rtl_support/forms/_input-fields.scss
@@ -23,6 +23,10 @@
 			right: 0;
 		}
 		// Prefix Icons
+		.prefix {
+			text-align: right;
+		}
+
 		.prefix ~ .autocomplete-content,
 		.prefix ~ .validate ~ label,
 		.prefix ~ input,
@@ -30,7 +34,6 @@
 		.prefix ~ textarea {
 			margin-left: initial;
 			margin-right: 3rem;
-			text-align: right;
 		}
 
 		.prefix ~ label {

--- a/sass/components/rtl_support/forms/_input-fields.scss
+++ b/sass/components/rtl_support/forms/_input-fields.scss
@@ -1,0 +1,57 @@
+/* Text Inputs + Textarea
+   ========================================================================== */
+
+.rtl {
+	/* Text inputs */
+	// Styling for input field wrapper
+	.input-field {
+		// Inline styles
+		&.inline {
+			margin-left: initial;
+			margin-right: 5px;
+		}
+		// Gutter spacing
+		&.col {
+			label {
+				left: initial;
+				right: $gutter-width / 2;
+			}
+		}
+
+		label {
+			left: initial;
+			right: 0;
+		}
+		// Prefix Icons
+		.prefix ~ .autocomplete-content,
+		.prefix ~ .validate ~ label,
+		.prefix ~ input,
+		.prefix ~ label,
+		.prefix ~ textarea {
+			margin-left: initial;
+			margin-right: 3rem;
+			text-align: right;
+		}
+
+		.prefix ~ label {
+			margin-left: initial;
+			margin-right: 3rem;
+		}
+	}
+	/* Search Field */
+	.input-field input[type=search] {
+		padding-left: initial;
+		padding-right: 4rem;
+
+		& + label {
+			left: initial;
+			right: 1rem;
+		}
+
+		& ~ .material-icons,
+		& ~ .mdi-navigation-close {
+			right: initial;
+			left: 1rem;
+		}
+	}
+}

--- a/sass/components/rtl_support/forms/_radio-buttons.scss
+++ b/sass/components/rtl_support/forms/_radio-buttons.scss
@@ -1,0 +1,18 @@
+/* Radio Buttons
+   ========================================================================== */
+
+.rtl {
+	[type="radio"]:checked + label,
+	[type="radio"]:not(:checked) + label {
+		padding-left: initial;
+		padding-right: 35px;
+		margin-right: initial;
+		margin-left: 15px;
+	}
+
+	[type="radio"] + label:after,
+	[type="radio"] + label:before {
+		left: initial;
+		right: 0;
+	}
+}

--- a/sass/components/rtl_support/forms/_select.scss
+++ b/sass/components/rtl_support/forms/_select.scss
@@ -1,0 +1,33 @@
+/* Select Field
+   ========================================================================== */
+.rtl {
+	.select-wrapper {
+		span.caret {
+			right: initial;
+			left: 0;
+		}
+	}
+	// Prefix Icons
+	.prefix ~ .select-wrapper {
+		margin-left: initial;
+		margin-right: 3rem;
+	}
+
+	.prefix ~ label {
+		margin-left: initial;
+		margin-right: 3rem;
+	}
+	// Icons
+	.select-dropdown li {
+		img {
+			float: left;
+		}
+	}
+	// Optgroup styles
+	.select-dropdown li.optgroup {
+		& ~ li.optgroup-option {
+			padding-left: initial;
+			padding-right: 1rem;
+		}
+	}
+}

--- a/sass/materialize.scss
+++ b/sass/materialize.scss
@@ -42,3 +42,4 @@
 @import "components/date_picker/default";
 @import "components/date_picker/default.date";
 @import "components/date_picker/default.time";
+@import "components/rtl_support/rtl";


### PR DESCRIPTION
### RTL Support as a component
All scss modifications related to RTL support are placed in sass/components/rtl_support.
It works out of the box for almost every component and element by just adding .rtl class to their container parents.

My goal was to add RTL support alongside the vanilla LTR base at the same time with no conflicts, which can be useful for multi-language web designs.

**These components are not supported yet** (might not even need to be!)**:**
* forms/range
* slider
* carousel
* date_picker/default
* date_picker/default.date
* date_picker/default.time
