### PR TITLE
Blinking cursor in Select on IE11

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -118,6 +118,11 @@ select:disabled {
   user-select: none;
 }
 
+.select-wrapper input.select-dropdown:focus {
+    text-indent: -9999999em;
+    transition: none;
+}
+
 .select-wrapper i {
   color: $select-disabled-color;
 }


### PR DESCRIPTION
On open the select shows a blinking cursor in IE 11 (Closed Issues #4413, #3715)
See in demos: http://materializecss.com/forms.html

As this issue hasn`t been fixed for IE 10 / 11 I thought I propose this fix which has been mentioned in closed issue #4413.

I added for transition: none but it takes some time.
Maybe you have a better solution for this @Dogfalo

I have tested the fix in Chrome,FF and IE 11 and it works equal for all 3 browsers



