### PR TITLE
Add interactive playgrounds to documentation

### DIFF
--- a/color.html
+++ b/color.html
@@ -148,27 +148,6 @@
         </div>
       </div>
 
-      <div id="sass" class="section scrollspy">
-        <h2 class="header">Sass</h2>
-        <p>
-        For background colors, you can apply the color simply by extending the classes like the example below.
-        </p>
-        <pre><code class="language-scss col s12">
-  .ilike-blue-container {
-    @extend .blue, .lighten-4;
-  }
-        </code></pre>
-
-        <p>
-        For changing text color, you can apply the color simply by extending the classes like the example below.
-        </p>
-        <pre><code class="language-scss col s12">
-  .ilike-blue-container {
-    @extend .blue-text, .text-lighten-4;
-  }
-        </code></pre>
-      </div>
-
       <div id="playground" class="section scrollspy">
         <h2 class="header">Try It</h2>
         
@@ -188,6 +167,27 @@
             playgroundElement.className = playgroundElement.getAttribute("data-initial-class") + playgroundInput.value;
         });
         </script>
+      </div>
+
+      <div id="sass" class="section scrollspy">
+        <h2 class="header">Sass</h2>
+        <p>
+        For background colors, you can apply the color simply by extending the classes like the example below.
+        </p>
+        <pre><code class="language-scss col s12">
+  .ilike-blue-container {
+    @extend .blue, .lighten-4;
+  }
+        </code></pre>
+
+        <p>
+        For changing text color, you can apply the color simply by extending the classes like the example below.
+        </p>
+        <pre><code class="language-scss col s12">
+  .ilike-blue-container {
+    @extend .blue-text, .text-lighten-4;
+  }
+        </code></pre>
       </div>
       <div id="palette" class="section scrollspy">
 

--- a/color.html
+++ b/color.html
@@ -168,6 +168,27 @@
   }
         </code></pre>
       </div>
+
+      <div id="playground" class="section scrollspy">
+        <h2 class="header">Try It</h2>
+        
+        <p>Modify the classes below to test colors.</p>
+
+        <div id="playground-element" class="card-panel indigo darken-1 white-text" data-initial-class="card-panel ">Sample text</div>
+        <br>
+        <div class="input-field">
+            <input value="indigo darken-1 white-text" id="playground-div-class-input" class="active" type="text">
+            <label for="playground-div-class-input">Class</label>
+        </div>
+        <script>
+        var playgroundInput = document.getElementById("playground-div-class-input");
+        var playgroundElement = document.getElementById("playground-element");
+
+        playgroundInput.addEventListener("input", function() {
+            playgroundElement.className = playgroundElement.getAttribute("data-initial-class") + playgroundInput.value;
+        });
+        </script>
+      </div>
       <div id="palette" class="section scrollspy">
 
         <h2 class="header">Color Palette</h2>
@@ -485,6 +506,7 @@
         <div style="height: 1px;">
           <ul class="section table-of-contents">
             <li><a href="#color-usage">Usage</a></li>
+            <li><a href="#playground">Try It</a></li>
             <li><a href="#sass">Sass</a></li>
             <li><a href="#palette">Color Palette</a></li>
           </ul>

--- a/grid.html
+++ b/grid.html
@@ -219,13 +219,17 @@
           <h4>Columns live inside Rows</h4>
           <p>Remember when you are creating your layout that all columns must be contained inside a row and that you must add the <code class="language-markup">col</code> class to your inner divs to make them into columns</p>
           <div class="row">
-            <div class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes</span></div>
-            <div class="col s6 grid-example"><span class="flow-text">6-columns (one-half)</span></div>
-            <div class="col s6 grid-example"><span class="flow-text">6-columns (one-half)</span></div>
+            <div data-initial-class="grid-example col " class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes (<span class="editable-grid-example">col s12</span>)</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example col " class="col s6 grid-example"><span class="flow-text">6-columns (one-half) (<span class="editable-grid-example">col s6</span>)</span></div>
+            <div data-initial-class="grid-example col " class="col s6 grid-example"><span class="flow-text">6-columns (one-half) (<span class="editable-grid-example">col s6</span>)</span></div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
       &lt;div class="col s12">This div is 12-columns wide&lt;/div>
