### PR TITLE
add nav.collapse-* classes to define when the navbar collapses

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -8,9 +8,15 @@
         closeOnClick: false,
         draggable: true,
         onOpen: null,
-        onClose: null
+        onClose: null,
+        break: 992,
       };
       options = $.extend(defaults, options);
+
+      if (typeof options.break !== 'number') {
+        var breaks = { small: 600, medium: 992, large: 1200 };
+        options.break = breaks[options.break] ? breaks[options.break] : breaks.medium;
+      }
 
       $(this).each(function(){
         var $this = $(this);
@@ -48,7 +54,7 @@
 
         // If fixed sidenav, bring menu out
         if (menu.hasClass('fixed')) {
-            if (window.innerWidth > 992) {
+            if (window.innerWidth > options.break) {
               menu.css('transform', 'translateX(0)');
             }
           }
@@ -56,8 +62,8 @@
         // Window resize to reset on large screens fixed
         if (menu.hasClass('fixed')) {
           $(window).resize( function() {
-            if (window.innerWidth > 992) {
-              // Close menu if window is resized bigger than 992 and user has fixed sidenav
+            if (window.innerWidth > options.break) {
+              // Close menu if window is resized bigger than options.break and user has fixed sidenav
               if ($('#sidenav-overlay').length !== 0 && menuOut) {
                 removeMenu(true);
               }
@@ -82,7 +88,7 @@
         // if closeOnClick, then add close event for all a tags in side sideNav
         if (options.closeOnClick === true) {
           menu.on("click.itemclick", "a:not(.collapsible-header)", function(){
-            if (!(window.innerWidth > 992 && menu.hasClass('fixed'))){
+            if (!(window.innerWidth > options.break && menu.hasClass('fixed'))){
               removeMenu();
             }
           });

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -64,30 +64,28 @@ nav {
     font-size: $navbar-brand-font-size;
     padding: 0;
 
+    left: 50%;
+    transform: translateX(-50%);
+
     &.center {
       left: 50%;
       transform: translateX(-50%);
     }
 
-    @media #{$medium-and-down} {
-      left: 50%;
-      transform: translateX(-50%);
-
-      &.left, &.right {
-        padding: 0;
-        transform: none;
-      }
-
-      &.left { left: 0.5rem; }
-      &.right {
-        right: 0.5rem;
-        left: auto;
-      }
+    &.left, &.right {
+      padding: 0;
+      transform: none;
     }
 
+    &.left { left: 0.5rem; }
     &.right {
       right: 0.5rem;
-      padding: 0;
+      left: auto;
+    }
+
+    @media #{$large-and-up} {
+      left: auto;
+      transform: translateX(0);
     }
 
     i,
@@ -98,6 +96,37 @@ nav {
     }
   }
 
+
+  &.collapse-small {
+    @media #{$medium-and-up} {
+      a.button-collapse { display: none; }
+
+      .brand-logo {
+        left: auto;
+        transform: translateX(0);
+      }
+    }
+  }
+
+  &.collapse-large {
+    @media #{$large-and-up} {
+      a.button-collapse { display: block; }
+
+      .brand-logo {
+        left: 50%;
+        transform: translateX(-50%);
+      }
+    }
+
+    @media #{$extra-large-and-up} {
+      a.button-collapse { display: none; }
+
+      .brand-logo {
+        left: auto;
+        transform: translateX(0);
+      }
+    }
+  }
 
   // Title
   .nav-title {


### PR DESCRIPTION
## Proposed changes
When the navbar should collapse depends on the size of the navbar and is therefore something that is different on each site. With these changes the user can define when the navbar collapses with `nav.collapse-small` and `nav.collapse-large`.

The defaults are not touched by this PR.

## Screenshots (if appropriate) or codepen:
https://codepen.io/tflori/pen/WEgLOr
This example does not need to break to a sidenav for a medium screen

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
