### PR TITLE
Add option to select remaining entry with enter

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -310,7 +310,8 @@
         data: {},
         limit: Infinity,
         onAutocomplete: null,
-        minLength: 1
+        minLength: 1,
+        selectLastEnter: false
       };
 
       options = $.extend(defaults, options);
@@ -430,13 +431,18 @@
                 $active = $autocomplete.children('.active').first();
 
             // select element on Enter
-            if (keyCode === 13 && activeIndex >= 0) {
-              liElement = $autocomplete.children('li').eq(activeIndex);
-              if (liElement.length) {
-                liElement.trigger('mousedown.autocomplete');
-                e.preventDefault();
+            if (keyCode === 13) {
+              if(options.selectLastEnter && numItems == 1) {
+                activeIndex = 0;
               }
-              return;
+              if(activeIndex >= 0) {
+                liElement = $autocomplete.children('li').eq(activeIndex);
+                if (liElement.length) {
+                  liElement.trigger('mousedown.autocomplete');
+                  e.preventDefault();
+                }
+                return;
+              }
             }
 
             // Capture up and down key


### PR DESCRIPTION
A small change that makes it possible to select and choose a last remaining entry by pressing enter. This was a requirement in my project and saves the user an unnecessary keystroke.
May not seem like much, but in an application that is used hundred of times a day it can make a real difference.

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
