### PR TITLE
Fixed prev_index declaration in order to comply with JS strict mode.

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -25,7 +25,8 @@
           $tabs_wrapper,
           $tab_width = Math.max($tabs_width, $this[0].scrollWidth) / $links.length,
           $indicator,
-          index = prev_index = 0,
+          index = 0,
+          prev_index = 0,
           clicked = false,
           clickedTimeout,
           transition = 300;


### PR DESCRIPTION
## Proposed changes
Fixes a violation of JS strict mode. Especially, fixes the following error that appears when the lib is bundled within an iife that contains `'use strict'`:
```
Uncaught ReferenceError: prev_index is not defined
    at HTMLUListElement.<anonymous> (bundle.js:13569)
    at Function.each (bundle.js:365)
    at jQuery.fn.init.each (bundle.js:160)
    at jQuery.fn.init.init (bundle.js:13552)
    at jQuery.fn.init.$.fn.tabs (bundle.js:13773)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