+    &lt;/div>
+    &lt;div class="row">
       &lt;div class="col s6">This div is 6-columns wide&lt;/div>
       &lt;div class="col s6">This div is 6-columns wide&lt;/div>
     &lt;/div>
@@ -238,13 +242,18 @@
         <div id="grid-offsets" class="section scrollspy">
           <h2 class="header">Offsets</h2>
           <p>To offset, simply add <code class="language-markup">offset-s2</code> to the class where <code class="language-markup">s</code> signifies the screen class-prefix (s = small, m = medium, l = large) and the number after is the number of columns you want to offset by.</p>
+          <p>You can edit the values for each column in order to get a feel for them by clicking the class name (ex. <code class="language-markup">col s12</code>)</p>
           <div class="row">
-            <div class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes</span></div>
-            <div class="col s6 offset-s6 grid-example"><span class="flow-text">6-columns (offset-by-6)</span></div>
+            <div data-initial-class="grid-example col " class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes (<span class="editable-grid-example">col s12</span>)</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example col " class="col s6 offset-s6 grid-example"><span class="flow-text">6-columns (offset-by-6) (<span class="editable-grid-example">col s6 offset-s6</span>)</div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
       &lt;div class="col s12">&lt;span class="flow-text">This div is 12-columns wide on all screen sizes&lt;/span>&lt;/div>
+    &lt;/div>
+    &lt;div class="row">
       &lt;div class="col s6 offset-s6">&lt;span class="flow-text">6-columns (offset-by-6)&lt;/span>&lt;/div>
     &lt;/div>
           </code></pre>
@@ -257,8 +266,8 @@
           <h2 class="header">Push and Pull</h2>
           <p>You can easily change the order of your columns with push and pull. Simply add <code class="language-markup">push-s2</code> or <code class="language-markup">pull-s2</code> to the class where <code class="language-markup">s</code> signifies the screen class-prefix (s = small, m = medium, l = large) and the number after is the number of columns you want to push or pull by.</p>
           <div class="row">
-            <div class="col s7 push-s5 grid-example"><span style="font-size: 14px;">This div is 7-columns wide on pushed to the right by 5-columns.</span></div>
-            <div class="col s5 pull-s7 grid-example"><span style="font-size: 14px;">5-columns wide pulled to the left by 7-columns.</span></div>
+            <div data-initial-class="grid-example col " class="col s7 push-s5 grid-example"><span style="font-size: 14px;">This div is 7-columns wide on pushed to the right by 5-columns. (<span class="editable-grid-example">col s7 push-s5</span>)</span></div>
+            <div data-initial-class="grid-example col " class="col s5 pull-s7 grid-example"><span style="font-size: 14px;">5-columns wide pulled to the left by 7-columns. (<span class="editable-grid-example">col s5 pull-s7</span>)</span></div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
@@ -544,14 +553,18 @@
 
           <h4>More Responsive Grid Examples</h4>
           <div class="row">
-            <div class="col grid-example s12 blue lighten-1"><span class="flow-text">s12</span></div>
-            <div class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text">s12 m4 l2</span></div>
-            <div class="col grid-example s12 m4 l8 teal lighten-1"><span class="flow-text">s12 m4 l8</span></div>
-            <div class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text">s12 m4 l2</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example blue lighten-1 col " class="col grid-example s12 blue lighten-1"><span class="editable-grid-example flow-text">s12</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l2</span></div>
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l8 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l8</span></div>
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l2</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
           </div>
           <div class="row">
             <pre><code class="language-markup col s12">
@@ -573,7 +586,7 @@
 
 
         <div id="playground" class="section scrollspy">
-          <h2 class="header">Try It</h2>
+          <h2 class="header">Playground</h2>
           
           <p>Modify the classes below to test colors.</p>
 
@@ -585,11 +598,7 @@
           <div id="add-btn" class="btn">Add</div>
           <div id="rm-btn" class="btn red">Remove</div>
           
