### PR TITLE
Added reference to guidelines notice in dragout menu pages

### DIFF
--- a/jade/mobile/mobile_content.html
+++ b/jade/mobile/mobile_content.html
@@ -9,6 +9,9 @@
         </p>
         <h4>Drag Out Menu</h4>
         <p>This plugin includes several options for customizing the menu. See <a href="side-nav.html#options">Plugin Options</a> for details.</p>
+        <div class="card-panel amber lighen-1">
+          <span style="vertical-align: middle;"><i class="material-icons yellow-text text-darken-4">warning</i></span> <span style="font-weight: bold;">Notice:</span> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+        </div>
         <img class="mobile-image" src="images/menu.gif">
 
       </div>

--- a/jade/mobile/mobile_content.html
+++ b/jade/mobile/mobile_content.html
@@ -9,8 +9,8 @@
         </p>
         <h4>Drag Out Menu</h4>
         <p>This plugin includes several options for customizing the menu. See <a href="side-nav.html#options">Plugin Options</a> for details.</p>
-        <div class="card-panel amber lighen-1">
-          <span style="vertical-align: middle;"><i class="material-icons yellow-text text-darken-4">warning</i></span> <span style="font-weight: bold;">Notice:</span> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+        <div class="card-panel amber lighten-1">
+          <span style="vertical-align: middle;"><i class="material-icons left yellow-text text-darken-4">warning</i></span> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
         </div>
         <img class="mobile-image" src="images/menu.gif">
 

--- a/jade/mobile/mobile_content.html
+++ b/jade/mobile/mobile_content.html
@@ -10,7 +10,7 @@
         <h4>Drag Out Menu</h4>
         <p>This plugin includes several options for customizing the menu. See <a href="side-nav.html#options">Plugin Options</a> for details.</p>
         <div class="card-panel amber lighten-1">
-          <span style="vertical-align: middle;"><i class="material-icons left yellow-text text-darken-4">warning</i></span> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+          <i style="vertical-align: middle;" class="material-icons left yellow-text text-darken-4">warning</i> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
         </div>
         <img class="mobile-image" src="images/menu.gif">
 

--- a/jade/page-contents/sideNav_content.html
+++ b/jade/page-contents/sideNav_content.html
@@ -69,6 +69,9 @@
     }
   );
         </code></pre>
+        <div class="card-panel amber lighen-1">
+          <span style="vertical-align: middle;"><i class="material-icons yellow-text text-darken-4">warning</i></span> <span style="font-weight: bold;">Notice:</span> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+        </div>
       </div>
 
       <div id="method" class="section scrollspy">

--- a/jade/page-contents/sideNav_content.html
+++ b/jade/page-contents/sideNav_content.html
@@ -69,8 +69,8 @@
     }
   );
         </code></pre>
-        <div class="card-panel amber lighen-1">
-          <span style="vertical-align: middle;"><i class="material-icons yellow-text text-darken-4">warning</i></span> <span style="font-weight: bold;">Notice:</span> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+        <div class="card-panel amber lighten-1">
+          <span style="vertical-align: middle;"><i class="material-icons left yellow-text text-darken-4">warning</i></span> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
         </div>
       </div>
 

--- a/jade/page-contents/sideNav_content.html
+++ b/jade/page-contents/sideNav_content.html
@@ -70,7 +70,7 @@
   );
         </code></pre>
         <div class="card-panel amber lighten-1">
-          <span style="vertical-align: middle;"><i class="material-icons left yellow-text text-darken-4">warning</i></span> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
+          <i style="vertical-align: middle;" class="material-icons left yellow-text text-darken-4">warning</i> <b>Notice:</b> The official Material Guidelines <a target="_blank" href="https://material.io/guidelines/platforms/platform-adaptation.html#platform-adaptation-platform-recommendations">do not support drag-out sidenavs on web</a>.
         </div>
       </div>
 


### PR DESCRIPTION
_(Sorry it took me 6 commits lol I just noticed new errors/improvements)_
Dragout menus on web are discouraged by the material guideline rules, so it's good to let people know and have them choose by themselves. I added a simple card for that. It's on mobile page & on sidenav page.