### PR TITLE
Desktop users needs some 💕 on hover disabled elemets

### DIFF
--- a/jade/page-contents/buttons_content.html
+++ b/jade/page-contents/buttons_content.html
@@ -170,15 +170,15 @@
       <div id="disabled" class="section scrollspy">
         <h2 class="header">Disabled</h2>
         <p>This style can be applied to all button types</p>
-        <a class="btn-large disabled">Button</a>
+        <a class="btn btn-large disabled">Button</a>
         <a class="btn disabled">Button</a>
-        <a class="btn-flat disabled">Button</a>
-        <a class="btn-floating disabled"><i class="material-icons">add</i></a>
+        <a class="btn btn-flat disabled">Button</a>
+        <a class="btn btn-floating disabled"><i class="material-icons">add</i></a>
         <pre><code class="language-markup col s12">
-&lt;a class="btn-large disabled">Button&lt;/a>
+&lt;a class="btn btn-large disabled">Button&lt;/a>
 &lt;a class="btn disabled">Button&lt;/a>
-&lt;a class="btn-flat disabled">Button&lt;/a>
-&lt;a class="btn-floating disabled">&lt;i class="material-icons">add&lt;/i>&lt;/a>
+&lt;a class="btn btn-flat disabled">Button&lt;/a>
+&lt;a class="btn btn-floating disabled">&lt;i class="material-icons">add&lt;/i>&lt;/a>
         </code></pre>
       </div>
 

--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -26,15 +26,16 @@
 .btn-floating[disabled],
 .btn-large[disabled],
 .btn-flat[disabled] {
-  pointer-events: none;
-  background-color: $button-disabled-background !important;
+  background-color: $button-disabled-background;
   box-shadow: none;
-  color: $button-disabled-color !important;
+  color: $button-disabled-color;
   cursor: default;
 
-  &:hover {
-    background-color: $button-disabled-background !important;
-    color: $button-disabled-color !important;
+  &:hover,
+  &:focus {
+    background-color: $button-disabled-background;
+    color: $button-disabled-color;
+    cursor: not-allowed;
   }
 }
 
@@ -261,6 +262,7 @@ button.btn-floating {
   &:focus,
   &:hover {
     box-shadow: none;
+    background-color: transparent;
   }
 
   &:focus {
@@ -270,7 +272,7 @@ button.btn-floating {
   &.disabled {
     background-color: transparent !important;
     color: $button-flat-disabled-color !important;
-    cursor: default;
+    cursor: not-allowed;
   }
 }
 

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -159,7 +159,7 @@ video.responsive-video {
     &.active { background-color: $primary-color; }
 
     &.disabled a {
-      cursor: default;
+      cursor: not-allowed;
       color: #999;
     }
 

--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -5,7 +5,8 @@
     .tab a,
     .tab.disabled a,
     .tab.disabled a:hover {
-      color: rgba(255,255,255,0.7);
+      color: #9F9F9F;
+      cursor: not-allowed;
     }
 
     .tab a:hover,
@@ -67,8 +68,8 @@
 
     &.disabled a,
     &.disabled a:hover {
-      color: rgba($tabs-text-color, .7);
-      cursor: default;
+      color: #9F9F9F;
+      cursor: not-allowed;
     }
   }
   .indicator {

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -55,12 +55,18 @@ textarea.materialize-textarea {
   &[readonly="readonly"] {
     color: $input-disabled-color;
     border-bottom: $input-disabled-border;
+    &:hover {
+      cursor: not-allowed;
+    }
   }
 
   // Disabled label style
   &:disabled+label,
   &[readonly="readonly"]+label {
     color: $input-disabled-color;
+    &:hover {
+      cursor: not-allowed;
+    }
   }
 
   // Focused input style


### PR DESCRIPTION
Hello there,

- Update `cursor: not-allowed` for disabled elements
- Drop `pointer-events: none;` for buttons because we can't see the hover effect

Here is an example for buttons https://codepen.io/flexbox/pen/jwrzdG