### PR TITLE
align text with the initial value

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -108,6 +108,7 @@ textarea.materialize-textarea {
   &.validate + label {
     width: 100%;
     pointer-events: none;
+    text-align: initial;
   }
 
   // Form Message Shared Styles


### PR DESCRIPTION
An alternative fix in code like [here](https://github.com/Dogfalo/materialize/issues/4182#issue-205324166)
```CSS
input.validate+label {
    text-align: initial;
}
```