### PR TITLE
Proposed change to description grammar

### DIFF
--- a/about.html
+++ b/about.html
@@ -113,7 +113,7 @@
     <div class="row">
       <div class="col s12 m9">
         <h1 class="header center-on-small-only">About</h1>
-        <h4 class ="light red-text text-lighten-4 center-on-small-only">Learn about the Material Design and our Project Team.</h4>
+        <h4 class ="light red-text text-lighten-4 center-on-small-only">Learn about Material Design and our Project Team.</h4>
       </div>
       <div class="col s12 m3">
         <div class="buysellads-header center-on-small-only">


### PR DESCRIPTION
The term "Material Design" doesn't need an article in front of it. The official site doesn't use "the" in front of "Material Design."