### PR TITLE
Properly pass jQuery to toasts.js

### DIFF
--- a/js/toasts.js
+++ b/js/toasts.js
@@ -1,4 +1,4 @@
-(function() {
+(function($) {
   'use strict';
 
   let _defaults = {
@@ -317,4 +317,4 @@
   window.Materialize.toast = function(message, displayLength, className, completeCallback) {
     return new Toast(message, displayLength, className, completeCallback);
   }
-})();
+})(jQuery);


### PR DESCRIPTION
## Proposed changes
js/toasts.js assumes that the global jQuery (`$`) object exists when calling `$.extend`, which can lead to errors when `window.$` is undefined. We should properly pass jQuery to this file's scope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
