### PR TITLE
Allows element with .waves-effect to be centered

### DIFF
--- a/sass/components/_waves.scss
+++ b/sass/components/_waves.scss
@@ -12,7 +12,6 @@
 .waves-effect {
   position: relative;
   cursor: pointer;
-  display: inline-block;
   overflow: hidden;
   user-select: none;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
This fixes elements with `.waves-effect` class added to this. Currently they cannot be centered without overriding the `display: inline-block` style that was set here. I do not see a reason for setting that property as it appears to do nothing. Removing it allows for easier centerting of buttons with `.waves-effect` class added to them

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Remove `display: inline-block` from `.waves-effect` class.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
