### PR TITLE
Drop @extends and make the linter happy

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -349,7 +349,7 @@ ul.staggered-list li {
     padding: 10px 0px;
     color: $footer-copyright-font-color;
     background-color: $footer-copyright-bg-color;
-    @extend .light;
+    font-weight: 300;
   }
 }
 

--- a/sass/components/_typography.scss
+++ b/sass/components/_typography.scss
@@ -3,7 +3,7 @@ a {
   text-decoration: none;
 }
 
-html{
+html {
   line-height: 1.5;
 
   @media only screen and (min-width: 0) {
@@ -22,6 +22,7 @@ html{
   font-weight: normal;
   color: $off-black;
 }
+
 h1, h2, h3, h4, h5, h6 {
 	font-weight: 400;
 	line-height: 1.1;
@@ -43,14 +44,14 @@ small { font-size: 75%; }
 .light { font-weight: 300; }
 .thin { font-weight: 200; }
 
-
-.flow-text{
+.flow-text {
   font-weight: 300;
   $i: 0;
   @while $i <= $intervals {
     @media only screen and (min-width : 360 + ($i * $interval-size)) {
       font-size: 1.2rem * (1 + (.02 * $i));
     }
+
     $i: $i + 1;
   }
 


### PR DESCRIPTION
## Proposed changes
_Scenario:_
I want to use the framework without the `_typography.scss` stylesheet.
I can't do that because we have an extend rule for `.footer-copyright`

_Solution:_
For a better modularisation, we need to avoid `@extends`
https://www.sitepoint.com/avoid-sass-extend/

## Screenshots (if appropriate) or codepen:
No needed

## Types of changes
- [x] Gardening fix (non-breaking change which fixes an issue).


## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