-          <script>
-          var playgroundInputs = document.getElementsByClassName("playground-div-class-input");
-          var playgroundInputWrapper = document.getElementById("playground-input-wrapper");
-          var playgroundElements = document.getElementsByClassName("playground-child");
-          var playgroundWrapper = document.getElementById("playground-wrapper");
+          <script defer>
           var addButton = document.getElementById("add-btn");
           var rmButton = document.getElementById("rm-btn");
 
@@ -601,53 +610,28 @@
           addButton.addEventListener("click", addPlaygroundElement);
 
           function addPlaygroundElement(global) {
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundWrapper = document.getElementById("playground-wrapper");
             playgroundElements = document.getElementsByClassName("playground-child");
 
-            var num=playgroundElements.length+1;
             // build element
             var span = document.createElement("span");
             span.className = "flow-text white-text";
-            span.innerHTML = num;
+            span.innerHTML = "col s6 m4 l1";
+            span.contentEditable = true;
+            span.addEventListener("input", updatePremadeExample);
             var element = document.createElement("div");
-            element.id = "playground-child-"+num;
             color = randomPlaygroundColor();
-            element.className = "playground-child col s1 "+color;
-            element.setAttribute("data-initial-class", "playground-child "+color+" ");
+            element.className = "playground-child col s6 m4 l1 "+color;
+            element.setAttribute("data-initial-class", "playground-child "+color+" col ");
             element.appendChild(span);
             playgroundWrapper.appendChild(element);
-
-            // build input
-            var input = document.createElement("input");
-            input.id = "playground-div-class-input-"+num;
-            input.className = "active playground-div-class-input";
-            input.setAttribute("type", "text");
-            input.setAttribute("oninput", "updatePlayground();");
-            input.value = "col s1";
-            var label = document.createElement("label");
-            label.setAttribute("for", input.id);
-            label.innerHTML = "Class (section "+num+")";
-            var inputField = document.createElement("div");
-            inputField.className = "input-field";
-            inputField.id = "input-playground-"+num;
-            inputField.appendChild(input);
-            inputField.appendChild(label);
-            playgroundInputWrapper.appendChild(inputField);
-            Materialize.updateTextFields();
-
-            // reinitialize arrays
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
-            playgroundElements = document.getElementsByClassName("playground-child");
           };
 
           rmButton.addEventListener("click", rmPlaygroundElement);
 
           function rmPlaygroundElement(global) {
-            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
-            playgroundInputs[playgroundInputs.length-1].parentElement.parentElement.removeChild(playgroundInputs[playgroundInputs.length-1].parentElement);
-
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
             playgroundElements = document.getElementsByClassName("playground-child");
+            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
           }
 
           function updatePlayground() {
@@ -657,6 +641,23 @@
           }
 
           addPlaygroundElement(); // create first one
+
+          var editable = document.getElementsByClassName("editable-grid-example");
+          for (var i = 0; i < editable.length; i++) {
+            editable[i].contentEditable = true;
+            editable[i].addEventListener("input", updatePremadeExample);
+          }
+
+          function updatePremadeExample(event) {
+            newClasses = event.target.innerHTML;
+            newClasses = newClasses.replace("col", "");
+            newClasses = newClasses.replace("&nbsp;", " "); // strange bug
+            parent = event.target.parentElement;
+            while (parent.tagName != "DIV") { // for nested spans
+              parent = parent.parentElement;
+            }
+            parent.className = parent.getAttribute("data-initial-class") + newClasses;
+          }
           </script>
         </div>
       </div>
@@ -678,7 +679,7 @@
             <li><a href="#grid-push">Push and Pull</a></li>
             <li><a href="#grid-layouts">Creating Layouts</a></li>
             <li><a href="#grid-responsive">Responsive Layouts</a></li>
-            <li><a href="#playground">Try It</a></li>
+            <li><a href="#playground">Playground</a></li>
           </ul>
         </div>
       </div>

--- a/grid.html
+++ b/grid.html
@@ -570,6 +570,95 @@
             </code></pre>
           </div>
         </div>
