### PR TITLE
Fixed missleading with variable $button-font-size

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -43,11 +43,11 @@
 .btn-floating,
 .btn-large,
 .btn-flat {
-
+  font-size: $button-font-size;
   outline: 0;
 
   i {
-    font-size: $button-font-size;
+    font-size: $button-icon-font-size;
     line-height: inherit;
   }
 }

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -56,7 +56,8 @@ $badge-height: 22px !default;
 // Shared styles
 $button-border: none !default;
 $button-background-focus: lighten($secondary-color, 4%) !default;
-$button-font-size: 1.3rem !default;
+$button-font-size: 1rem !default;
+$button-icon-font-size: 1.3rem !default;
 $button-height: 36px !default;
 $button-padding: 0 2rem !default;
 $button-radius: 2px !default;


### PR DESCRIPTION
See #4492
There are two changes:
- It changes the name of the variable $button-font-size that is missleading
to a better name like $button-icon-font-size.
- It adds a new variable called $button-font-size with value of 1rem.