### PR TITLE
fix SELECT border for valid/invalid state

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -34,6 +34,14 @@ select {
     margin: $input-margin;
     padding: 0;
     display: block;
+    
+    &.valid {
+      border-bottom: 1px solid $input-success-color;
+    }
+    
+    &.invalid {
+      border-bottom: $input-invalid-border;
+    }
   }
 
   span.caret {


### PR DESCRIPTION
At the moment adding `valid`/`invalid` classes to the SELECT's input produces a greyish border.