### PR TITLE
Added flat navigation bar option

### DIFF
--- a/jade/page-contents/navbar_content.html
+++ b/jade/page-contents/navbar_content.html
@@ -122,6 +122,74 @@
         </code></pre>
       </div>
 
+      <div id="flat" class="section scrollspy">
+
+        <h2 class="header">Flat</h2>
+        <p>
+          Add flat class to nav tag to make nav not stand out.
+        </p>
+
+        <nav class="flat">
+          <div class="nav-wrapper">
+            <div class="col s12">
+              <a href="#!" class="brand-logo">Logo</a>
+              <ul class="right hide-on-med-and-down">
+                <li><a href="sass.html">Sass</a></li>
+                <li><a href="badges.html">Components</a></li>
+                <li><a href="collapsible.html">JavaScript</a></li>
+              </ul>
+            </div>
+          </div>
+        </nav><br>
+
+        <pre><code class="language-markup">
+  &lt;nav class="flat">
+    &lt;div class="nav-wrapper">
+      &lt;a href="#!" class="brand-logo center">Logo&lt;/a>
+      &lt;ul class="left hide-on-med-and-down">
+        &lt;li>&lt;a href="sass.html">Sass&lt;/a>&lt;/li>
+        &lt;li>&lt;a href="badges.html">Components&lt;/a>&lt;/li>
+        &lt;li class="active">&lt;a href="collapsible.html">JavaScript&lt;/a>&lt;/li>
+      &lt;/ul>
+    &lt;/div>
+  &lt;/nav>
+        </code></pre>
+      </div>
+
+      <div id="transparent" class="section scrollspy">
+
+        <h2 class="header">Transparent</h2>
+        <p>
+          You can add the transparent class to make the nav have no background.
+        </p>
+
+        <nav class="transparent">
+          <div class="nav-wrapper">
+            <div class="col s12">
+              <a href="#!" class="brand-logo">Logo</a>
+              <ul class="right hide-on-med-and-down">
+                <li><a href="sass.html">Sass</a></li>
+                <li><a href="badges.html">Components</a></li>
+                <li><a href="collapsible.html">JavaScript</a></li>
+              </ul>
+            </div>
+          </div>
+        </nav><br>
+
+        <pre><code class="language-markup">
+  &lt;nav class="transparent">
+    &lt;div class="nav-wrapper">
+      &lt;a href="#!" class="brand-logo center">Logo&lt;/a>
+      &lt;ul class="left hide-on-med-and-down">
+        &lt;li>&lt;a href="sass.html">Sass&lt;/a>&lt;/li>
+        &lt;li>&lt;a href="badges.html">Components&lt;/a>&lt;/li>
+        &lt;li class="active">&lt;a href="collapsible.html">JavaScript&lt;/a>&lt;/li>
+      &lt;/ul>
+    &lt;/div>
+  &lt;/nav>
+        </code></pre>
+      </div>
+
       <div id="navbar-tabs" class="section scrollspy">
 
         <h2 class="header">Extended Navbar with Tabs</h2>
@@ -504,6 +572,8 @@ $(".dropdown-button").dropdown();
             <li><a href="#left">Left Aligned</a></li>
             <li><a href="#center">Center Logo</a></li>
             <li><a href="#active-label">Active Items</a></li>
+            <li><a href="#flat">Flat</a></li>
+            <li><a href="#transparent">Transparent</a></li>
             <li><a href="#navbar-tabs">Navbar with Tabs</a></li>
             <li><a href="#navbar-fixed">Fixed Navbar</a></li>
             <li><a href="#navbar-dropdown">Dropdown Menu</a></li>

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -15,6 +15,9 @@ nav {
 
   color: $navbar-font-color;
   @extend .z-depth-1;
+  &.flat {
+    @extend .z-depth-0;
+  }
   background-color: $primary-color;
   width: 100%;
   height: $navbar-height-mobile;

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -12,12 +12,13 @@ nav {
       line-height: normal;
     }
   }
+  
+  &.transparent, &.flat {
+    @extend .z-depth-0;
+  }
 
   color: $navbar-font-color;
   @extend .z-depth-1;
-  &.flat {
-    @extend .z-depth-0;
-  }
   background-color: $primary-color;
   width: 100%;
   height: $navbar-height-mobile;


### PR DESCRIPTION
By adding the class `.flat` to a navigation bar, the navigation bar looses its box shadow and becomes "flat".