### PR TITLE
use <body> instead of separate wrapper div for navbar-fixed

### DIFF
--- a/jade/page-contents/navbar_content.html
+++ b/jade/page-contents/navbar_content.html
@@ -195,11 +195,11 @@
 
         <h2 class="header">Fixed Navbar</h2>
         <p>
-          To make the navbar fixed, you have to add an outer wrapping div with the class <code class="language-markup">navbar-fixed</code>. This will offset your other content while making your nav fixed. You can adjust the height of this outer div to change how much offset is on your content.
+          To make the navbar fixed, add the class <code class="language-markup">navbar-fixed</code> to the body. This will offset your other content while making your nav fixed. You can adjust the offset on your content using the <code class="language-markup">top</code> property of <code class="language-markup">.navbar-fixed</code>.
         </p>
 
         <pre><code class="language-markup">
-  &lt;div class="navbar-fixed">
+  &lt;body class="navbar-fixed">
     &lt;nav>
       &lt;div class="nav-wrapper">
         &lt;a href="#!" class="brand-logo">Logo&lt;/a>
@@ -209,7 +209,7 @@
         &lt;/ul>
       &lt;/div>
     &lt;/nav>
-  &lt;/div>
+  &lt;/body>
         </code></pre>
       </div>
 

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -188,11 +188,12 @@ nav {
 // Fixed Navbar
 .navbar-fixed {
   position: relative;
-  height: $navbar-height-mobile;
-  z-index: 997;
+  top: $navbar-height-mobile;
 
   nav {
     position: fixed;
+    z-index: 997;
+    top: 0px;
   }
 }
 @media #{$medium-and-up} {

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -194,6 +194,7 @@ nav {
     position: fixed;
     z-index: 997;
     top: 0px;
+    height: $navbar-height-mobile
   }
 }
 @media #{$medium-and-up} {
@@ -205,6 +206,9 @@ nav {
     line-height: $navbar-line-height;
   }
   .navbar-fixed {
-    height: $navbar-height;
+    top: $navbar-height;
   }
+  .navbar-fixed nav {
+      height: $navbar-height;
+    }
 }


### PR DESCRIPTION
### Description
The materialize navbar contains code to handle a fixed navigation bar, but developers must add a separate div to handle the page offset and z-index. This commit moves the z-index property to the actual `.navbar-fixed nav` element itself, and handles offset using `top`on both elements

### Repro Steps
1: create a `<nav>` element.
2: add `class="navbar-fixed"` to the parent element (`<body>`).
3: scroll down to see elements on top of the fixed navbar instead of underneath it.
4: page offset does not function in this case.

### Screenshots / Codepen
https://codepen.io/anon/pen/vZmWEy
![currently](https://user-images.githubusercontent.com/7945901/27359552-6297a3e8-55ea-11e7-964c-837d5012ee89.png)

### Corrected
https://codepen.io/anon/pen/Kqmypx
![fixed](https://user-images.githubusercontent.com/7945901/27406382-a6a89066-56a2-11e7-997b-e42dfc71723b.png)

