### PR TITLE
Url changes

### DIFF
--- a/jade/_footer.html
+++ b/jade/_footer.html
@@ -20,7 +20,7 @@
           </div>
           <div class="col l4 s12" style="overflow: hidden;">
             <h5 class="white-text">Connect</h5>
-            <iframe src="http://ghbtns.com/github-btn.html?user=dogfalo&repo=materialize&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dogfalo&repo=materialize&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
             <br>
             <a href="https://twitter.com/MaterializeCSS" class="twitter-follow-button" data-show-count="true" data-size="large" data-dnt="true">Follow @MaterializeCSS</a>
             <br>

--- a/jade/_head.jade
+++ b/jade/_head.jade
@@ -25,8 +25,8 @@ meta(name='theme-color', content='#EE6E73')
 // CSS
 link(href='css/prism.css', rel='stylesheet')
 link(href='css/ghpages-materialize.css', type='text/css', rel='stylesheet', media='screen,projection')
-link(href='http://fonts.googleapis.com/css?family=Inconsolata', rel='stylesheet', type='text/css')
-link(href='http://fonts.googleapis.com/icon?family=Material+Icons', rel='stylesheet')
+link(href='https://fonts.googleapis.com/css?family=Inconsolata', rel='stylesheet', type='text/css')
+link(href='https://fonts.googleapis.com/icon?family=Material+Icons', rel='stylesheet')
 
 if !isDemo
   script.

--- a/jade/_navbar.jade
+++ b/jade/_navbar.jade
@@ -9,7 +9,7 @@ header
       i.material-icons menu
   ul#nav-mobile.side-nav.fixed
     li(class="logo")
-      a#logo-container.brand-logo(href='http://materializecss.com/')
+      a#logo-container.brand-logo(href='/')
         object#front-page-logo(type='image/svg+xml', data='res/materialize.svg') Your browser does not support SVG
     li(class="search")
       div.search-wrapper.card
@@ -114,7 +114,7 @@ header
                 a(href='waves.html') Waves
 
     li.bold(class=(page == "Mobile" ? "active" : ""))
-      a.waves-effect.waves-teal(href='http://materializecss.com/mobile.html') Mobile
+      a.waves-effect.waves-teal(href='mobile.html') Mobile
     li.bold(class=(page == "Showcase" ? "active" : ""))
       a.waves-effect.waves-teal(href='showcase.html') Showcase
     li.bold(class=(page == "Themes" ? "active" : ""))

--- a/jade/getting_started/getting_started_content.html
+++ b/jade/getting_started/getting_started_content.html
@@ -81,7 +81,7 @@
             <br>
           </div>
           <div class="col l3 s12 center" style="overflow: hidden;">
-            <iframe src="http://ghbtns.com/github-btn.html?user=dogfalo&repo=materialize&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=dogfalo&repo=materialize&type=watch&count=true&size=large" allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
             <br>
           </div>
           <div class="col l3 s12 center" style="overflow: hidden;">
@@ -125,7 +125,7 @@
   &lt;html>
     &lt;head>
       &lt;!--Import Google Icon Font-->
-      &lt;link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+      &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
       &lt;!--Import materialize.css-->
       &lt;link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
 

--- a/jade/page-contents/cards_content.html
+++ b/jade/page-contents/cards_content.html
@@ -167,7 +167,7 @@
             <h2 class="header">Horizontal Card</h2>
             <div class="card horizontal">
               <div class="card-image">
-                <img src="http://lorempixel.com/100/190/nature/6">
+                <img src="https://lorempixel.com/100/190/nature/6">
               </div>
               <div class="card-stacked">
                 <div class="card-content">
@@ -192,7 +192,7 @@
     &lt;h2 class="header">Horizontal Card&lt;/h2>
     &lt;div class="card horizontal">
       &lt;div class="card-image">
