### PR TITLE
Datepicker label move fix for input[type=date] on mozilla

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -3,7 +3,7 @@
 
     // Function to update labels of text fields
     Materialize.updateTextFields = function() {
-      var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
+      var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], input[type=date], textarea';
       $(input_selector).each(function(index, element) {
         var $this = $(this);
         if ($(element).val().length > 0 || $(element).is(':focus') || element.autofocus || $this.attr('placeholder') !== undefined) {
@@ -17,7 +17,7 @@
     };
 
     // Text based inputs
-    var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
+    var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], input[type=date], textarea';
 
     // Add active if form auto complete
     $(document).on('change', input_selector, function () {


### PR DESCRIPTION
## Proposed changes
Add input[date] to change watchlist for inputs whose labels need to be moved up/down.

## Screenshots (if appropriate) or codepen:
Environment - Windows 10, Firefox 54.0.1 (32-bit)
Before code changes-
![image](https://user-images.githubusercontent.com/17565234/29497197-66768c9e-8601-11e7-9165-7d119bcf747e.png)

After code changes-
![image](https://user-images.githubusercontent.com/17565234/29497205-8b5988d6-8601-11e7-8eb9-568eaa620854.png)



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
