### PR TITLE
Created three events for input fields that are fired after validation.

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -93,11 +93,11 @@
             object.addClass('valid');
           }
           else {
-            object.removeClass('valid');
-            object.addClass('invalid');
             if (!object.hasClass('invalid')) {
               object.trigger($.Event('materialize:invalid', {}));
             }
+            object.removeClass('valid');
+            object.addClass('invalid');
           }
         }
       }

--- a/js/forms.js
+++ b/js/forms.js
@@ -86,16 +86,18 @@
         if (object.hasClass('validate')) {
           // Check for character counter attributes
           if ((object.is(':valid') && hasLength && (len <= lenAttr)) || (object.is(':valid') && !hasLength)) {
+            if (!object.hasClass('valid')) {
+              object.trigger($.Event('materialize:valid', {}));
+            }
             object.removeClass('invalid');
             object.addClass('valid');
-            var evt = $.Event('materialize:valid', {});
-            object.trigger(evt);
           }
           else {
             object.removeClass('valid');
             object.addClass('invalid');
-            var evt = $.Event('materialize:invalid', {});
-            object.trigger(evt);
+            if (!object.hasClass('invalid')) {
+              object.trigger($.Event('materialize:invalid', {}));
+            }
           }
         }
       }

--- a/js/forms.js
+++ b/js/forms.js
@@ -76,6 +76,10 @@
 
       if (object.val().length === 0 && object[0].validity.badInput === false) {
         if (object.hasClass('validate')) {
+          if (object.hasClass('valid') || object.hasClass('invalid')) {
+            var evt = $.Event('materialize:reset-input', {});
+            object.trigger(evt);
+          }
           object.removeClass('valid');
           object.removeClass('invalid');
         }
@@ -85,14 +89,16 @@
           // Check for character counter attributes
           if ((object.is(':valid') && hasLength && (len <= lenAttr)) || (object.is(':valid') && !hasLength)) {
             if (!object.hasClass('valid')) {
-              object.trigger($.Event('materialize:valid', {}));
+              var evt = $.Event('materialize:valid-input', {});
+              object.trigger(evt);
             }
             object.removeClass('invalid');
             object.addClass('valid');
           }
           else {
             if (!object.hasClass('invalid')) {
-              object.trigger($.Event('materialize:invalid', {}));
+              var evt = $.Event('materialize:invalid-input', {});
+              object.trigger(evt);
             }
             object.removeClass('valid');
             object.addClass('invalid');

--- a/js/forms.js
+++ b/js/forms.js
@@ -78,6 +78,8 @@
         if (object.hasClass('validate')) {
           object.removeClass('valid');
           object.removeClass('invalid');
+          var evt = $.Event('materialize:invalid', {});
+          object.trigger(evt);
         }
       }
       else {
@@ -86,10 +88,14 @@
           if ((object.is(':valid') && hasLength && (len <= lenAttr)) || (object.is(':valid') && !hasLength)) {
             object.removeClass('invalid');
             object.addClass('valid');
+            var evt = $.Event('materialize:valid', {});
+            object.trigger(evt);
           }
           else {
             object.removeClass('valid');
             object.addClass('invalid');
+            var evt = $.Event('materialize:invalid', {});
+            object.trigger(evt);
           }
         }
       }

--- a/js/forms.js
+++ b/js/forms.js
@@ -78,8 +78,6 @@
         if (object.hasClass('validate')) {
           object.removeClass('valid');
           object.removeClass('invalid');
-          var evt = $.Event('materialize:invalid', {});
-          object.trigger(evt);
         }
       }
       else {


### PR DESCRIPTION
Created two events that are fired after input field validation/invalidation.

- 'materialize:valid-input' - event is fired when the input field receives the 'valid' CSS class.
- 'materialize:invalid-input' - event is fired when the input field receives the 'invalid' CSS class.
- 'materialize:reset-input' - event is fired when the input field has the 'valid' or 'invalid' CSS classes removed.

These events can be handled with the jQuery `on` method.

Valid:
```
$('#inputField').on('materialize:valid-input', function() {
  // handle a valid input field
});
```

Invalid:
```
$('#inputField').on('materialize:invalid-input', function() {
  // handle an invalid input field
});
```

Reset:
```
$('#inputField').on('materialize:reset-input', function() {
  // handle a reset of the input field
});
```