### PR TITLE
remove blue background color on mobile browsers

### DIFF
--- a/sass/components/forms/_switches.scss
+++ b/sass/components/forms/_switches.scss
@@ -3,6 +3,8 @@
 
 .switch,
 .switch * {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -khtml-user-select: none;


### PR DESCRIPTION
Also -webkit-user-select was removed in new Chromium / Blink versions.

https://www.chromestatus.com/feature/5062926088011776
https://www.chromestatus.com/feature/5722186220306432

http://caniuse.com/#feat=user-select-none