### PR TITLE
Add portrait/landscape selector classes

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -304,6 +304,16 @@ ul.staggered-list li {
     display: none !important;
   }
 }
+.hide-on-portrait {
+  @media #{$portrait} {
+    display: none !important;
+  }
+}
+.hide-on-landscape {
+  @media #{$landscape} {
+    display: none !important;
+  }
+}
 .show-on-large {
   @media #{$large-and-up} {
     display: block !important;
@@ -329,6 +339,16 @@ ul.staggered-list li {
     display: block !important;
   }
 }
+.show-on-portrait {
+  @media #{$portrait} {
+    display: block !important;
+  }
+}
+.show-on-landscape {
+  @media #{$landscape} {
+    display: block !important;
+  }
+}
 
 
 // Center text on mobile
@@ -341,7 +361,6 @@ ul.staggered-list li {
 // Footer
 .page-footer {
   padding-top: 20px;
-  color: $footer-font-color;
   background-color: $footer-bg-color;
 
   .footer-copyright {
@@ -350,8 +369,8 @@ ul.staggered-list li {
     display: flex;
     align-items: center;
     padding: 10px 0px;
-    color: $footer-copyright-font-color;
-    background-color: $footer-copyright-bg-color;
+    color: rgba(255,255,255,.8);
+    background-color: rgba(51,51,51,.08);
     @extend .light;
   }
 }

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -361,6 +361,7 @@ ul.staggered-list li {
 // Footer
 .page-footer {
   padding-top: 20px;
+  color: $footer-font-color;
   background-color: $footer-bg-color;
 
   .footer-copyright {
@@ -369,8 +370,8 @@ ul.staggered-list li {
     display: flex;
     align-items: center;
     padding: 10px 0px;
-    color: rgba(255,255,255,.8);
-    background-color: rgba(51,51,51,.08);
+    color: $footer-copyright-font-color;
+    background-color: $footer-copyright-bg-color;
     @extend .light;
   }
 }

--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -168,7 +168,7 @@
       $i: 1;
       @while $i <= $num-cols {
         $perc: unquote((100 / ($num-cols / $i)) + "%");
-        @include grid-classes("xl", $i, $perc);
+        @include grid-classes("P", $i, $perc);
         $i: $i + 1;
       }
     }
@@ -188,7 +188,7 @@
       $i: 1;
       @while $i <= $num-cols {
         $perc: unquote((100 / ($num-cols / $i)) + "%");
-        @include grid-classes("xl", $i, $perc);
+        @include grid-classes("L", $i, $perc);
         $i: $i + 1;
       }
     }

--- a/sass/components/_grid.scss
+++ b/sass/components/_grid.scss
@@ -152,5 +152,45 @@
         $i: $i + 1;
       }
     }
+
+    @media #{$portrait} {
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
+        &.P#{$i} {
+          width: $perc;
+          @include reset-offset;
+        }
+        $i: $i + 1;
+      }
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
+        @include grid-classes("xl", $i, $perc);
+        $i: $i + 1;
+      }
+    }
+
+    @media #{$landscape} {
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
+        &.L#{$i} {
+          width: $perc;
+          @include reset-offset;
+        }
+        $i: $i + 1;
+      }
+
+      $i: 1;
+      @while $i <= $num-cols {
+        $perc: unquote((100 / ($num-cols / $i)) + "%");
+        @include grid-classes("xl", $i, $perc);
+        $i: $i + 1;
+      }
+    }
   }
 }

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -214,6 +214,9 @@ $small-and-down: "only screen and (max-width : #{$small-screen})" !default;
 $medium-and-down: "only screen and (max-width : #{$medium-screen})" !default;
 $medium-only: "only screen and (min-width : #{$small-screen-up}) and (max-width : #{$medium-screen})" !default;
 
+$portrait: "only screen and (orientation : portrait)" !default;
+$landscape: "only screen and (orientation : landscape)" !default;
+
 
 // 12. Grid
 // ==========================================================================
@@ -299,10 +302,7 @@ $h6-fontsize: 1rem !default;
 // 21. Footer
 // ==========================================================================
 
-$footer-font-color: #fff !default;
 $footer-bg-color: $primary-color !default;
-$footer-copyright-font-color: rgba(255,255,255,.8) !default;
-$footer-copyright-bg-color: rgba(51,51,51,.08) !default;
 
 
 // 22. Flow Text

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -302,7 +302,10 @@ $h6-fontsize: 1rem !default;
 // 21. Footer
 // ==========================================================================
 
+$footer-font-color: #fff !default;
 $footer-bg-color: $primary-color !default;
+$footer-copyright-font-color: rgba(255,255,255,.8) !default;
+$footer-copyright-bg-color: rgba(51,51,51,.08) !default;
 
 
 // 22. Flow Text


### PR DESCRIPTION
Corrected version of #4860 

As suggested by myself in #4849 

Two new selectors have been added in addition to `.s#`, `.m#`, `.l#` and `.xl#`

These are `.P#` and `.L#` which are active for portrait and landscape screen sizes. Unsure of their interactions with the standard classes; would advise to avoid using both together.

Also added `.hide-on-portrait` and `.hide-on-landscape`, as well as the respective `.show...` classes.

Also added `.offset-P#`, `.pull-P#` and `.push-P#` with respective versions for landscape.