### PR TITLE
Fix a bug with proper initialization of select tag

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -509,7 +509,7 @@
       }
 
       var uniqueID = Materialize.guid();
-      $select.data('select-id', uniqueID);
+      $select.attr('data-select-id', uniqueID);
       var wrapper = $('<div class="select-wrapper"></div>');
       wrapper.addClass($select.attr('class'));
       var options = $('<ul id="select-options-' + uniqueID +'" class="dropdown-content select-dropdown ' + (multiple ? 'multiple-select-dropdown' : '') + '"></ul>'),


### PR DESCRIPTION
## Proposed changes
$select.data() was being used to add a data-attribute which was not actually appearing on the select tag. This was fine for normal usage but it leaves trash when updating or destroying. That was because the check for initialized select was looking for the said data-attribute.

I've now used $select.attr() instead and everything is working properly now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
