### PR TITLE
Remove font files to stop bower throwing warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,17 +15,7 @@
   ],
   "main": [
     "dist/js/materialize.js",
-    "dist/css/materialize.css",
-    "dist/fonts/roboto/Roboto-Bold.woff",
-    "dist/fonts/roboto/Roboto-Bold.woff2",
-    "dist/fonts/roboto/Roboto-Light.woff",
-    "dist/fonts/roboto/Roboto-Light.woff2",
-    "dist/fonts/roboto/Roboto-Medium.woff",
-    "dist/fonts/roboto/Roboto-Medium.woff2",
-    "dist/fonts/roboto/Roboto-Regular.woff",
-    "dist/fonts/roboto/Roboto-Regular.woff2",
-    "dist/fonts/roboto/Roboto-Thin.woff",
-    "dist/fonts/roboto/Roboto-Thin.woff2"
+    "dist/css/materialize.css"
   ],
   "ignore": [
     "jade/",


### PR DESCRIPTION
## Proposed changes
When installing the package via bower errors are being thrown. This commit fixes this issue by removing the font files from the main property in bower.json

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->
![screenshot](http://i.imgur.com/5m974L7.png)
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
