### PR TITLE
Display browser-default for inputs

### DIFF
--- a/jade/page-contents/helpers_content.html
+++ b/jade/page-contents/helpers_content.html
@@ -166,6 +166,10 @@
               <td>SELECT</td>
               <td>Browser default select element</td>
             </tr>
+            <tr>
+              <td>INPUT</td>
+              <td>Browser default input</td>
+            </tr>
           </tbody>
         </table>
       </div><!--  End Browser Default Section  -->

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -22,17 +22,17 @@
 /* Text inputs */
 
 input:not([type]),
-input[type=text],
-input[type=password],
-input[type=email],
-input[type=url],
-input[type=time],
-input[type=date],
-input[type=datetime],
-input[type=datetime-local],
-input[type=tel],
-input[type=number],
-input[type=search],
+input[type=text]:not(.browser-default),
+input[type=password]:not(.browser-default),
+input[type=email]:not(.browser-default),
+input[type=url]:not(.browser-default),
+input[type=time]:not(.browser-default),
+input[type=date]:not(.browser-default),
+input[type=datetime]:not(.browser-default),
+input[type=datetime-local]:not(.browser-default),
+input[type=tel]:not(.browser-default),
+input[type=number]:not(.browser-default),
+input[type=search]:not(.browser-default),
 textarea.materialize-textarea {
 
   // General Styles


### PR DESCRIPTION
Added pseudo classes  to the input selectors so that "browser-defaults" can be applied to other input fields. This is a replacement PR for #4041 

closes Dogfalo/materialize#4041
closes Dogfalo/materialize#3975
closes Dogfalo/materialize#4764