### PR TITLE
Run tests on BrowserStack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ before_install:
   - npm install -g grunt-cli
 git:
   depth: 10
+script:
+  - npm test
+  - npm run test-bstack

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,0 +1,28 @@
+{
+    "username": "BROWSERSTACK_USERNAME",
+    "key": "BROWSERSTACK_KEY",
+    "test_framework": "jasmine2",
+    "test_path": [
+	"_SpecRunner.html"
+	],
+    "browsers": [
+        {
+            "browser": "chrome",
+            "browser_version": "latest",
+            "os": "OS X",
+            "os_version": "Mountain Lion"
+        },
+        {
+            "browser": "firefox",
+            "browser_version": "latest",
+            "os": "Windows",
+            "os_version": "7"
+        },
+        {
+            "browser": "chrome",
+            "browser_version": "latest",
+            "os": "Windows",
+            "os_version": "7"
+        }
+    ]
+}

--- a/browserstack.json
+++ b/browserstack.json
@@ -10,7 +10,7 @@
             "browser": "chrome",
             "browser_version": "latest",
             "os": "OS X",
-            "os_version": "Mountain Lion"
+            "os_version": "Sierra"
         },
         {
             "browser": "firefox",
@@ -19,10 +19,16 @@
             "os_version": "7"
         },
         {
-            "browser": "chrome",
+            "browser": "ie",
             "browser_version": "latest",
             "os": "Windows",
-            "os_version": "7"
+            "os_version": "10"
+        },
+        {
+            "browser": "safari",
+            "browser_version": "latest",
+            "os": "OS X",
+            "os_version": "Yosemite"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "browserstack-runner": "^0.5.0"
   },
   "scripts": {
-    "test": "grunt travis --verbose && browserstack-runner --verbose"
+    "test": "grunt travis --verbose",
+    "test-bstack": "browserstack-runner"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "jasmine-jquery": "^2.1.1",
     "jquery": "^2.1.4",
     "node-sass": "^3.4.2",
-    "phantomjs": "^1.9.18"
+    "phantomjs": "^1.9.18",
+    "browserstack-runner": "^0.5.0"
   },
   "scripts": {
-    "test": "grunt travis --verbose"
+    "test": "grunt travis --verbose && browserstack-runner --verbose"
   }
 }


### PR DESCRIPTION
Hi

We just integrated Materialize test suite to run on BrowserStack. It will run across latest browsers of Chrome, Firefox, IE and Safari. The exposed command for this is: npm test:ci. It is using [browerstack-runner](https://github.com/browserstack/browserstack-runner) for integration.

To enable it on your Travis build, you just have to expose `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY`. You can set it at repository level. More information - [here](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).

Let us know if you face any issues with this integration. We would love to get your feedback on your experience of using BrowserStack to run your test suite. :)

Thanks
Ankur Goel
\- BrowserStack Automate