### PR TITLE
Fix fixed sideNav example

### DIFF
--- a/jade/page-contents/sideNav_content.html
+++ b/jade/page-contents/sideNav_content.html
@@ -154,7 +154,7 @@
       padding-left: 300px;
     }
 
-    @media only screen and (max-width : 992px) {
+    @media only screen and (max-width : 993px) {
       header, main, footer {
         padding-left: 0;
       }


### PR DESCRIPTION
## Proposed changes
Fixed the example at the very bottom of http://materializecss.com/side-nav.html.
This should be `max-width: 993px` because else there is one specific width where the sideNav is hidden but the content gets padded.

## Screenshots (if appropriate) or codepen:
(unrelated)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation. (unrelated)
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (unrelated)
- [ ] All new and existing tests passed. (unrelated)
