### PR TITLE
Enable Checkbox and RadioButtons to be clickable when are inside input-field div

### DIFF
--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -31,6 +31,7 @@ form p:last-child {
     line-height: 25px;
     font-size: 1rem;
     user-select: none;
+    pointer-events: auto;    
   }
 
   /* checkbox aspect */

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -213,6 +213,8 @@ textarea.materialize-textarea {
   .prefix ~ label { margin-left: 3rem; }
 
   @media #{$medium-and-down} {
+    height: 4.5rem;
+
     .prefix ~ input {
       width: 86%;
       width: calc(100% - 3rem);

--- a/sass/components/forms/_radio-buttons.scss
+++ b/sass/components/forms/_radio-buttons.scss
@@ -20,6 +20,7 @@
   font-size: 1rem;
   transition: .28s ease;
   user-select: none;
+  pointer-events: auto;
 }
 
 [type="radio"] + label:before,


### PR DESCRIPTION
I created the following CodePen to show the problem and solution.
https://codepen.io/alexisdiel/pen/gxwPWj

This fix makes it possible to use checkboxes and radio-buttons inside the input-field div so that they inherit the CSS (margin, padding...).

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
