### PR TITLE
Corrected punctuation and grammatical errors

### DIFF
--- a/jade/page-contents/dialogs_content.html
+++ b/jade/page-contents/dialogs_content.html
@@ -12,7 +12,7 @@
   // Materialize.toast(message, displayLength, className, completeCallback);
   Materialize.toast('I am a toast!', 4000) // 4000 is the duration of the toast
         </code></pre>
-        <p>One way to add this into your application is to add this as an onclick event to a button</p>
+        <p>One way to add this into your application is to add this as an onclick event to a button.</p>
         <pre><code class="language-markup">
   &lt;a class="btn" onclick="Materialize.toast('I am a toast', 4000)">Toast!&lt;/a>
         </code></pre>
@@ -26,7 +26,7 @@
         </code></pre>
 
         <h4>Callback</h4>
-        <p>You can have the toast callback a function when it has been dismissed</p>
+        <p>You can have the toast callback a function when it has been dismissed.</p>
         <a class="btn" onclick="Materialize.toast('I am a toast', 4000,'',function(){alert('Your toast was dismissed')})">Toast!</a>
         <pre><code class="language-markup">
   &lt;a class="btn" onclick="Materialize.toast('I am a toast', 4000,'',function(){alert('Your toast was dismissed')})">Toast!&lt;/a>
@@ -51,9 +51,9 @@
         <p>Tooltips are small, interactive, textual hints for mainly graphical elements. When using icons for actions you can use a tooltip to give people clarification on its function.</p>
         <div class="row">
           <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-html="true" data-position="bottom" data-delay="50" data-tooltip="I am tooltip"> Bottom</a>
-          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="top" data-delay="50" data-tooltip="I am tooltip"> Top</a>
-          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="left" data-delay="50" data-tooltip="I am tooltip"> Left</a>
-          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="right" data-delay="50" data-tooltip="I am tooltip"> Right</a>
+          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="top" data-delay="50" data-tooltip="I am a tooltip"> Top</a>
+          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="left" data-delay="50" data-tooltip="I am a tooltip"> Left</a>
+          <a class="btn tooltipped col s4 offset-s4 l2 offset-l1" data-position="right" data-delay="50" data-tooltip="I am a tooltip"> Right</a>
         </div>
 
 
@@ -61,7 +61,7 @@
         <pre><code class="language-markup">
   &lt;!-- data-position can be : bottom, top, left, or right -->
   &lt;!-- data-delay controls delay before tooltip shows (in milliseconds)-->
-  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-tooltip="I am tooltip">Hover me!&lt;/a>
+  &lt;a class="btn tooltipped" data-position="bottom" data-delay="50" data-tooltip="I am a tooltip">Hover me!&lt;/a>
         </code></pre>
         <br>
         <h4>Initialization</h4>


### PR DESCRIPTION
Added periods to the ends of sentences and "a" to all instances of "I am [a] tooltip" in the dialogs page of the documentation.