### PR TITLE
Add "contribution to documentation" as type of change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue).
 - [ ] New feature (non-breaking change which adds functionality).
 - [ ] Breaking change (fix or feature that would cause existing functionality to change).
+- [ ] Contribution to Materialize's documentation
 
 ## Checklist:
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


### PR DESCRIPTION
## Proposed changes
Adds "contribution to documentation" as fourth point in the type of change section.

## Screenshots (if appropriate) or codepen:
(unrelated)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
