### PR TITLE
Change hiddenDiv.height() to .outerHeight()

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -159,8 +159,8 @@
        * Resize if the new height is greater than the
        * original height of the textarea
        */
-      if ($textarea.data('original-height') <= hiddenDiv.height()) {
-        $textarea.css('height', hiddenDiv.height());
+      if ($textarea.data('original-height') <= hiddenDiv.outerHeight()) {
+        $textarea.css('height', hiddenDiv.outerHeight());
       } else if ($textarea.val().length < $textarea.data('previous-length')) {
         /**
          * In case the new height is less than original height, it


### PR DESCRIPTION
The autosize feature for textareas does not work that well if one changes the style of the textarea to make use of padding and border-box.
I would suggest to simply change .height to .outerHeight for the hiddenDiv. It does not change anything to the current behavior, but one now can simply add the style also to the hiddenDiv, which then gets applied to the autosize automatically.

Another option would be to consider the textareas other css (beside the existing checks) and check for padding as well as box-sizing, and more. Also possible, but needs way more testing. The first approach would be a easier and faster fix.

Chose your favorite solution. One of them would be awesome!!

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
