### PR TITLE
Disable user select on toasts

### DIFF
--- a/sass/components/_toast.scss
+++ b/sass/components/_toast.scss
@@ -40,6 +40,7 @@
   align-items: center;
   justify-content: space-between;
   cursor: default;
+  user-select: none;
 
   .toast-action {
     color: $toast-action-color;


### PR DESCRIPTION
## Proposed changes
Disabled user select on toasts. When trying to swipe away (on desktop), sometimes, you select a portion of text when just trying to swipe the toast away.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
