### PR TITLE
Fix markup and word order

### DIFF
--- a/jade/page-contents/transitions_content.html
+++ b/jade/page-contents/transitions_content.html
@@ -7,7 +7,7 @@
         <p class="caption">We've made some custom animation functions that will transition your content. It's recommended to use this with our <a href="/scrollfire.html">ScrollFire Plugin</a> to make your content transition in as you scroll.</p>
 
         <h4>showStaggeredList</h4>
-        <p>Use this to create a staggered reveal effect for any <code class="language-markup">UL</code> Tag with list items. Just make sure the list items in the <code class="language-markup">UL</code> are <code class="language-css">opacity: 0; to ensure the animation works correctly.</code></p>
+        <p>Use this function to create a staggered reveal effect for all <code class=" language-markup"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>li</span><span class="token punctuation">&gt;</span></span></code> elements of an unordered list. To ensure the animation works correctly just initialize each list item inside the <code class=" language-markup"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>ul</span><span class="token punctuation">&gt;</span></span></code> tag with  <code class=" language-css"><span class="token property">opacity</span><span class="token punctuation">:</span> 0<span class="token punctuation">;</span></code>.</p>
 
         <table class="highlight">
           <thead>


### PR DESCRIPTION
## Proposed changes
Fixes markup and word order of the `Materialize.showStaggeredList()` method documentation.

## Screenshots (if appropriate) or codepen:
(unrelated)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Contribution to Materialize's documentation

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
