### PR TITLE
Fix incorrect <input> type for Date Picker example

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -772,7 +772,7 @@
         <label for="birthdate">Birthdate</label>
         <input id="birthdate" type="text" class="datepicker">
         <pre><code class="language-markup">
-  &lt;input type="date" class="datepicker">
+  &lt;input type="text" class="datepicker">
         </code></pre>
 
         <h4>Initialization</h4>


### PR DESCRIPTION
## Proposed changes
Fix the documentation for Date Picker; it requires `type="text"`, but it was set to `type="date"` in the example (the actual component had the correct type).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
