### PR TITLE
Restore margins for <p> within .card-content

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -143,7 +143,12 @@
     border-radius: 0 0 2px 2px;
 
     p {
-      margin: 0;
+      &:first-child: {
+        margin-top: 0;
+      }
+      &:last-child {
+        margin-bottom: 0;
+      }
       color: inherit;
     }
     .card-title {

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -143,7 +143,7 @@
     border-radius: 0 0 2px 2px;
 
     p {
-      &:first-child: {
+      &:first-child {
         margin-top: 0;
       }
       &:last-child {


### PR DESCRIPTION
Restores margins for paragraphs within `.card-content`.

Fixes issue #5222 