### PR TITLE
Remove 'data-tooltip-id' reference from the origin on remove

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -15,6 +15,7 @@
       if (options === "remove") {
         this.each(function() {
           $('#' + $(this).attr('data-tooltip-id')).remove();
+          $(this).attr('data-tooltip-id').remove();
           $(this).off('mouseenter.tooltip mouseleave.tooltip');
         });
         return false;


### PR DESCRIPTION
Do not only remove the tooltip content element, but also the 'data-tooltip-id' reference to it from the origin.