### PR TITLE
 The hammer.js bug only happens if the value of eventType is 8.

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -160,18 +160,13 @@
           $dragTarget.hammer({
             prevent_default: false
           }).bind('pan', function(e) {
-
-            if (e.gesture.pointerType == "touch") {
+            // Vertical scroll bugfix eventType Value === 8 is hammer.js bug
+            if (e.gesture.pointerType == "touch" && e.gesture.eventType !== 8) {
 
               var direction = e.gesture.direction;
               var x = e.gesture.center.x;
               var y = e.gesture.center.y;
               var velocityX = e.gesture.velocityX;
-
-              // Vertical scroll bugfix
-              if (x === 0 && y === 0) {
-                return;
-              }
 
               // Disable Scrolling
               var $body = $('body');


### PR DESCRIPTION
I am a developer studying the materialize css source. I noticed that during the creation of sidenav, Chrome experienced a drag error on newer browsers, and when the eventType value is 8, an odd value comes in. Share the source you have resolved as above.