+
+
+        <div id="playground" class="section scrollspy">
+          <h2 class="header">Try It</h2>
+          
+          <p>Modify the classes below to test colors.</p>
+
+          <div id="playground-wrapper" class="card-panel row center">
+          </div>
+          <br>
+          <div id="playground-input-wrapper">
+          </div>
+          <div id="add-btn" class="btn">Add</div>
+          <div id="rm-btn" class="btn red">Remove</div>
+          
+          <script>
+          var playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+          var playgroundInputWrapper = document.getElementById("playground-input-wrapper");
+          var playgroundElements = document.getElementsByClassName("playground-child");
+          var playgroundWrapper = document.getElementById("playground-wrapper");
+          var addButton = document.getElementById("add-btn");
+          var rmButton = document.getElementById("rm-btn");
+
+          function randomPlaygroundColor() {
+            var colors = ["red", "pink", "purple", "indigo", "blue", "cyan", "teal", "green", "yellow", "orange"];
+            return colors[Math.floor(Math.random()*colors.length)];
+          };
+
+          addButton.addEventListener("click", addPlaygroundElement);
+
+          function addPlaygroundElement(global) {
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+
+            var num=playgroundElements.length+1;
+            // build element
+            var span = document.createElement("span");
+            span.className = "flow-text white-text";
+            span.innerHTML = num;
+            var element = document.createElement("div");
+            element.id = "playground-child-"+num;
+            color = randomPlaygroundColor();
+            element.className = "playground-child col s1 "+color;
+            element.setAttribute("data-initial-class", "playground-child "+color+" ");
+            element.appendChild(span);
+            playgroundWrapper.appendChild(element);
+
+            // build input
+            var input = document.createElement("input");
+            input.id = "playground-div-class-input-"+num;
+            input.className = "active playground-div-class-input";
+            input.setAttribute("type", "text");
+            input.setAttribute("oninput", "updatePlayground();");
+            input.value = "col s1";
+            var label = document.createElement("label");
+            label.setAttribute("for", input.id);
+            label.innerHTML = "Class (section "+num+")";
+            var inputField = document.createElement("div");
+            inputField.className = "input-field";
+            inputField.id = "input-playground-"+num;
+            inputField.appendChild(input);
+            inputField.appendChild(label);
+            playgroundInputWrapper.appendChild(inputField);
+            Materialize.updateTextFields();
+
+            // reinitialize arrays
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+          };
+
+          rmButton.addEventListener("click", rmPlaygroundElement);
+
+          function rmPlaygroundElement(global) {
+            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
+            playgroundInputs[playgroundInputs.length-1].parentElement.parentElement.removeChild(playgroundInputs[playgroundInputs.length-1].parentElement);
+
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+          }
+
+          function updatePlayground() {
+            for (var i = 0; i < playgroundElements.length; i++) {
+              playgroundElements[i].className = playgroundElements[i].getAttribute("data-initial-class") + playgroundInputs[i].value;
+            }
+          }
+
+          addPlaygroundElement(); // create first one
+          </script>
+        </div>
       </div>
 
 
@@ -589,6 +678,7 @@
             <li><a href="#grid-push">Push and Pull</a></li>
             <li><a href="#grid-layouts">Creating Layouts</a></li>
             <li><a href="#grid-responsive">Responsive Layouts</a></li>
+            <li><a href="#playground">Try It</a></li>
           </ul>
         </div>
       </div>

--- a/jade/page-contents/color_content.html
+++ b/jade/page-contents/color_content.html
@@ -53,6 +53,27 @@
   }
         </code></pre>
       </div>
+
+      <div id="playground" class="section scrollspy">
+        <h2 class="header">Try It</h2>
+        
+        <p>Modify the classes below to test colors.</p>
+
+        <div id="playground-element" class="card-panel indigo darken-1 white-text" data-initial-class="card-panel ">Sample text</div>
+        <br>
+        <div class="input-field">
+            <input value="indigo darken-1 white-text" id="playground-div-class-input" class="active" type="text">
+            <label for="playground-div-class-input">Class</label>
+        </div>
+        <script>
+        var playgroundInput = document.getElementById("playground-div-class-input");
+        var playgroundElement = document.getElementById("playground-element");
+
+        playgroundInput.addEventListener("input", function() {
+            playgroundElement.className = playgroundElement.getAttribute("data-initial-class") + playgroundInput.value;
+        });
+        </script>
+      </div>
       <div id="palette" class="section scrollspy">
 
         <h2 class="header">Color Palette</h2>
