### PR TITLE
Fixed grid offset bug

### DIFF
--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -101,6 +101,9 @@
         $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.m#{$i} {
           width: $perc;
+          margin-left: auto;
+          left: auto;
+          right: auto;
         }
         $i: $i + 1
       }
@@ -128,6 +131,9 @@
         $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.l#{$i} {
           width: $perc;
+          margin-left: auto;
+          left: auto;
+          right: auto;
         }
         $i: $i + 1;
       }
@@ -155,6 +161,9 @@
         $perc: unquote((100 / ($num-cols / $i)) + "%");
         &.xl#{$i} {
           width: $perc;
+          margin-left: auto;
+          left: auto;
+          right: auto;
         }
         $i: $i + 1;
       }

--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -59,22 +59,12 @@
 
     $i: 1;
     @while $i <= $num-cols {
-      &.s#{$i},
-      &.m#{$i},
-      &.l#{$i},
-      &.xl#{$i} {
-        margin-left: auto;
-        left: auto;
-        right: auto;
-      }
-      $i: $i + 1;
-    }
-
-    $i: 1;
-    @while $i <= $num-cols {
       $perc: unquote((100 / ($num-cols / $i)) + "%");
       &.s#{$i} {
         width: $perc;
+        margin-left: auto;
+        left: auto;
+        right: auto;
       }
       $i: $i + 1;
     }


### PR DESCRIPTION
See #4410
This appeared when xl breakpoints were added. margin-left, left, and right properties were removed from the media queries which is a problem because now offset-m (for example) would also be applied to large and xlarge.

This PR just reverts the code back the way it was before + adds the properties for xl breakpoints