### PR TITLE
Modal overlay height fixed

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -46,7 +46,7 @@
 .modal-overlay {
   position: fixed;
   z-index: 999;
-  top: -100px;
+  top: -25%;
   left: 0;
   bottom: 0;
   right: 0;


### PR DESCRIPTION
If on a smaller device,  (with the height `400px` or less), that height of 125% will not cover all those `-100px` added. As the height of the screen would be, for eg: `200px`, the height of the overlay would be 125% (`250px`), and the `-100px` would set only `150px` of the overlay on the screen, and `50px` would be left with no overlay.
Demo of the bug: https://codepen.io/artur99/pen/qmpMYy
Demo of the fix: https://codepen.io/artur99/pen/ZKvMRy