@@ -370,6 +391,7 @@
         <div style="height: 1px;">
           <ul class="section table-of-contents">
             <li><a href="#color-usage">Usage</a></li>
+            <li><a href="#playground">Try It</a></li>
             <li><a href="#sass">Sass</a></li>
             <li><a href="#palette">Color Palette</a></li>
           </ul>

--- a/jade/page-contents/color_content.html
+++ b/jade/page-contents/color_content.html
@@ -33,27 +33,6 @@
         </div>
       </div>
 
-      <div id="sass" class="section scrollspy">
-        <h2 class="header">Sass</h2>
-        <p>
-        For background colors, you can apply the color simply by extending the classes like the example below.
-        </p>
-        <pre><code class="language-scss col s12">
-  .ilike-blue-container {
-    @extend .blue, .lighten-4;
-  }
-        </code></pre>
-
-        <p>
-        For changing text color, you can apply the color simply by extending the classes like the example below.
-        </p>
-        <pre><code class="language-scss col s12">
-  .ilike-blue-container {
-    @extend .blue-text, .text-lighten-4;
-  }
-        </code></pre>
-      </div>
-
       <div id="playground" class="section scrollspy">
         <h2 class="header">Try It</h2>
         
@@ -73,6 +52,27 @@
             playgroundElement.className = playgroundElement.getAttribute("data-initial-class") + playgroundInput.value;
         });
         </script>
+      </div>
+
+      <div id="sass" class="section scrollspy">
+        <h2 class="header">Sass</h2>
+        <p>
+        For background colors, you can apply the color simply by extending the classes like the example below.
+        </p>
+        <pre><code class="language-scss col s12">
+  .ilike-blue-container {
+    @extend .blue, .lighten-4;
+  }
+        </code></pre>
+
+        <p>
+        For changing text color, you can apply the color simply by extending the classes like the example below.
+        </p>
+        <pre><code class="language-scss col s12">
+  .ilike-blue-container {
+    @extend .blue-text, .text-lighten-4;
+  }
+        </code></pre>
       </div>
       <div id="palette" class="section scrollspy">
 

--- a/jade/page-contents/grid_content.html
+++ b/jade/page-contents/grid_content.html
@@ -104,13 +104,17 @@
           <h4>Columns live inside Rows</h4>
           <p>Remember when you are creating your layout that all columns must be contained inside a row and that you must add the <code class="language-markup">col</code> class to your inner divs to make them into columns</p>
           <div class="row">
-            <div class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes</span></div>
-            <div class="col s6 grid-example"><span class="flow-text">6-columns (one-half)</span></div>
-            <div class="col s6 grid-example"><span class="flow-text">6-columns (one-half)</span></div>
+            <div data-initial-class="grid-example col " class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes (<span class="editable-grid-example">col s12</span>)</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example col " class="col s6 grid-example"><span class="flow-text">6-columns (one-half) (<span class="editable-grid-example">col s6</span>)</span></div>
+            <div data-initial-class="grid-example col " class="col s6 grid-example"><span class="flow-text">6-columns (one-half) (<span class="editable-grid-example">col s6</span>)</span></div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
       &lt;div class="col s12">This div is 12-columns wide&lt;/div>
+    &lt;/div>
+    &lt;div class="row">
       &lt;div class="col s6">This div is 6-columns wide&lt;/div>
       &lt;div class="col s6">This div is 6-columns wide&lt;/div>
     &lt;/div>
@@ -123,13 +127,18 @@
         <div id="grid-offsets" class="section scrollspy">
           <h2 class="header">Offsets</h2>
           <p>To offset, simply add <code class="language-markup">offset-s2</code> to the class where <code class="language-markup">s</code> signifies the screen class-prefix (s = small, m = medium, l = large) and the number after is the number of columns you want to offset by.</p>
+          <p>You can edit the values for each column in order to get a feel for them by clicking the class name (ex. <code class="language-markup">col s12</code>)</p>
           <div class="row">
