### PR TITLE
add show-on-* classes for display inline, inline-block, flex, inline-…

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -301,6 +301,8 @@ ul.staggered-list li {
     display: none !important;
   }
 }
+
+
 .show-on-large {
   @media #{$large-and-up} {
     display: block !important;
@@ -324,6 +326,114 @@ ul.staggered-list li {
 .show-on-medium-and-down {
   @media #{$medium-and-down} {
     display: block !important;
+  }
+}
+
+
+.show-on-large-inline-block {
+  @media #{$large-and-up} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-inline-block {
+  @media only screen and (min-width: $small-screen) and (max-width: $medium-screen) {
+    display: inline-block !important;
+  }
+}
+.show-on-small-inline-block {
+  @media #{$small-and-down} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-and-up-inline-block {
+  @media #{$medium-and-up} {
+    display: inline-block !important;
+  }
+}
+.show-on-medium-and-down-inline-block {
+  @media #{$medium-and-down} {
+    display: inline-block !important;
+  }
+}
+
+
+.show-on-large-inline {
+  @media #{$large-and-up} {
+    display: inline !important;
+  }
+}
+.show-on-medium-inline {
+  @media only screen and (min-width: $small-screen) and (max-width: $medium-screen) {
+    display: inline !important;
+  }
+}
+.show-on-small-inline {
+  @media #{$small-and-down} {
+    display: inline !important;
+  }
+}
+.show-on-medium-and-up-inline {
+  @media #{$medium-and-up} {
+    display: inline !important;
+  }
+}
+.show-on-medium-and-down-inline {
+  @media #{$medium-and-down} {
+    display: inline !important;
+  }
+}
+
+
+.show-on-large-flex {
+  @media #{$large-and-up} {
+    display: flex !important;
+  }
+}
+.show-on-medium-flex {
+  @media only screen and (min-width: $small-screen) and (max-width: $medium-screen) {
+    display: flex !important;
+  }
+}
+.show-on-small-flex {
+  @media #{$small-and-down} {
+    display: flex !important;
+  }
+}
+.show-on-medium-and-up-flex {
+  @media #{$medium-and-up} {
+    display: flex !important;
+  }
+}
+.show-on-medium-and-down-flex {
+  @media #{$medium-and-down} {
+    display: flex !important;
+  }
+}
+
+
+.show-on-large-inline-flex {
+  @media #{$large-and-up} {
+    display: inline-flex !important;
+  }
+}
+.show-on-medium-inline-flex {
+  @media only screen and (min-width: $small-screen) and (max-width: $medium-screen) {
+    display: inline-flex !important;
+  }
+}
+.show-on-small-inline-flex {
+  @media #{$small-and-down} {
+    display: inline-flex !important;
+  }
+}
+.show-on-medium-and-up-inline-flex {
+  @media #{$medium-and-up} {
+    display: inline-flex !important;
+  }
+}
+.show-on-medium-and-down-inline-flex {
+  @media #{$medium-and-down} {
+    display: inline-flex !important;
   }
 }
 


### PR DESCRIPTION
…flex

## Proposed changes
The CSS classes `.show-on-*` like `.show-on-medium-and-up` will always lead to a `display: block` but that's not always what you want.

I added classes for .show-on-* to make them supporting inline-block, inline, flex, inline-flex with the following pattern:
```
.show-on-(screensize)-(display-property)
// f.e.
.show-on-small-inline-block
```

## Screenshots (if appropriate) or codepen:
Codepen: [https://codepen.io/anon/pen/ayZrMP](https://codepen.io/anon/pen/ayZrMP)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
