### PR TITLE
Add right class for collapsible-flex header

### DIFF
--- a/sass/components/_collapsible.scss
+++ b/sass/components/_collapsible.scss
@@ -22,6 +22,12 @@
     text-align: center;
     margin-right: 1rem;
   }
+  
+  i.right {
+    flex: 0 1 auto;
+    clear:right;
+    margin-left: auto;
+  }
 }
 
 .collapsible-body {


### PR DESCRIPTION
## Proposed changes
Use right-aligned icons in collapsible-flex header

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