-        &lt;img src="http://lorempixel.com/100/190/nature/6">
+        &lt;img src="https://lorempixel.com/100/190/nature/6">
       &lt;/div>
       &lt;div class="card-stacked">
         &lt;div class="card-content">

--- a/jade/page-contents/carousel_content.html
+++ b/jade/page-contents/carousel_content.html
@@ -9,20 +9,20 @@
          <p>Note: This is also touch compatible! Try swiping with your finger to scroll through the carousel.</p><br>
 
         <div class="carousel">
-          <a class="carousel-item" href="#one!"><img src="http://lorempixel.com/250/250/nature/1"></a>
-          <a class="carousel-item" href="#two!"><img src="http://lorempixel.com/250/250/nature/2"></a>
-          <a class="carousel-item" href="#three!"><img src="http://lorempixel.com/250/250/nature/3"></a>
-          <a class="carousel-item" href="#four!"><img src="http://lorempixel.com/250/250/nature/4"></a>
-          <a class="carousel-item" href="#five!"><img src="http://lorempixel.com/250/250/nature/5"></a>
+          <a class="carousel-item" href="#one!"><img src="https://lorempixel.com/250/250/nature/1"></a>
+          <a class="carousel-item" href="#two!"><img src="https://lorempixel.com/250/250/nature/2"></a>
+          <a class="carousel-item" href="#three!"><img src="https://lorempixel.com/250/250/nature/3"></a>
+          <a class="carousel-item" href="#four!"><img src="https://lorempixel.com/250/250/nature/4"></a>
+          <a class="carousel-item" href="#five!"><img src="https://lorempixel.com/250/250/nature/5"></a>
         </div><br>
 
       <pre><code class="language-markup">
   &lt;div class="carousel">
-    &lt;a class="carousel-item" href="#one!">&lt;img src="http://lorempixel.com/250/250/nature/1">&lt;/a>
-    &lt;a class="carousel-item" href="#two!">&lt;img src="http://lorempixel.com/250/250/nature/2">&lt;/a>
-    &lt;a class="carousel-item" href="#three!">&lt;img src="http://lorempixel.com/250/250/nature/3">&lt;/a>
-    &lt;a class="carousel-item" href="#four!">&lt;img src="http://lorempixel.com/250/250/nature/4">&lt;/a>
-    &lt;a class="carousel-item" href="#five!">&lt;img src="http://lorempixel.com/250/250/nature/5">&lt;/a>
+    &lt;a class="carousel-item" href="#one!">&lt;img src="https://lorempixel.com/250/250/nature/1">&lt;/a>
+    &lt;a class="carousel-item" href="#two!">&lt;img src="https://lorempixel.com/250/250/nature/2">&lt;/a>
+    &lt;a class="carousel-item" href="#three!">&lt;img src="https://lorempixel.com/250/250/nature/3">&lt;/a>
+    &lt;a class="carousel-item" href="#four!">&lt;img src="https://lorempixel.com/250/250/nature/4">&lt;/a>
+    &lt;a class="carousel-item" href="#five!">&lt;img src="https://lorempixel.com/250/250/nature/5">&lt;/a>
   &lt;/div>
       </code></pre>
     </div>
@@ -100,18 +100,18 @@ $('.carousel').carousel('set', 4);
         <p>Note: This is also touch compatible! Try swiping with your finger to scroll through the carousel.</p><br>
 
         <div class="carousel carousel-slider">
-          <a class="carousel-item" href="#one!"><img src="http://lorempixel.com/800/400/food/1"></a>
-          <a class="carousel-item" href="#two!"><img src="http://lorempixel.com/800/400/food/2"></a>
-          <a class="carousel-item" href="#three!"><img src="http://lorempixel.com/800/400/food/3"></a>
-          <a class="carousel-item" href="#four!"><img src="http://lorempixel.com/800/400/food/4"></a>
+          <a class="carousel-item" href="#one!"><img src="https://lorempixel.com/800/400/food/1"></a>
+          <a class="carousel-item" href="#two!"><img src="https://lorempixel.com/800/400/food/2"></a>
+          <a class="carousel-item" href="#three!"><img src="https://lorempixel.com/800/400/food/3"></a>
+          <a class="carousel-item" href="#four!"><img src="https://lorempixel.com/800/400/food/4"></a>
         </div><br>
 
         <pre><code class="language-markup">
   &lt;div class="carousel carousel-slider">
