### PR TITLE
Removed tap highlight of Dropdown

### DIFF
--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -23,6 +23,7 @@
 
     &:hover, &.active, &.selected {
       background-color: $dropdown-hover-bg-color;
+      -webkit-tap-highlight-color: transparent;
     }
 
     &.active.selected {


### PR DESCRIPTION
## Proposed changes
Fix for issue #4976
I add `-webkit-tap-highlight-color: transparent;` to each list item of Dropdown.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
