### PR TITLE
add missing margin-bottom

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -276,6 +276,7 @@ textarea {
 /* Autocomplete */
 .autocomplete-content {
   margin-top: -1 * $input-margin-bottom;
+  margin-bottom: $input-margin-bottom;
   display: block;
   opacity: 1;
   position: static;


### PR DESCRIPTION
Currently the negative margin-top moves the dropdown content up and removes the visual spacing.

This fixes it.

Old behavior: https://codepen.io/anon/pen/jwwbbx
New behavior: https://codepen.io/anon/pen/BZZojd