### PR TITLE
Solution For Swipeable Tabs Fixed Height

### DIFF
--- a/sass/components/_carousel.scss
+++ b/sass/components/_carousel.scss
@@ -55,6 +55,12 @@
       width: 100%;
     }
   }
+  
+  &.tabs-content {
+    .carousel-item {
+      height: auto;
+    }
+  }
 
   .indicators {
     position: absolute;


### PR DESCRIPTION
## Proposed changes

When tabs swipeable option is set to true, height is fixed 200px. #4148
Swipeable tabs have `.tabs-content` class so we can use this to solve the problem without affecting the existing carousel system.
I set `.carousel-item` height to `auto` which inside of `.tabs-content` class. This solved the problem.

## Screenshots (if appropriate) or codepen:

Issue and Solution: https://codepen.io/atemiz/pen/BdLOwq

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.