### PR TITLE
Use data-target to open modal if href provided too

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -133,11 +133,13 @@
     handleTriggerClick(e) {
       let $trigger =  $(e.target).closest('.modal-trigger');
       if (e.target && $trigger.length) {
-        let modalId = $trigger[0].getAttribute('href');
-        if (modalId) {
+        let modalId = $trigger[0].getAttribute('data-target');
+        if (!modalId) {
+          modalId = $trigger[0].getAttribute('href');
+          if (!modalId) {
+            return;
+          }
           modalId = modalId.slice(1);
-        } else {
-          modalId = $trigger[0].getAttribute('data-target');
         }
         let modalInstance = document.getElementById(modalId).M_Modal;
         if (modalInstance) {

--- a/tests/spec/modal/modalFixture.html
+++ b/tests/spec/modal/modalFixture.html
@@ -42,3 +42,18 @@
     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat">Agree</a>
   </div>
 </div>
+
+
+<!-- Modal Trigger -->
+<a class="waves-effect waves-light btn modal-trigger" href="#" data-target="modal4">Modal</a>
+
+<!-- Modal Structure -->
+<div id="modal4" class="modal">
+  <div class="modal-content">
+    <h4>Modal Header</h4>
+    <p>A bunch of text</p>
+  </div>
+  <div class="modal-footer">
+    <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat">Agree</a>
+  </div>
+</div>

--- a/tests/spec/modal/modalSpec.js
+++ b/tests/spec/modal/modalSpec.js
@@ -1,6 +1,6 @@
 describe( 'Modal:', function() {
   var transformMaterialbox;
-  var trigger1, modal1, trigger2, modal2, trigger3, modal3;
+  var trigger1, modal1, trigger2, modal2, trigger3, modal3, trigger4, modal4;
 
   beforeEach(function() {
     loadFixtures('modal/modalFixture.html');
@@ -8,9 +8,11 @@ describe( 'Modal:', function() {
     triggerIcon1 = $('.btn[data-target="modal1"] i');
     trigger2 = $('.btn[href="#modal2"]');
     trigger3 = $('.btn[href="#modal3"]');
+    trigger4 = $('.btn[href="#modal4"]');
     modal1 = $('#modal1');
     modal2 = $('#modal2');
     modal3 = $('#modal3');
+    modal4 = $('#modal4');
   });
 
   describe('Modals', function() {
@@ -121,6 +123,24 @@ describe( 'Modal:', function() {
         }, 500);
       }, 500);
     });
+  });
+
+  it('Should open instead of navigate', function(done) {
+    modal4.modal();
+    expect(modal4).toBeHidden('Modal should be hidden');
+
+    click(trigger4[0]);
+
+    setTimeout(function() {
+      expect(modal4).toBeVisible('Modal should be shown');
+      expect(modal4.hasClass('open')).toEqual(true, 'Modal should have class open');
+
+      // Check overlay is attached
+      var overlay = modal4.modal('getInstance').$overlay;
+      var overlayInDOM = $.contains(document, overlay[0]);
+      expect(overlayInDOM).toEqual(true, 'Overlay should be attached on open');
+
+    }, 500);
   });
 
 });


### PR DESCRIPTION
## Proposed changes
What I was trying to achieve is to have a `.modal-trigger` that can trigger the modal on a normal browser and have a fallback to an alternative page for others, such as web crawlers.

For example:
```html
<a href="/example/details.html" data-target="modal-details" class="modal-trigger">Show details [+]</a>
<div class="modal" id="modal-details">
    My Details...
</div>
```

This allows to keep content accessible for devices such as screen readers and is also good for SEO.
This is similar to the background idea of this issue: https://github.com/Dogfalo/materialize/issues/3100

The problem is that in the current implementation of modals, `href` takes precedence over `data-target` making the above example to fail and open the page instead of the modal even on JS enabled browsers.

The proposed change is to swap the precedence and take the `data-target` if it is provided, regardless of the `href`.

PS: Please check the unit tests, I never used js testing tools and doesn't have an env to run them.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
