### PR TITLE
Buttons: Change z-index of .fixed-action-btn from 998 to 997

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -216,7 +216,7 @@ button.btn-floating {
   bottom: 23px;
   padding-top: 15px;
   margin-bottom: 0;
-  z-index: 998;
+  z-index: 997;
 
   ul {
     left: 0;


### PR DESCRIPTION
This way it is behind the sidenav backdrop and not in front of it. I noticed the issue when using an FAB.