### PR TITLE
Removed color: inital from the caret element #5076

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -82,7 +82,6 @@ select {
   }
 
   span.caret {
-    color: initial;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
## Proposed changes
Remove the
```css
color: inital
```
from the .caret element. #5076 
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
