### PR TITLE
Move Materialize.updateTextFields out of $(document).ready

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1,5 +1,4 @@
 (function ($) {
-  $(document).ready(function() {
 
     // Function to update labels of text fields
     Materialize.updateTextFields = function() {
@@ -15,6 +14,8 @@
         }
       });
     };
+  
+    $(document).ready(function() {
 
     // Text based inputs
     var input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';


### PR DESCRIPTION
This PR fixes an error with Angular 2+ where the ng lifecycle hook `ngAfterViewInit(){}` gets called BEFORE $(document).ready(). Therefore this code fails because the function isn't available at run time.

Fixes #5194

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Move updateTextFields() outside of `$(document).ready`. 

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