-    &lt;a class="carousel-item" href="#one!">&lt;img src="http://lorempixel.com/800/400/food/1">&lt;/a>
-    &lt;a class="carousel-item" href="#two!">&lt;img src="http://lorempixel.com/800/400/food/2">&lt;/a>
-    &lt;a class="carousel-item" href="#three!">&lt;img src="http://lorempixel.com/800/400/food/3">&lt;/a>
-    &lt;a class="carousel-item" href="#four!">&lt;img src="http://lorempixel.com/800/400/food/4">&lt;/a>
+    &lt;a class="carousel-item" href="#one!">&lt;img src="https://lorempixel.com/800/400/food/1">&lt;/a>
+    &lt;a class="carousel-item" href="#two!">&lt;img src="https://lorempixel.com/800/400/food/2">&lt;/a>
+    &lt;a class="carousel-item" href="#three!">&lt;img src="https://lorempixel.com/800/400/food/3">&lt;/a>
+    &lt;a class="carousel-item" href="#four!">&lt;img src="https://lorempixel.com/800/400/food/4">&lt;/a>
   &lt;/div>
         </code></pre>
 

--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -723,7 +723,7 @@
         <h2 class="header">Range</h2>
         <p>Add a range slider for values with a wide range. This one is set to be a number between 0 and 100. We have two different types of sliders. nouiSlider is a 3rd party plugin which we've modified. To use the noUiSlider, you will have to manually link the <code class="language-markup">nouislider.css</code> and <code class="language-markup">nouislider.js</code> files located in the extras folder.</p>
         <h4>noUiSlider</h4>
-        <p>See noUiSlider's official documentation <a href="http://refreshless.com/nouislider/">here</a> to see a variety of slider options</p>
+        <p>See noUiSlider's official documentation <a href="https://refreshless.com/nouislider/">here</a> to see a variety of slider options</p>
         <div id="range-input"></div>
         <p>&nbsp;</p>
         <pre><code class="language-javascript">
