### PR TITLE
Fix issue in pulse when using non-floating buttons

### DIFF
--- a/jade/page-contents/pulse_content.html
+++ b/jade/page-contents/pulse_content.html
@@ -7,14 +7,14 @@
 
         <div style="display: flex; justify-content: space-around;">
           <a class="btn btn-floating pulse"><i class="material-icons">menu</i></a>
-          <a class="btn btn-floating btn-large pulse"><i class="material-icons">cloud</i></a>
+          <a class="btn btn-large pulse"><i class="material-icons">cloud</i></a>
           <a class="btn btn-floating btn-large cyan pulse"><i class="material-icons">edit</i></a>
         </div>
 
         <h4>Pulse HTML Structure</h4>
         <pre><code class="language-markup">
 &lt;a class="btn btn-floating pulse">&lt;i class="material-icons">menu&lt;/i>&lt;/a>
-&lt;a class="btn btn-floating btn-large pulse">&lt;i class="material-icons">cloud&lt;/i>&lt;/a>
+&lt;a class="btn btn-large pulse">&lt;i class="material-icons">cloud&lt;/i>&lt;/a>
 &lt;a class="btn btn-floating btn-large cyan pulse">&lt;i class="material-icons">edit&lt;/i>&lt;/a>
 </code></pre>
       </div>

--- a/sass/components/_pulse.scss
+++ b/sass/components/_pulse.scss
@@ -5,6 +5,8 @@
     position: absolute;
     width: 100%;
     height: 100%;
+    top: 0;
+    left: 0;
     background-color: inherit;
     border-radius: inherit;
     transition: opacity .3s, transform .3s;
@@ -13,6 +15,7 @@
   }
 
   overflow: initial;
+  position: relative;
 }
 
 @keyframes pulse-animation {


### PR DESCRIPTION
When using `.pulse` with non-`.btn-floating` buttons, there was a big glitch on the screen.

This is fixed in this PR, with no impact on current buttons:

Before:

![screen recording 2017-04-02 at 08 52 50 pm](https://cloud.githubusercontent.com/assets/3369266/24590077/96145140-17e6-11e7-8d24-ba64f41eb443.gif)

After:
![screen recording 2017-04-02 at 08 52 10 pm](https://cloud.githubusercontent.com/assets/3369266/24590076/946b161c-17e6-11e7-8a19-df184b69c542.gif)

I also updated the examples so we can see that it works for every button now

