### PR TITLE
Added tests for the classic input fields.

### DIFF
--- a/tests/spec/forms/inputfields/inputfieldsFixture.html
+++ b/tests/spec/forms/inputfields/inputfieldsFixture.html
@@ -1,0 +1,60 @@
+
+<form>
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_text" type="text"/>
+      <label for="input_text">Materialize CSS Text</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_password" type="password"/>
+      <label for="input_password">Materialize CSS Password</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_email" type="email"/>
+      <label for="input_email">Materialize CSS Email</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_url" type="url"/>
+      <label for="input_url">Materialize CSS Url</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_tel" type="tel"/>
+      <label for="input_tel">Materialize CSS Tel</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_number" type="number"/>
+      <label for="input_number">Materialize CSS Number</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <input id="input_search" type="search"/>
+      <label for="input_search">Materialize CSS Search</label>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col s12 input-field">
+      <textarea id="input_textarea" class="materialize-textarea"></textarea>
+      <label for="input_textarea">Materialize CSS Textarea</label>
+    </div>
+  </div>
+
+  <input type="reset" value="reset" />
+</form>

--- a/tests/spec/forms/inputfields/inputfieldsSpec.js
+++ b/tests/spec/forms/inputfields/inputfieldsSpec.js
@@ -1,0 +1,244 @@
+describe("Input Fields Plugin", function() {
+  var inputTypes = [
+    {"type": "input[type=text]", "goodValue": "Materialize CSS", "badValue": ""},
+    {"type": "input[type=password]", "goodValue": "Materialize CSS", "badValue": ""},
+    {"type": "input[type=email]", "goodValue": "contact@materialize.com", "badValue": ""},
+    {"type": "input[type=url]", "goodValue": "http://materialize-css.com", "badValue": ""},
+    {"type": "input[type=tel]", "goodValue": "0123456789", "badValue": ""},
+    {"type": "input[type=number]", "goodValue": 10, "badValue": ""},
+    {"type": "input[type=search]", "goodValue": "Materialize CSS", "badValue": ""},
+    {"type": "textarea", "goodValue": "Materialize CSS", "badValue": ""}
+  ];
+  var inputsBrowser = {};
+
+  function testEachInput(index, fnPredicate, fnExpect, done) {
+    if (index >= inputTypes.length) {
+      done();
+      return;
+    }
+    fnPredicate(inputsBrowser[inputTypes[index].type], function() {
+      setTimeout(function() {
+        fnExpect(inputsBrowser[inputTypes[index].type], function() {
+          testEachInput(index + 1, fnPredicate, fnExpect, done);
+        });
+      }, 200);
+    });
+  }
+
+  beforeEach(function() {
+    loadFixtures('forms/inputfields/inputfieldsFixture.html');
+
+    inputTypes.forEach(function(type) {
+      inputsBrowser[type.type] = {};
+      inputsBrowser[type.type].input = $(type.type);
+      inputsBrowser[type.type].label = inputsBrowser[type.type].input.siblings("label");
+      inputsBrowser[type.type].badValue = type.badValue;
+      inputsBrowser[type.type].goodValue = type.goodValue;
+    });
+  });
+
+  describe("Input and textarea", function() {
+    it("should have label not active when input have not focused", function() {
+      inputTypes.forEach(function(type) {
+        expect(inputsBrowser[type.type].label.hasClass("active")).toBe(false);
+      });
+    });
+
+    it("should have label active when input have focused", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          next();
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+
+    it("should have label active when input have value", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.goodValue);
+          next();
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+
+    it("should have label not active when input have no value", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.blur();
+          next();
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(false);
+          next();
+        },
+        done
+      );
+    });
+
+    it("should have label not active when input is reset", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.goodValue);
+          inputBrowser.input.blur();
+
+          setTimeout(function() {
+            $("input[type=reset").click();
+            next();
+          }, 200);
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(false);
+          next();
+        },
+        done
+      );
+    });
+  });
+
+  describe("Input with placeholder", function() {
+    beforeEach(function(done){
+      Object.keys(inputsBrowser).forEach(function(inputType){
+        inputsBrowser[inputType].input.prop("placeholder", inputsBrowser[inputType].goodValue);
+      });
+      
+      setTimeout(function(){
+        Materialize.updateTextFields();
+        done();
+      }, 400);
+    });
+
+    it("Should have label active by default", function() {
+      inputTypes.forEach(function(type) {
+        expect(inputsBrowser[type.type].label.hasClass("active")).toBe(true);
+      });
+    });
+
+    it("Should have label active when input has focus and lost it", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.blur();
+          next();
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+
+    it("Should have label active when user set value", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.goodValue);
+          inputBrowser.input.blur();
+          next();
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+
+    it("Should have label active when user set value and remove it", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.goodValue);
+          inputBrowser.input.blur();
+
+          setTimeout(function(){
+            inputBrowser.input.focus();
+            inputBrowser.input.val("");
+            inputBrowser.input.blur();
+            next();
+          }, 200);
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.label.hasClass("active")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+  });
+
+  describe("Input validation", function() {
+    beforeEach(function(done) {
+      Object.keys(inputsBrowser).forEach(function(inputType){
+        inputsBrowser[inputType].input.addClass("validate")
+        .prop("required", true);
+      });
+
+      setTimeout(function(){
+        Materialize.updateTextFields();
+        done();
+      }, 400);
+    });
+
+    it("Should be valid when input lost focus", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.goodValue);
+
+          setTimeout(function() {
+            inputBrowser.input.blur();
+            next();
+          }, 200);
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.input.hasClass("invalid")).toBe(false);
+          next();
+        },
+        done
+      );
+    });
+
+    it("Should be invalid when input lost focus", function(done) {
+      testEachInput(
+        0,
+        function(inputBrowser, next) {
+          inputBrowser.input.focus();
+          inputBrowser.input.val(inputBrowser.badValue);
+
+          setTimeout(function() {
+            inputBrowser.input.blur();
+            next();
+          }, 200);
+        },
+        function(inputBrowser, next) {
+          expect(inputBrowser.input.hasClass("invalid")).toBe(true);
+          next();
+        },
+        done
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes
I propose multiple tests about input fields #5023. I give you the list of field test :
- text
- password
- email
- url
- tel
- number
- search
- textarea

Tests added should cover all interactions that use could do.
The pull request may throw an error due to a bug about reset action on input. When the user click on reset button the label shouldn't be active.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
