### PR TITLE
Include SRI attributes for public CDN-hosted URLs

### DIFF
--- a/jade/getting_started/getting_started_content.html
+++ b/jade/getting_started/getting_started_content.html
@@ -42,10 +42,10 @@
           <p>You can find all the versions of the CDN at <a href="https://cdnjs.com/libraries/materialize">cdnjs</a>.</p>
           <pre><code class="language-markup">
   &lt;!-- Compiled and minified CSS -->
-  &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.1/css/materialize.min.css">
+  &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.1/css/materialize.min.css" integrity="sha384-XLFTL9dXwsRBFwMcBk5JP+istfIgaKTvAbLqTmyktLfziA2a99vZ4xRLRNKxneYz" crossorigin="anonymous">
 
   &lt;!-- Compiled and minified JavaScript -->
-  &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.1/js/materialize.min.js">&lt;/script>
+  &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.1/js/materialize.min.js" integrity="sha384-19rESMe189YojNq+NTrxzeIMwe6yoS9R5+zESkGGJQdFJmzS66Nuhl+V8O2Z2GFm" crossorigin="anonymous">&lt;/script>
           </code></pre>
         </div>
         <div class="col s12">
@@ -135,7 +135,7 @@
 
     &lt;body>
       &lt;!--Import jQuery before materialize.js-->
-      &lt;script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js">&lt;/script>
+      &lt;script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js" integrity="sha384-fj9YEHKNa/e0CNquG4NcocjoyMATYo1k2Ff5wGB42C/9AwOlJjDoySPtNJalccfI" crossorigin="anonymous">&lt;/script>
       &lt;script type="text/javascript" src="js/materialize.min.js">&lt;/script>
     &lt;/body>
   &lt;/html>


### PR DESCRIPTION
When referencing code on a CDN, one should provide hashes for "sub-resource integrity" checks. (cf. https://www.w3.org/TR/SRI/). According to http://caniuse.com/#search=sri, nearly 50%–60% of browsers support this (backwards-compatible) check.

(Technically, SRI attributes will always provide value, but that is especially the case when you reference resources on a third-party domain such as a shared CDN.)

I generated these hashes with https://www.srihash.org/