### PR TITLE
A Simple Solution For Swipeable Tabs Fixed Height

### DIFF
--- a/sass/components/_carousel.scss
+++ b/sass/components/_carousel.scss
@@ -56,6 +56,10 @@
     }
   }
 
+  .tabs-content .carousel-item {
+      height: auto;
+    }
+
   .indicators {
     position: absolute;
     text-align: center;


### PR DESCRIPTION
When tabs swipeable option is setted to true, height is fixed 200px.
To solve this, setting carousel-item height to auto which is inside of
tabs-content class can be useful.