### PR TITLE
remove transition and transform from dropdown option label

### DIFF
--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -43,6 +43,8 @@
     }
 
     & > span > label {
+      transform: none;
+      transition: none;
       top: 1px;
       left: 0;
       height: 18px;


### PR DESCRIPTION
fixes #5155 and fixes #5083 