-            <div class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes</span></div>
-            <div class="col s6 offset-s6 grid-example"><span class="flow-text">6-columns (offset-by-6)</span></div>
+            <div data-initial-class="grid-example col " class="col s12 grid-example"><span class="flow-text">This div is 12-columns wide on all screen sizes (<span class="editable-grid-example">col s12</span>)</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example col " class="col s6 offset-s6 grid-example"><span class="flow-text">6-columns (offset-by-6) (<span class="editable-grid-example">col s6 offset-s6</span>)</div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
       &lt;div class="col s12">&lt;span class="flow-text">This div is 12-columns wide on all screen sizes&lt;/span>&lt;/div>
+    &lt;/div>
+    &lt;div class="row">
       &lt;div class="col s6 offset-s6">&lt;span class="flow-text">6-columns (offset-by-6)&lt;/span>&lt;/div>
     &lt;/div>
           </code></pre>
@@ -142,8 +151,8 @@
           <h2 class="header">Push and Pull</h2>
           <p>You can easily change the order of your columns with push and pull. Simply add <code class="language-markup">push-s2</code> or <code class="language-markup">pull-s2</code> to the class where <code class="language-markup">s</code> signifies the screen class-prefix (s = small, m = medium, l = large) and the number after is the number of columns you want to push or pull by.</p>
           <div class="row">
-            <div class="col s7 push-s5 grid-example"><span style="font-size: 14px;">This div is 7-columns wide on pushed to the right by 5-columns.</span></div>
-            <div class="col s5 pull-s7 grid-example"><span style="font-size: 14px;">5-columns wide pulled to the left by 7-columns.</span></div>
+            <div data-initial-class="grid-example col " class="col s7 push-s5 grid-example"><span style="font-size: 14px;">This div is 7-columns wide on pushed to the right by 5-columns. (<span class="editable-grid-example">col s7 push-s5</span>)</span></div>
+            <div data-initial-class="grid-example col " class="col s5 pull-s7 grid-example"><span style="font-size: 14px;">5-columns wide pulled to the left by 7-columns. (<span class="editable-grid-example">col s5 pull-s7</span>)</span></div>
           </div>
           <pre><code class="language-markup">
     &lt;div class="row">
@@ -429,14 +438,18 @@
 
           <h4>More Responsive Grid Examples</h4>
           <div class="row">
-            <div class="col grid-example s12 blue lighten-1"><span class="flow-text">s12</span></div>
-            <div class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text">s12 m4 l2</span></div>
-            <div class="col grid-example s12 m4 l8 teal lighten-1"><span class="flow-text">s12 m4 l8</span></div>
-            <div class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text">s12 m4 l2</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
-            <div class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example blue lighten-1 col " class="col grid-example s12 blue lighten-1"><span class="editable-grid-example flow-text">s12</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l2</span></div>
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l8 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l8</span></div>
+            <div data-initial-class="grid-example teal lighten-1 col " class="col grid-example s12 m4 l2 teal lighten-1"><span class="flow-text editable-grid-example">s12 m4 l2</span></div>
+          </div>
+          <div class="row">
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
+            <div data-initial-class="grid-example purple lighten-3 col " class="col grid-example s12 m6 l3 purple lighten-3"><span class="flow-text editable-grid-example">s12 m6 l3</span></div>
           </div>
           <div class="row">
             <pre><code class="language-markup col s12">
@@ -458,7 +471,7 @@
 
 
         <div id="playground" class="section scrollspy">
-          <h2 class="header">Try It</h2>
+          <h2 class="header">Playground</h2>
           
           <p>Modify the classes below to test colors.</p>
 
@@ -470,11 +483,7 @@
           <div id="add-btn" class="btn">Add</div>
           <div id="rm-btn" class="btn red">Remove</div>
           
-          <script>
-          var playgroundInputs = document.getElementsByClassName("playground-div-class-input");
-          var playgroundInputWrapper = document.getElementById("playground-input-wrapper");
-          var playgroundElements = document.getElementsByClassName("playground-child");
-          var playgroundWrapper = document.getElementById("playground-wrapper");
+          <script defer>
           var addButton = document.getElementById("add-btn");
           var rmButton = document.getElementById("rm-btn");
 
