### PR TITLE
Changed the "div" to "li"

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -88,7 +88,7 @@
 
       // append indicator then set indicator width to tab width
       if (!$this.find('.indicator').length) {
-        $this.append('<div class="indicator"></div>');
+        $this.append('<li class="indicator"></li>');
       }
       $indicator = $this.find('.indicator');
 


### PR DESCRIPTION
According to W3C rules, it is unacceptable to insert a div directly as child of ul tag.
Here is the link to w3c: [The ul Element](https://www.w3.org/TR/html5/grouping-content.html#the-ul-element)

The UL element content model as taken from w3c suggests:
`Zero or more li and script-supporting elements.`