### PR TITLE
Updated package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-images/
-.sass-cache/
-.grunt/
-.DS_Store
-prepros.cfg
-Thumbs.db
-.projectile
-**/*.log

--- a/js/.npmignore
+++ b/js/.npmignore
@@ -1,0 +1,5 @@
+# Ignore documentation related files
+
+jquery.timeago.min.js
+init.js
+prism.js

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "author": "Alvin Wang, Alan Chang",
   "url": "http://materializecss.com/",
   "version": "0.98.2",
-  "main": "bin/materialize.js",
-  "style": "bin/materialize.css",
+  "main": "dist/js/materialize.js",
+  "style": "dist/css/materialize.css",
   "sass": "sass/materialize.scss",
   "license": "MIT",
   "repository": {
@@ -47,4 +47,12 @@
   "scripts": {
     "test": "grunt travis --verbose"
   }
+  "files": [
+    "dist",
+    "extras",
+    "js/**/*.js",
+    "sass/**/*.scss",
+    "Gruntfile.js",
+    "LICENSE"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hammerjs": "^2.0.8",
     "jquery": "^2.1.4"
   },
-  "engine": "node >= 6.10.0",
+  "engine": "node >= 6",
   "devDependencies": {
     "autoprefixer": "^6.7.7",
     "grunt": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "materialize-css",
   "description": "Builds Materialize distribution packages",
   "author": "Alvin Wang, Alan Chang",
-  "url": "http://materializecss.com/",
+  "homepage": "http://materializecss.com/",
   "version": "0.98.2",
   "main": "dist/js/materialize.js",
   "style": "dist/css/materialize.css",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "type": "git",
     "url": "git://github.com/Dogfalo/materialize.git"
   },
+  "scripts": {
+    "test": "grunt travis --verbose"
+  },
   "dependencies": {
     "hammerjs": "^2.0.8",
-    "jquery": "^2.1.4",
-    "node-archiver": "^0.3.0"
+    "jquery": "^2.1.4"
   },
   "engine": "node >= 6.10.0",
   "devDependencies": {
@@ -40,13 +42,10 @@
     "grunt-text-replace": "^0.4.0",
     "jasmine": "^2.6.0",
     "jasmine-jquery": "^2.1.1",
-    "jquery": "^2.1.4",
+    "node-archiver": "^0.3.0",
     "node-sass": "^4.5.2",
     "phantomjs-prebuilt": "^2.1.14"
   },
-  "scripts": {
-    "test": "grunt travis --verbose"
-  }
   "files": [
     "dist",
     "extras",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "git://github.com/Dogfalo/materialize.git"
   },
+  "bugs": {
+    "url": "https://github.com/Dogfalo/materialize/issues"
+  },
   "scripts": {
     "test": "grunt travis --verbose"
   },

--- a/sass/.npmignore
+++ b/sass/.npmignore
@@ -1,0 +1,4 @@
+# Ignore documentation related files
+
+_style.scss
+ghpages-materialize.scss


### PR DESCRIPTION
- From now on only necessary [files](https://github.com/Dogfalo/materialize/blob/packagejson-update/package.json#L52) are getting pushed to npm.
- Changed `main`, `sass` and `style` path to use the compiled files inside `dist/`
- Added the bugs field (See: https://docs.npmjs.com/files/package.json#bugs for more information)
- Renamed the `url` field to `homepage`
- Changed node engine from `6.10.0` to `6`
- Removed `jQuery` as a devDependency, but no worries jQuery is still a dependency!
- Moved `node-archiver` to the devDependencies

These changes also should prevent materialize from using it's own bundled version of jQuery. (See https://github.com/Dogfalo/materialize/issues/3707)