@@ -486,53 +495,28 @@
           addButton.addEventListener("click", addPlaygroundElement);
 
           function addPlaygroundElement(global) {
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundWrapper = document.getElementById("playground-wrapper");
             playgroundElements = document.getElementsByClassName("playground-child");
 
-            var num=playgroundElements.length+1;
             // build element
             var span = document.createElement("span");
             span.className = "flow-text white-text";
-            span.innerHTML = num;
+            span.innerHTML = "col s6 m4 l1";
+            span.contentEditable = true;
+            span.addEventListener("input", updatePremadeExample);
             var element = document.createElement("div");
-            element.id = "playground-child-"+num;
             color = randomPlaygroundColor();
-            element.className = "playground-child col s1 "+color;
-            element.setAttribute("data-initial-class", "playground-child "+color+" ");
+            element.className = "playground-child col s6 m4 l1 "+color;
+            element.setAttribute("data-initial-class", "playground-child "+color+" col ");
             element.appendChild(span);
             playgroundWrapper.appendChild(element);
-
-            // build input
-            var input = document.createElement("input");
-            input.id = "playground-div-class-input-"+num;
-            input.className = "active playground-div-class-input";
-            input.setAttribute("type", "text");
-            input.setAttribute("oninput", "updatePlayground();");
-            input.value = "col s1";
-            var label = document.createElement("label");
-            label.setAttribute("for", input.id);
-            label.innerHTML = "Class (section "+num+")";
-            var inputField = document.createElement("div");
-            inputField.className = "input-field";
-            inputField.id = "input-playground-"+num;
-            inputField.appendChild(input);
-            inputField.appendChild(label);
-            playgroundInputWrapper.appendChild(inputField);
-            Materialize.updateTextFields();
-
-            // reinitialize arrays
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
-            playgroundElements = document.getElementsByClassName("playground-child");
           };
 
           rmButton.addEventListener("click", rmPlaygroundElement);
 
           function rmPlaygroundElement(global) {
-            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
-            playgroundInputs[playgroundInputs.length-1].parentElement.parentElement.removeChild(playgroundInputs[playgroundInputs.length-1].parentElement);
-
-            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
             playgroundElements = document.getElementsByClassName("playground-child");
+            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
           }
 
           function updatePlayground() {
@@ -542,6 +526,23 @@
           }
 
           addPlaygroundElement(); // create first one
+
+          var editable = document.getElementsByClassName("editable-grid-example");
+          for (var i = 0; i < editable.length; i++) {
+            editable[i].contentEditable = true;
+            editable[i].addEventListener("input", updatePremadeExample);
+          }
+
+          function updatePremadeExample(event) {
+            newClasses = event.target.innerHTML;
+            newClasses = newClasses.replace("col", "");
+            newClasses = newClasses.replace("&nbsp;", " "); // strange bug
+            parent = event.target.parentElement;
+            while (parent.tagName != "DIV") { // for nested spans
+              parent = parent.parentElement;
+            }
+            parent.className = parent.getAttribute("data-initial-class") + newClasses;
+          }
           </script>
         </div>
       </div>
@@ -563,7 +564,7 @@
             <li><a href="#grid-push">Push and Pull</a></li>
             <li><a href="#grid-layouts">Creating Layouts</a></li>
             <li><a href="#grid-responsive">Responsive Layouts</a></li>
-            <li><a href="#playground">Try It</a></li>
+            <li><a href="#playground">Playground</a></li>
           </ul>
         </div>
       </div>

--- a/jade/page-contents/grid_content.html
+++ b/jade/page-contents/grid_content.html
@@ -455,6 +455,95 @@
             </code></pre>
           </div>
         </div>
