### PR TITLE
Incorrect input type in form example.

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -780,7 +780,7 @@
         <label for="lunchtime">Lunchtime</label>
         <input id="lunchtime" type="text" class="timepicker">
         <pre><code class="language-markup">
-  &lt;input type="date" class="timepicker">
+  &lt;input type="text" class="timepicker">
         </code></pre>
 
         <h4>Initialization</h4>


### PR DESCRIPTION
Input type should be set to text for time picker example.