### PR TITLE
Added remote ajax call to autocomplete

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -911,6 +911,29 @@
     minLength: 1, // The minimum length of the input for the autocomplete to start. Default: 1.
   });
         </code></pre>
+
+        <h4>Remote ajax call</h4>
+        <p>To fetch a remote server, you need to replace the "data" parameter with the "url" parameter containing the remote content url.</p>
+        <p>Few things to note :</p>
+        <ul>
+          <li>The request is send by GET according to HTML protocol spec for fetching content</li>
+          <li>The get variable name containing the search is "val" </li>
+          <li>Your server must respond in XML or JSON</li>
+          <li>The output should be an object's array. Each object must have at least a "value" key containing the text. It can also have an "img" key containing the optional picture url. <b>Any other key present in the response objects can be retrieve in the onAutocomplete callback. See below :</b></li>
+        </ul>
+        <pre><code class="language-javascript">
+  $('input.autocomplete').autocomplete({
+    url: "/my/api/users/search"
+    limit: 20, // The max amount of results that can be shown at once. Default: Infinity.
+    onAutocomplete: function(val, data) {
+      // Callback function when value is autcompleted.
+      // If your response objects has and "id" key, you can access it like that
+      $('#my-hidden-user-field').val(data.id);
+    },
+    minLength: 1, // The minimum length of the input for the autocomplete to start. Default: 1.
+    debounceTime: 500 // Time after you stop typing for the request to be sent. Default: 500
+  });
+        </code></pre>
       </div>
 
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -475,6 +475,7 @@
                 if( data[key].value ) {
                   buildAutocompleteOption(val, data[key].value, data[key].img, other);
                 }
+                count++;
               }
             });
 

--- a/js/forms.js
+++ b/js/forms.js
@@ -460,14 +460,18 @@
 
               if( ! data ) return;
               
-              for(var key in data) { 
+              for(var key in data) {
+                // Break if past limit
+                if (count >= options.limit) {
+                  break;
+                } 
                 // Find any other property than value and img, and pass it in 'other' arg
                 for(var p in data[key]) {
                   if( ['value', 'img'].indexOf(p) == -1 ) {
                     other[p] = data[key][p];
                   }  
                 }
-                
+                // Build option
                 if( data[key].value ) {
                   buildAutocompleteOption(val, data[key].value, data[key].img, other);
                 }


### PR DESCRIPTION
Hi. First of all, thanks for this nice framework. This is the first time I contribute to this repository. I added this feature because I need it in some project. 

## Proposed changes
This PR add the possibility to the autocomplete framework to fetch remote server to get results. I did this with the care of not breaking anything existing in mind. So, basically, if you replace the "data" parameter by an "url" parameter, the plugin will change its behavior to fetch results on the url. If you dont, no changes will be made at how the plugin work.

About how the Ajax part works, please note the following : 

- Request is send x ms after the user stop typing. x can be set with the "debounceTime" options, default is 500.
- If a request start but a previous one is still running, it cancel the old one to avoid unpredictable behavior
- The request is sent by GET, according to HTTP protocol specification. The string parameter name is "val" 
- The server output must be an objects array in XML or JSON. The needed key is "value" (the text), and an optional "img" key can be used to pass image url. Any other key -> val present in the objects will be available in the onAutocomplete callback (see example code for this in the updated doc).

I have updated the doc but since i'm not a native english speaker, things can be not so well said, you can check it and make corrections if it need some.

If you want others changes about this, feel free to ask.

## Screenshots (if appropriate) or codepen:
Screenshot would be the same as the actual autocomplete, and I can't provide a pen since it need a server call to give back results. You will however find some code in the doc page I updated.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