+
+
+        <div id="playground" class="section scrollspy">
+          <h2 class="header">Try It</h2>
+          
+          <p>Modify the classes below to test colors.</p>
+
+          <div id="playground-wrapper" class="card-panel row center">
+          </div>
+          <br>
+          <div id="playground-input-wrapper">
+          </div>
+          <div id="add-btn" class="btn">Add</div>
+          <div id="rm-btn" class="btn red">Remove</div>
+          
+          <script>
+          var playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+          var playgroundInputWrapper = document.getElementById("playground-input-wrapper");
+          var playgroundElements = document.getElementsByClassName("playground-child");
+          var playgroundWrapper = document.getElementById("playground-wrapper");
+          var addButton = document.getElementById("add-btn");
+          var rmButton = document.getElementById("rm-btn");
+
+          function randomPlaygroundColor() {
+            var colors = ["red", "pink", "purple", "indigo", "blue", "cyan", "teal", "green", "yellow", "orange"];
+            return colors[Math.floor(Math.random()*colors.length)];
+          };
+
+          addButton.addEventListener("click", addPlaygroundElement);
+
+          function addPlaygroundElement(global) {
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+
+            var num=playgroundElements.length+1;
+            // build element
+            var span = document.createElement("span");
+            span.className = "flow-text white-text";
+            span.innerHTML = num;
+            var element = document.createElement("div");
+            element.id = "playground-child-"+num;
+            color = randomPlaygroundColor();
+            element.className = "playground-child col s1 "+color;
+            element.setAttribute("data-initial-class", "playground-child "+color+" ");
+            element.appendChild(span);
+            playgroundWrapper.appendChild(element);
+
+            // build input
+            var input = document.createElement("input");
+            input.id = "playground-div-class-input-"+num;
+            input.className = "active playground-div-class-input";
+            input.setAttribute("type", "text");
+            input.setAttribute("oninput", "updatePlayground();");
+            input.value = "col s1";
+            var label = document.createElement("label");
+            label.setAttribute("for", input.id);
+            label.innerHTML = "Class (section "+num+")";
+            var inputField = document.createElement("div");
+            inputField.className = "input-field";
+            inputField.id = "input-playground-"+num;
+            inputField.appendChild(input);
+            inputField.appendChild(label);
+            playgroundInputWrapper.appendChild(inputField);
+            Materialize.updateTextFields();
+
+            // reinitialize arrays
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+          };
+
+          rmButton.addEventListener("click", rmPlaygroundElement);
+
+          function rmPlaygroundElement(global) {
+            playgroundElements[playgroundElements.length-1].parentElement.removeChild(playgroundElements[playgroundElements.length-1]);
+            playgroundInputs[playgroundInputs.length-1].parentElement.parentElement.removeChild(playgroundInputs[playgroundInputs.length-1].parentElement);
+
+            playgroundInputs = document.getElementsByClassName("playground-div-class-input");
+            playgroundElements = document.getElementsByClassName("playground-child");
+          }
+
+          function updatePlayground() {
+            for (var i = 0; i < playgroundElements.length; i++) {
+              playgroundElements[i].className = playgroundElements[i].getAttribute("data-initial-class") + playgroundInputs[i].value;
+            }
+          }
+
+          addPlaygroundElement(); // create first one
+          </script>
+        </div>
       </div>
 
 
@@ -474,6 +563,7 @@
             <li><a href="#grid-push">Push and Pull</a></li>
             <li><a href="#grid-layouts">Creating Layouts</a></li>
             <li><a href="#grid-responsive">Responsive Layouts</a></li>
+            <li><a href="#playground">Try It</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Hi,
This is the first of (hopefully) many additions I would like to add.

What this modification does is add a section to the color.html page which allows the user to edit the classes on a sample element through a simple element.  
It resides directly below the usage category.

![image](https://cloud.githubusercontent.com/assets/8005215/24309226/60782166-10a1-11e7-9712-70fc7d8f6f88.png)

By editing the text in the class input field, a user can change the classes of the box (asides from the card-panel class.

This is done through vanilla JavaScript.

It does not require any specific ordering of classes in the input field.

Demonstration: 

![materialize_color_playground](https://cloud.githubusercontent.com/assets/8005215/24309386/0cbd5c3e-10a2-11e7-8849-a7d871e7deae.gif)

I didn't add any additional tests, as I was not changing any distribution files, only documentation.

I'm considering adding a "open in CodePen" link or similar.  What do you guys think?