### PR TITLE
Fixed nesting tabs bug

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -66,6 +66,12 @@
 
       // If the location.hash matches one of the links, use that as the active tab.
       $active = $($links.filter('[href="'+location.hash+'"]'));
+        
+      // With nested tabs, activate the parent tab if the nested tab is active.
+      if ($active.length > 0) {
+        var id = $(this).parent().attr('id');
+        $('a[href="#'+id+'"]').trigger('click');
+      }
 
       // If no match is found, use the first link or any with class 'active' as the initial active tab.
       if ($active.length === 0) {


### PR DESCRIPTION
When using the URL to pre-select a nested tab, activate that tab's parent tab. #5087

## Proposed changes
With nested tabs, activate the parent tab if the nested tab is active through the URL.

## Screenshots (if appropriate) or codepen:
[Example](http://i.imgur.com/MZUkKHQ.gifv)

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [ x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