@@ -863,7 +863,7 @@
     data: {
       "Apple": null,
       "Microsoft": null,
-      "Google": 'http://placehold.it/250x250'
+      "Google": 'https://placehold.it/250x250'
     },
     limit: 20, // The max amount of results that can be shown at once. Default: Infinity.
     onAutocomplete: function(val) {

--- a/jade/page-contents/icons_content.html
+++ b/jade/page-contents/icons_content.html
@@ -3,7 +3,7 @@
     <div class="col s12 m9 l10">
 
     <div id="usage" class="row scrollspy">
-            <p class="caption">We have included 740 Material Design Icons courtesy of Google. You can download them directly from the <a href="http://google.github.io/material-design-icons/#icon-font-for-the-web">Material Design specs</a>.</p>
+            <p class="caption">We have included 740 Material Design Icons courtesy of Google. You can download them directly from the <a href="https://google.github.io/material-design-icons/#icon-font-for-the-web">Material Design specs</a>.</p>
             <h4>Usage</h4>
             <p>To be able to use these icons, you must include this line in the <code class="language-markup">&lt;head></code>portion of your HTML code</p>
             <pre><code class="language-markup">

--- a/jade/page-contents/icons_content.html
+++ b/jade/page-contents/icons_content.html
@@ -295,7 +295,7 @@
         <div style="height: 1px;">
           <ul class="section table-of-contents">
             <li><a href="#usage">Usage</a></li>
-            <li><a href="http://www.google.com/design/icons/">Search Google's Icons</a></li>
+            <li><a href="https://material.io/icons/">Search Google's Icons</a></li>
           </ul>
         </div>
       </div>

--- a/jade/page-contents/media-css_content.html
+++ b/jade/page-contents/media-css_content.html
@@ -70,7 +70,7 @@
         <p>To make your HTML5 Videos responsive just add the class <code class="language-markup">responsive-video</code> to the video tag.</p>
 
         <video width="100%" controls>
-          <source src="http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4">
+          <source src="https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4" type="video/mp4">
         </video>
         <pre><code class="language-markup">
   &lt;video class="responsive-video" controls>

--- a/jade/page-contents/media_content.html
+++ b/jade/page-contents/media_content.html
@@ -24,9 +24,9 @@
 
         <h4>Captions</h4>
         <p>It is very easy to add a short caption to your photo. Just add the caption as a <code class="language-markup">data-caption</code> attribute.</p>
-        <img class="materialboxed" data-caption="A picture of a way with a group of trees in a park" width="250" src="http://lorempixel.com/800/400/nature/4">
+        <img class="materialboxed" data-caption="A picture of a way with a group of trees in a park" width="250" src="https://lorempixel.com/800/400/nature/4">
           <pre><code class="language-markup">
-  &lt;img class="materialboxed" data-caption="A picture of a way with a group of trees in a park" width="250" src="http://lorempixel.com/800/400/nature/4">
+  &lt;img class="materialboxed" data-caption="A picture of a way with a group of trees in a park" width="250" src="https://lorempixel.com/800/400/nature/4">
           </code></pre>
       </div>
 
@@ -42,28 +42,28 @@
         <div class="slider">
           <ul class="slides">
             <li>
-              <img src="http://lorempixel.com/580/250/nature/1"> <!-- random image -->
+              <img src="https://lorempixel.com/580/250/nature/1"> <!-- random image -->
               <div class="caption center-align">
                 <h3>This is our big Tagline!</h3>
                 <h5 class="light grey-text text-lighten-3">Here's our small slogan.</h5>
               </div>
             </li>
             <li>
-              <img src="http://lorempixel.com/580/250/nature/2"> <!-- random image -->
+              <img src="https://lorempixel.com/580/250/nature/2"> <!-- random image -->
               <div class="caption left-align">
                 <h3>Left Aligned Caption</h3>
                 <h5 class="light grey-text text-lighten-3">Here's our small slogan.</h5>
               </div>
             </li>
             <li>
-              <img src="http://lorempixel.com/580/250/nature/3"> <!-- random image -->
+              <img src="https://lorempixel.com/580/250/nature/3"> <!-- random image -->
               <div class="caption right-align">
                 <h3>Right Aligned Caption</h3>
                 <h5 class="light grey-text text-lighten-3">Here's our small slogan.</h5>
               </div>
             </li>
             <li>
-              <img src="http://lorempixel.com/580/250/nature/4"> <!-- random image -->
+              <img src="https://lorempixel.com/580/250/nature/4"> <!-- random image -->
               <div class="caption center-align">
                 <h3>This is our big Tagline!</h3>
                 <h5 class="light grey-text text-lighten-3">Here's our small slogan.</h5>
@@ -76,28 +76,28 @@
   &lt;div class="slider">
     &lt;ul class="slides">
       &lt;li>
-        &lt;img src="http://lorempixel.com/580/250/nature/1"> &lt;!-- random image -->
+        &lt;img src="https://lorempixel.com/580/250/nature/1"> &lt;!-- random image -->
         &lt;div class="caption center-align">
           &lt;h3>This is our big Tagline!&lt;/h3>
           &lt;h5 class="light grey-text text-lighten-3">Here's our small slogan.&lt;/h5>
         &lt;/div>
       &lt;/li>
       &lt;li>
-        &lt;img src="http://lorempixel.com/580/250/nature/2"> &lt;!-- random image -->
+        &lt;img src="https://lorempixel.com/580/250/nature/2"> &lt;!-- random image -->
         &lt;div class="caption left-align">
           &lt;h3>Left Aligned Caption&lt;/h3>
           &lt;h5 class="light grey-text text-lighten-3">Here's our small slogan.&lt;/h5>
         &lt;/div>
       &lt;/li>
       &lt;li>
-        &lt;img src="http://lorempixel.com/580/250/nature/3"> &lt;!-- random image -->
+        &lt;img src="https://lorempixel.com/580/250/nature/3"> &lt;!-- random image -->
         &lt;div class="caption right-align">
           &lt;h3>Right Aligned Caption&lt;/h3>
           &lt;h5 class="light grey-text text-lighten-3">Here's our small slogan.&lt;/h5>
         &lt;/div>
       &lt;/li>
       &lt;li>
-        &lt;img src="http://lorempixel.com/580/250/nature/4"> &lt;!-- random image -->
+        &lt;img src="https://lorempixel.com/580/250/nature/4"> &lt;!-- random image -->
         &lt;div class="caption center-align">
           &lt;h3>This is our big Tagline!&lt;/h3>
           &lt;h5 class="light grey-text text-lighten-3">Here's our small slogan.&lt;/h5>

--- a/jade/page-contents/tabs_content.html
+++ b/jade/page-contents/tabs_content.html
@@ -144,7 +144,7 @@
 
       <div id="external" class="section scrollspy">
         <h4>Linking to an External Page</h4>
-          <p>By default, Materialize tabs will ignore their default anchor behaviour.  To force a tab to behave as a regular hyperlink, just specify the <code class="language-markup">target</code> property of that link!  A list of <code class="language-markup">target</code> values may be <a href="http://www.w3schools.com/tags/att_a_target.asp">found here</a>.</p>
+          <p>By default, Materialize tabs will ignore their default anchor behaviour.  To force a tab to behave as a regular hyperlink, just specify the <code class="language-markup">target</code> property of that link!  A list of <code class="language-markup">target</code> values may be <a href="https://www.w3schools.com/tags/att_a_target.asp">found here</a>.</p>
         <pre><code class="language-markup col s12">
   &lt;li class="tab col s2">
     &lt;a target="_blank" href="https://github.com/Dogfalo/materialize">External link in new window&lt;/a>

--- a/jade/page-contents/typography_content.html
+++ b/jade/page-contents/typography_content.html
@@ -11,7 +11,7 @@
           </p>
           <div class="row">
             <p class="col s12 m4">We bundle our framework with the latest iteration of Roboto Google has released. It comes with 5 different font weights you can use: 100, 300, 400, 500, 600.<br> <br> Here is an image from Google's Roboto Specimen document displaying the different font weights.</p>
-            <img class="col s12 m8" src="http://material-design.storage.googleapis.com/publish/v_2/material_ext_publish/0Bx4BSt6jniD7SW9CUzR4MnRpOTg/style_typography_roboto1.png">
+            <img class="col s12 m8" src="https://material-design.storage.googleapis.com/publish/v_2/material_ext_publish/0Bx4BSt6jniD7SW9CUzR4MnRpOTg/style_typography_roboto1.png">
           </div>
 
           <h4>Removing Roboto</h4>


### PR DESCRIPTION
* New material design icons url
* Changed materializecss.com/mobile.html to mobile.html
* Changed some urls to https instead of http. This was also a problem when using sample codes in codepen. [Codepen is going HTTPS](https://blog.codepen.io/2017/03/31/codepen-going-https/). In the future requests that come in over HTTP will be redirected to HTTPS. That means all the images that are required over http, will show a warning. That's annoying. This fixes it.

Also we are getting just a little step closer to https://github.com/Dogfalo/materialize/issues/4040