### PR TITLE
Added reference to guidelines notice in dragout menu section

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -124,6 +124,9 @@
         </p>
         <h4>Drag Out Menu</h4>
         <p>This plugin includes several options for customizing the menu. See <a href="side-nav.html#options">Plugin Options</a> for details.</p>
+        <div class="card-panel amber lighen-1">
+          <span style="vertical-align: middle;"><i class="material-icons yellow-text text-darken-4">warning</i></span> <span style="font-weight: bold;">Notice:</span> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+        </div>
         <img class="mobile-image" src="images/menu.gif">
 
       </div>


### PR DESCRIPTION
Dragout menus on web are forbidden by the material guideline rules, so it's good to let people know and have them choose by themselves. I added a simple card for that.