### PR TITLE
Removed scrollbar from fixed width tabs

### DIFF
--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -20,6 +20,7 @@
 
   &.tabs-fixed-width {
     display: flex;
+    overflow-x: hidden;
 
     .tab {
       -webkit-box-flex: 1;


### PR DESCRIPTION
Removed scrollbar from fixed width tabs - as it should be. Fixed width tabs shouldn't be scrollable anyways, _and_ this solves https://github.com/Dogfalo/materialize/issues/4400 .