### PR TITLE
Remove 'data-tooltip-id' attribute from the origin on tooltip('remove')

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -15,6 +15,7 @@
       if (options === "remove") {
         this.each(function() {
           $('#' + $(this).attr('data-tooltip-id')).remove();
+          $(this).removeAttr('data-tooltip-id');
           $(this).off('mouseenter.tooltip mouseleave.tooltip');
         });
         return false;


### PR DESCRIPTION
Do not only remove the tooltip content element, but also the 'data-tooltip-id' attribute from the origin.