### PR TITLE
Allow using material design icons in combination with `span` tags

### DIFF
--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -166,7 +166,7 @@ a.button-collapse.top-nav {
     line-height: 122px;
   }
 
-  i {
+  .material-icons {
     font-size: 32px;
   }
 }
@@ -299,7 +299,7 @@ a.button-collapse.top-nav {
 .promo{
   width: 100%;
 
-  i {
+  .material-icons {
     margin: 40px 0;
     color: color("materialize-red", "lighten-2");
     font-size: 7rem;
@@ -493,7 +493,7 @@ $height: auto;
 .material-icons.icon-demo {
   line-height: 50px;
 }
-.icon-container i {
+.icon-container .material-icons {
   font-size: 3em;
   margin-bottom: 10px;
 }
@@ -962,7 +962,7 @@ body.parallax-demo footer {
       border: 0;
     }
 
-    i.material-icons {
+    .material-icons {
       position: absolute;
       top: 10px;
       right: 10px;

--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -46,7 +46,7 @@
   font-size: $button-font-size;
   outline: 0;
 
-  i {
+  .material-icons  {
     font-size: $button-icon-font-size;
     line-height: inherit;
   }
@@ -95,7 +95,7 @@
 
     width: $button-floating-large-size;
     height: $button-floating-large-size;
-    i {
+    .material-icons  {
       line-height: $button-floating-large-size;
     }
   }
@@ -127,7 +127,7 @@
   cursor: pointer;
   vertical-align: middle;
 
-  i {
+  .material-icons  {
     width: inherit;
     display: inline-block;
     text-align: center;
@@ -171,7 +171,7 @@ button.btn-floating {
 
   &.toolbar {
     &.active {
-      & > a i {
+      & > a .material-icons  {
         opacity: 0;
       }
     }
@@ -204,7 +204,7 @@ button.btn-floating {
           line-height: $button-floating-large-size;
           z-index: 1;
 
-          i {
+          .material-icons  {
             line-height: inherit;
           }
         }
@@ -280,7 +280,7 @@ button.btn-floating {
   height: $button-large-height;
   line-height: $button-large-height;
 
-  i {
+  .material-icons  {
     font-size: $button-large-icon-font-size;
   }
 }

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -151,7 +151,7 @@
       line-height: 32px;
       margin-bottom: 8px;
 
-      i {
+      .material-icons  {
         line-height: 32px;
       }
     }

--- a/sass/components/_collapsible.scss
+++ b/sass/components/_collapsible.scss
@@ -16,7 +16,7 @@
   background-color: $collapsible-header-color;
   border-bottom: 1px solid $collapsible-border-color;
 
-  i {
+  .material-icons  {
     width: 2rem;
     font-size: 1.6rem;
     line-height: $collapsible-line-height;
@@ -53,7 +53,7 @@
     padding: 0 $sidenav-padding;
 
     &:hover { background-color: rgba(0,0,0,.05); }
-    i { line-height: inherit; }
+    .material-icons  { line-height: inherit; }
   }
 
   .collapsible-body {

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -49,7 +49,7 @@
     }
 
     // Icon alignment override
-    & > a > i {
+    & > a > .material-icons  {
       height: inherit;
       line-height: inherit;
       float: left;

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -100,7 +100,7 @@ blockquote {
 
 // Icon Styles
 
-i {
+.material-icons {
   line-height: inherit;
 
   &.left {
@@ -161,7 +161,7 @@ video.responsive-video {
       color: #999;
     }
 
-    i {
+    .material-icons {
       font-size: 2rem;
     }
   }
@@ -194,9 +194,7 @@ video.responsive-video {
   font-size: 18px;
   color: rgba(255,255,255, .7);
 
-  i,
-  [class^="mdi-"], [class*="mdi-"],
-  i.material-icons {
+  .material-icons {
     display: inline-block;
     float: left;
     font-size: 24px;
@@ -508,13 +506,14 @@ td, th{
         left: 15px;
         display: inline-block;
         vertical-align: middle;
-      }
-      i.circle {
-        font-size: 18px;
-        line-height: 42px;
-        color: #fff;
-        background-color: #999;
-        text-align: center;
+
+        &.material-icons{
+          font-size: 18px;
+          line-height: 42px;
+          color: #fff;
+          background-color: #999;
+          text-align: center;
+        }
       }
 
 

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -22,9 +22,7 @@ nav {
 
   a { color: $navbar-font-color; }
 
-  i,
-  [class^="mdi-"], [class*="mdi-"],
-  i.material-icons {
+  .material-icons {
     display: block;
     font-size: 24px;
     height: $navbar-height-mobile;
@@ -49,7 +47,7 @@ nav {
     height: $navbar-height-mobile;
     margin: 0 18px;
 
-    i {
+    .material-icons {
       height: $navbar-height-mobile;
       line-height: $navbar-line-height-mobile;
     }
@@ -91,9 +89,7 @@ nav {
       padding: 0;
     }
 
-    i,
-    [class^="mdi-"], [class*="mdi-"],
-    i.material-icons {
+    .material-icons {
       float: left;
       margin-right: 15px;
     }
@@ -176,11 +172,11 @@ nav {
       top: 0;
       left: 0;
 
-      i {
+      .material-icons {
         color: rgba(255,255,255,.7);
         transition: color .3s;
       }
-      &.active i { color: $navbar-font-color; }
+      &.active .material-icons { color: $navbar-font-color; }
     }
   }
 }
@@ -199,7 +195,7 @@ nav {
   nav.nav-extended .nav-wrapper {
     min-height: $navbar-height;
   }
-  nav, nav .nav-wrapper i, nav a.button-collapse, nav a.button-collapse i {
+  nav, nav .nav-wrapper .material-icons, nav a.button-collapse, nav a.button-collapse .material-icons {
     height: $navbar-height;
     line-height: $navbar-line-height;
   }

--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -62,9 +62,7 @@
     &.btn-large:hover { background-color: lighten($button-raised-background, 5%); }
     &.btn-floating:hover { background-color: $button-raised-background; }
 
-    & > i,
-    & > [class^="mdi-"], li > a > [class*="mdi-"],
-    & > i.material-icons {
+    & > .material-icons {
       float: left;
       height: $sidenav-item-height;
       line-height: $sidenav-line-height;

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -213,8 +213,6 @@ textarea.materialize-textarea {
     box-shadow: none;
     color: #444;
 
-    & + label i,
-    & ~ .mdi-navigation-close,
     & ~ .material-icons {
       color: #444;
     }
@@ -224,7 +222,6 @@ textarea.materialize-textarea {
     left: 1rem;
   }
 
-  & ~ .mdi-navigation-close,
   & ~ .material-icons {
     position: absolute;
     top: 0;

--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -72,7 +72,7 @@ select:disabled {
   border-bottom: 1px solid rgba(0,0,0,.3);
 }
 
-.select-wrapper i {
+.select-wrapper .material-icons {
   color: $select-disabled-color;
 }
 


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
These changes allows users to use the `span` tag in combination with the material design icons.
Solves https://github.com/Dogfalo/materialize/issues/2228



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
