### PR TITLE
align buttons in modal footer in the right order

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -36,9 +36,9 @@
     padding: 4px 6px;
     height: 56px;
     width: 100%;
+    text-align: right;
 
     .btn, .btn-flat {
-      float: right;
       margin: 6px 0;
     }
   }


### PR DESCRIPTION
fixes #4078 