### PR TITLE
Added Thymeleaf compatibility for checkboxes

### DIFF
--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -22,7 +22,7 @@ form p:last-child {
 // Checkbox Styles
 [type="checkbox"] {
   // Text Label Style
-  + label {
+  ~ label {
     position: relative;
     padding-left: 35px;
     cursor: pointer;
@@ -38,8 +38,8 @@ form p:last-child {
   }
 
   /* checkbox aspect */
-  + label:before,
-  &:not(.filled-in) + label:after {
+  ~ label:before,
+  &:not(.filled-in) ~ label:after {
     content: '';
     position: absolute;
     top: 0;
@@ -53,18 +53,18 @@ form p:last-child {
     transition: .2s;
   }
 
-  &:not(.filled-in) + label:after {
+  &:not(.filled-in) ~ label:after {
     border: 0;
     transform: scale(0);
   }
 
-  &:not(:checked):disabled + label:before {
+  &:not(:checked):disabled ~ label:before {
     border: none;
     background-color: $input-disabled-color;
   }
 
   // Focused styles
-  &.tabbed:focus + label:after {
+  &.tabbed:focus ~ label:after {
     transform: scale(1);
     border: 0;
     border-radius: 50%;
@@ -74,7 +74,7 @@ form p:last-child {
 }
 
 [type="checkbox"]:checked {
-  + label:before {
+  ~ label:before {
     top: -4px;
     left: -5px;
     width: 12px;
@@ -88,7 +88,7 @@ form p:last-child {
     transform-origin: 100% 100%;
   }
 
-  &:disabled + label:before {
+  &:disabled ~ label:before {
     border-right: 2px solid $input-disabled-color;
     border-bottom: 2px solid $input-disabled-color;
   }
@@ -96,7 +96,7 @@ form p:last-child {
 
 /* Indeterminate checkbox */
 [type="checkbox"]:indeterminate {
-  +label:before {
+  ~label:before {
     top: -11px;
     left: -12px;
     width: 10px;
@@ -111,7 +111,7 @@ form p:last-child {
   }
 
   // Disabled indeterminate
-  &:disabled + label:before {
+  &:disabled ~ label:before {
     border-right: 2px solid $input-disabled-color;
     background-color: transparent;
   }
@@ -120,12 +120,12 @@ form p:last-child {
 // Filled in Style
 [type="checkbox"].filled-in {
   // General
-  + label:after {
+  ~ label:after {
     border-radius: 2px;
   }
 
-  + label:before,
-  + label:after {
+  ~ label:before,
+  ~ label:after {
     content: '';
     left: 0;
     position: absolute;
@@ -135,7 +135,7 @@ form p:last-child {
   }
 
   // Unchecked style
-  &:not(:checked) + label:before {
+  &:not(:checked) ~ label:before {
     width: 0;
     height: 0;
     border: 3px solid transparent;
@@ -148,7 +148,7 @@ form p:last-child {
     transform-origin: 100% 100%;
   }
 
-  &:not(:checked) + label:after {
+  &:not(:checked) ~ label:after {
     height: 20px;
     width: 20px;
     background-color: transparent;
@@ -159,7 +159,7 @@ form p:last-child {
 
   // Checked style
   &:checked {
-    + label:before {
+    ~ label:before {
       top: 0;
       left: 1px;
       width: 8px;
@@ -175,7 +175,7 @@ form p:last-child {
       transform-origin: 100% 100%;
     }
 
-    + label:after {
+    ~ label:after {
       top: 0;
       width: 20px;
       height: 20px;
@@ -186,34 +186,34 @@ form p:last-child {
   }
 
   // Focused styles
-  &.tabbed:focus + label:after {
+  &.tabbed:focus ~ label:after {
     border-radius: 2px;
     border-color: $radio-empty-color;
     background-color: rgba(0,0,0,.1);
   }
 
-  &.tabbed:checked:focus + label:after {
+  &.tabbed:checked:focus ~ label:after {
     border-radius: 2px;
     background-color: $secondary-color;
     border-color: $secondary-color;
   }
 
   // Disabled style
-  &:disabled:not(:checked) + label:before {
+  &:disabled:not(:checked) ~ label:before {
     background-color: transparent;
     border: 2px solid transparent;
   }
 
-  &:disabled:not(:checked) + label:after {
+  &:disabled:not(:checked) ~ label:after {
     border-color: transparent;
     background-color: $input-disabled-solid-color;
   }
 
-  &:disabled:checked + label:before {
+  &:disabled:checked ~ label:before {
     background-color: transparent;
   }
 
-  &:disabled:checked + label:after {
+  &:disabled:checked ~ label:after {
     background-color: $input-disabled-solid-color;
     border-color: $input-disabled-solid-color;
   }


### PR DESCRIPTION
Thymeleaf adds hidden fields between the input and label of checkboxes, which is documented in issue #1582. This means styling of checkboxes is broken when using Thymeleaf.

This change fixes that by altering the rules for checkboxes to use the general sibling selector instead of adjacent sibling selector.

Performance of this solution is probably a little bit worse, but the difference should be negligeble since you probably won't have many siblings of a checkbox. In the same way, this breaks styling of any additional labels which are accidental siblings of the checkbox, but this should also be rare in practice.