### PR TITLE
Replace deprecated $(document).ready() syntax

### DIFF
--- a/dist/js/materialize.js
+++ b/dist/js/materialize.js
@@ -1580,7 +1580,7 @@ if (jQuery) {
     });
   };
 
-  $(document).ready(function () {
+  $(function () {
     $('.collapsible').collapsible();
   });
 })(jQuery);;(function ($) {
@@ -1836,7 +1836,7 @@ if (jQuery) {
     });
   }; // End dropdown plugin
 
-  $(document).ready(function () {
+  $(function () {
     $('.dropdown-button').dropdown();
   });
 })(jQuery);
@@ -2492,7 +2492,7 @@ if (jQuery) {
     });
   };
 
-  $(document).ready(function () {
+  $(function () {
     $('.materialboxed').materialbox();
   });
 })(jQuery);
@@ -2789,7 +2789,7 @@ if (jQuery) {
     }
   };
 
-  $(document).ready(function () {
+  $(function () {
     $('ul.tabs').tabs();
   });
 })(jQuery);
@@ -3016,7 +3016,7 @@ if (jQuery) {
     return { x: newX, y: newY };
   };
 
-  $(document).ready(function () {
+  $(function () {
     $('.tooltipped').tooltip();
   });
 })(jQuery);
@@ -4245,7 +4245,7 @@ if (jQuery) {
       onScroll(options.scrollOffset);
     }, options.throttle || 100);
     var readyScroll = function () {
-      $(document).ready(throttledScroll);
+      $(throttledScroll);
     };
 
     if (!isSpying) {
@@ -4329,7 +4329,7 @@ if (jQuery) {
   };
 })(jQuery);
 ;(function ($) {
-  $(document).ready(function () {
+  $(function () {
 
     // Function to update labels of text fields
     Materialize.updateTextFields = function () {
@@ -4358,7 +4358,7 @@ if (jQuery) {
     });
 
     // Add active if input element has been pre-populated on document ready
-    $(document).ready(function () {
+    $(function () {
       Materialize.updateTextFields();
     });
 
@@ -4805,7 +4805,7 @@ if (jQuery) {
         }
       });
     };
-  }); // End of $(document).ready
+  }); // End of $
 
   /*******************
    *  Select Plugin  *
@@ -5430,7 +5430,7 @@ if (jQuery) {
   }; // Plugin end
 })(jQuery);
 ;(function ($) {
-  $(document).ready(function () {
+  $(function () {
 
     $(document).on('click.card', '.card', function (e) {
       if ($(this).find('> .card-reveal').length) {
@@ -5465,7 +5465,7 @@ if (jQuery) {
     autocompleteOptions: {}
   };
 
-  $(document).ready(function () {
+  $(function () {
     // Handle removal of static chips.
     $(document).on('click', '.chip .close', function (e) {
       var $chips = $(this).closest('.chips');
@@ -5840,7 +5840,7 @@ if (jQuery) {
     });
   };
 })(jQuery);;(function ($) {
-  $(document).ready(function () {
+  $(function () {
 
     // jQuery reverse
     $.fn.reverse = [].reverse;
@@ -6150,7 +6150,7 @@ if (jQuery) {
     });
   };
 
-  $(document).ready(function () {
+  $(function () {
     // Hardcoded .staggered-list scrollFire
     // var staggeredListOptions = [];
     // $('ul.staggered-list').each(function (i) {
@@ -9267,7 +9267,7 @@ if (jQuery) {
     }
   }
 
-  $(document).ready(function () {
+  $(function () {
     $('input, textarea').characterCounter();
   });
 })(jQuery);

--- a/jade/page-contents/carousel_content.html
+++ b/jade/page-contents/carousel_content.html
@@ -31,7 +31,7 @@
     <div id="options" class="scrollspy section">
       <h4>jQuery Initialization</h4>
        <pre><code class="language-javascript">
-    $(document).ready(function(){
+    $(function(){
       $('.carousel').carousel();
     });
         </code></pre>

--- a/jade/page-contents/collapsible_content.html
+++ b/jade/page-contents/collapsible_content.html
@@ -74,7 +74,7 @@
         <h4>Initialization</h4>
         <span>Collapsible elements only need initialization if they are added dynamically. You can also pass in options inside the initialization, however this can be done in the HTML markup as well.</span>
         <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('.collapsible').collapsible();
   });
         </code></pre>

--- a/jade/page-contents/dialogs_content.html
+++ b/jade/page-contents/dialogs_content.html
@@ -83,7 +83,7 @@
         <h4>Initialization</h4>
         <p>Tooltips are initialized automatically, but if you have dynamically added tooltips, you will need to initialize them.</p>
         <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('.tooltipped').tooltip({delay: 50});
   });
         </code></pre><br>

--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -115,7 +115,7 @@
         </code></pre>
 
         <pre><code class="language-javascript">
-  $(document).ready(function() {
+  $(function() {
     Materialize.updateTextFields();
   });
         </code></pre>
@@ -484,7 +484,7 @@
             <h4>Initialization</h4>
             <p>You must initialize the select element as shown below. In addition, you will need a separate call for any dynamically generated select elements your page generates.</p>
             <pre><code class="language-javascript col s12">
-  $(document).ready(function() {
+  $(function() {
     $('select').material_select();
   });
             </code></pre>
@@ -857,7 +857,7 @@
         <h4>Initialization</h4>
         <p>There are no options for this plugin, but if you are adding these dynamically, you can use this to initialize them.</p>
         <pre><code class="language-javascript">
-  $(document).ready(function() {
+  $(function() {
     $('input#input_text, textarea#textarea1').characterCounter();
   });
         </code></pre>

--- a/jade/page-contents/media_content.html
+++ b/jade/page-contents/media_content.html
@@ -17,7 +17,7 @@
       <h4>Initialization</h4>
        <p>Materialbox is intialized automatically. However, if you add images dynamically, you will have to add this initialization code.</p>
        <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('.materialboxed').materialbox();
   });
         </code></pre>
@@ -115,7 +115,7 @@
       <br>
       <h4>jQuery Initialization</h4>
        <pre><code class="language-javascript">
-    $(document).ready(function(){
+    $(function(){
       $('.slider').slider();
     });
         </code></pre>

--- a/jade/page-contents/modals_content.html
+++ b/jade/page-contents/modals_content.html
@@ -148,7 +148,7 @@
           <h4>jQuery Plugin Initialization</h4>
           <p>To open a modal using a trigger:</p>
           <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     // the "href" attribute of the modal trigger must specify the modal ID that wants to be triggered
     $('.modal').modal();
   });

--- a/jade/page-contents/parallax_content.html
+++ b/jade/page-contents/parallax_content.html
@@ -26,7 +26,7 @@
       <div id="initialization" class="scrollspy section">
         <h4>Initialization</h4>
         <pre><code class="language-javascript">
-    $(document).ready(function(){
+    $(function(){
       $('.parallax').parallax();
     });
         </code></pre>

--- a/jade/page-contents/pushpin_content.html
+++ b/jade/page-contents/pushpin_content.html
@@ -34,7 +34,7 @@
         <h4>jQuery Plugin Initialization</h4>
         <p>Here is a sample initialization of pushpin. Take a look at what the options are and customize them to your needs.</p>
         <pre><code class="language-javascript col s12">
-  $(document).ready(function(){
+  $(function(){
     $('.target').pushpin({
       top: 0,
       bottom: 1000,

--- a/jade/page-contents/scrollspy_content.html
+++ b/jade/page-contents/scrollspy_content.html
@@ -41,7 +41,7 @@
       <div id="initialization" class="section scrollspy">
         <h4>jQuery Plugin Initialization</h4>
         <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('.scrollspy').scrollSpy();
   });
         </code></pre>

--- a/jade/page-contents/tabs_content.html
+++ b/jade/page-contents/tabs_content.html
@@ -88,7 +88,7 @@
         <h4>jQuery Plugin Initialization</h4>
         <p>Tabs are initialized automatically, but if you add tabs dynamically you will have to initialize them like this.</p>
         <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('ul.tabs').tabs();
   });
         </code></pre>
@@ -98,7 +98,7 @@
         <h4>jQuery Plugin Methods</h4>
         <p>You can programmatically trigger a tab change with our <code class="language-javascript">select_tab</code> method. You have to input the id of the tab you want to switch to. In the case of our demo it would be either test1, test2, test3, or test4.</p>
         <pre><code class="language-javascript">
-  $(document).ready(function(){
+  $(function(){
     $('ul.tabs').tabs('select_tab', 'tab_id');
   });
         </code></pre>

--- a/jade/search.js
+++ b/jade/search.js
@@ -1,5 +1,5 @@
 (function ($) {
-  $(document).ready(function() {
+  $(function() {
     window.index = lunr(function () {
       this.field('title', {boost: 10});
       this.field('body');

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -1,5 +1,5 @@
 (function ($) {
-  $(document).ready(function() {
+  $(function() {
 
     // jQuery reverse
     $.fn.reverse = [].reverse;

--- a/js/cards.js
+++ b/js/cards.js
@@ -1,5 +1,5 @@
 (function ($) {
-  $(document).ready(function() {
+  $(function() {
 
     $(document).on('click.card', '.card', function (e) {
       if ($(this).find('> .card-reveal').length) {

--- a/js/character_counter.js
+++ b/js/character_counter.js
@@ -65,7 +65,7 @@
     }
   }
 
-  $(document).ready(function(){
+  $(function(){
     $('input, textarea').characterCounter();
   });
 

--- a/js/chips.js
+++ b/js/chips.js
@@ -6,7 +6,7 @@
     autocompleteOptions: {},
   };
 
-  $(document).ready(function() {
+  $(function() {
     // Handle removal of static chips.
     $(document).on('click', '.chip .close', function(e){
       var $chips = $(this).closest('.chips');

--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -177,7 +177,7 @@
     });
   };
 
-  $(document).ready(function(){
+  $(function(){
     $('.collapsible').collapsible();
   });
 }( jQuery ));

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -268,7 +268,7 @@
     });
   }; // End dropdown plugin
 
-  $(document).ready(function(){
+  $(function(){
     $('.dropdown-button').dropdown();
   });
 }( jQuery ));

--- a/js/forms.js
+++ b/js/forms.js
@@ -1,5 +1,5 @@
 (function ($) {
-  $(document).ready(function() {
+  $(function() {
 
     // Function to update labels of text fields
     Materialize.updateTextFields = function() {
@@ -28,7 +28,7 @@
     });
 
     // Add active if input element has been pre-populated on document ready
-    $(document).ready(function() {
+    $(function() {
       Materialize.updateTextFields();
     });
 
@@ -480,7 +480,7 @@
       });
     };
 
-  }); // End of $(document).ready
+  }); // End of $
 
   /*******************
    *  Select Plugin  *

--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -282,7 +282,7 @@
     });
   };
 
-  $(document).ready(function(){
+  $(function(){
     $('.materialboxed').materialbox();
   });
 

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -151,7 +151,7 @@
 			onScroll(options.scrollOffset);
 		}, options.throttle || 100);
 		var readyScroll = function(){
-			$(document).ready(throttledScroll);
+			$(throttledScroll);
 		};
 
 		if (!isSpying) {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -239,7 +239,7 @@
     }
   };
 
-  $(document).ready(function(){
+  $(function(){
     $('ul.tabs').tabs();
   });
 }( jQuery ));

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -233,7 +233,7 @@
     return {x: newX, y: newY};
   };
 
-  $(document).ready(function(){
+  $(function(){
      $('.tooltipped').tooltip();
    });
 }( jQuery ));

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -61,7 +61,7 @@
   };
 
 
-  $(document).ready(function() {
+  $(function() {
     // Hardcoded .staggered-list scrollFire
     // var staggeredListOptions = [];
     // $('ul.staggered-list').each(function (i) {

--- a/test/html/badges.html
+++ b/test/html/badges.html
@@ -133,7 +133,7 @@
 <!--  <script src="js/leanModal.js"></script>-->
 
   <script>
-    $(document).ready(function(){
+    $(function(){
         $('select').material_select();
     });
   </script>

--- a/test/html/dropdown.html
+++ b/test/html/dropdown.html
@@ -594,7 +594,7 @@ Align right: --------------------------------
 <!--  <script src="js/leanModal.js"></script>-->
 
   <script>
-   $(document).ready(function(){
+   $(function(){
 
   });
   </script>

--- a/test/html/forms.html
+++ b/test/html/forms.html
@@ -323,7 +323,7 @@
 <!--  <script src="js/leanModal.js"></script>-->
 
   <script>
-    $(document).ready(function(){
+    $(function(){
         $('select').material_select();
     });
   </script>

--- a/test/html/multiple_modals.html
+++ b/test/html/multiple_modals.html
@@ -111,7 +111,7 @@
   <!--  <script src="js/leanModal.js"></script>-->
 
     <script>
-     $(document).ready(function(){
+     $(function(){
       $('.modal').modal();
     });
     </script>


### PR DESCRIPTION
## Proposed changes
Starting with jQuery 3.0, the `$(document).ready(handler)` syntax is [deprecated](https://api.jquery.com/ready/). `$(handler)` is now the only recommended syntax for running a function when the DOM is fully initialized.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.