### PR TITLE
Fix select memory leak (remove window event listeners)

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -491,9 +491,11 @@
 
         $select.unwrap();
         $('ul#select-options-'+lastID).remove();
+
+        $(window).off('click.select-' + lastID);
       }
 
-      // If destroying the select, remove the selelct-id and reset it to it's uninitialized state.
+      // If destroying the select, remove the select-id and reset it to it's uninitialized state.
       if(callback === 'destroy') {
         $select.data('select-id', null).removeClass('initialized');
         return;
@@ -647,10 +649,8 @@
         optionsHover = false;
       });
 
-      $(window).on({
-        'click': function () {
-          multiple && (optionsHover || $newSelect.trigger('close'));
-        }
+      $(window).on('click.select-' + uniqueID, function() {
+        multiple && (optionsHover || $newSelect.trigger('close'));
       });
 
       // Add initial multiple selections.


### PR DESCRIPTION
This adds removal of the window event listeners for the select component and is a fix for #4266.

There may still be further steps necessary to properly cleanup all event listeners for the select component (i.e. select calls .dropdown() internally).
