### PR TITLE
fix test for jQuery 3

### DIFF
--- a/tests/spec/select/selectSpec.js
+++ b/tests/spec/select/selectSpec.js
@@ -102,7 +102,7 @@ describe("Select Plugin", function () {
 
         setTimeout(function() {
           expect(multipleDropdown).toBeHidden('Should be hidden after choosing item.');
-          expect(browserSelect.val()).toEqual(null, 'Actual select element should be empty because none chosen.');
+          expect(browserSelect.val()).toEqual([], 'Actual select element should be empty because none chosen.');
           expect(multipleInput.val()).toEqual(disabledOption[0].innerText, 'Value should equal default because none chosen.');
           done();
         }, 400);


### PR DESCRIPTION
This should be `[]`, not `null` for select.

```
As of jQuery 3.0, if no options are selected, it returns an empty array; prior to jQuery 3.0, it returns null.
```

https://api.jquery.com/val/