### PR TITLE
Reset Interval when manually sliding with .slider('next') or ('prev')

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -282,13 +282,37 @@
         });
 
         $this.on('sliderNext', function() {
+          //Reset Interval when manually sliding with .slider('next')
+          clearInterval($interval);
           $active_index = $slider.find('.active').index();
           moveToSlide($active_index + 1);
+          $interval = setInterval(
+            function(){
+              $active_index = $slider.find('.active').index();
+              if ($slides.length == $active_index + 1) $active_index = 0; // loop to start
+              else $active_index += 1;
+
+              moveToSlide($active_index);
+
+            }, options.transition + options.interval
+          );
         });
 
         $this.on('sliderPrev', function() {
+          //Reset Interval when manually sliding with .slider('prev')
+          clearInterval($interval);
           $active_index = $slider.find('.active').index();
           moveToSlide($active_index - 1);
+          $interval = setInterval(
+            function(){
+              $active_index = $slider.find('.active').index();
+              if ($slides.length == $active_index + 1) $active_index = 0; // loop to start
+              else $active_index += 1;
+
+              moveToSlide($active_index);
+
+            }, options.transition + options.interval
+          );
         });
 
       });


### PR DESCRIPTION
## Proposed changes
Found that when using .slider('next') or ('prev') on a slider, the Interval Timer was not reset, resulting in inaccurate view times while using buttons to view.

## Screenshots (if appropriate) or codepen:
Not Relivant

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
