### PR TITLE
move navbar-fixed z-index to nav element

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -189,10 +189,10 @@ nav {
 .navbar-fixed {
   position: relative;
   height: $navbar-height-mobile;
-  z-index: 997;
 
   nav {
     position: fixed;
+    z-index: 997;
   }
 }
 @media #{$medium-and-up} {


### PR DESCRIPTION
### Description
The materialize navbar contains code to handle a fixed navigation bar, but the z-index property for this navbar is on the class `.navbar-fixed` which belongs to the parent element instead of on the actual `.navbar-fixed nav` element itself.

### Repro Steps
1: create a `<nav>` element.
2: add `class="navbar-fixed"` to the parent element (`<body>`).
3: scroll down to see elements on top of the fixed navbar instead of underneath it.

### Screenshots / Codepen
https://codepen.io/anon/pen/vZmWEy
![currently](https://user-images.githubusercontent.com/7945901/27359552-6297a3e8-55ea-11e7-964c-837d5012ee89.png)

### Corrected
https://codepen.io/anon/pen/Kqmypx
![fixed](https://user-images.githubusercontent.com/7945901/27359533-392daa66-55ea-11e7-928b-c830ea09934c.png)
