### PR TITLE
changed position of close button in Card Reveal Documentation

### DIFF
--- a/jade/page-contents/cards_content.html
+++ b/jade/page-contents/cards_content.html
@@ -225,7 +225,7 @@
                 <p><a href="#!">This is a link</a></p>
               </div>
               <div class="card-reveal">
-                <span class="card-title grey-text text-darken-4">Card Title<i class="material-icons right">close</i></i></span>
+                <span class="card-title grey-text text-darken-4"><i class="material-icons right">close</i>Card Title</span>
                 <p>Here is some more information about this product that is only revealed once clicked on.</p>
               </div>
             </div>
@@ -248,7 +248,7 @@
       &lt;p>&lt;a href="#">This is a link&lt;/a>&lt;/p>
     &lt;/div>
     &lt;div class="card-reveal">
-      &lt;span class="card-title grey-text text-darken-4">Card Title&lt;i class="material-icons right">close</i>&lt;/i>&lt;/span>
+      &lt;span class="card-title grey-text text-darken-4">&lt;i class="material-icons right">close</i>&lt;/i>Card Title&lt;/span>
       &lt;p>Here is some more information about this product that is only revealed once clicked on.&lt;/p>
     &lt;/div>
   &lt;/div>
@@ -563,4 +563,3 @@
 
   </div>
 </div>
-

--- a/jade/page-contents/cards_content.html
+++ b/jade/page-contents/cards_content.html
@@ -244,7 +244,7 @@
       &lt;img class="activator" src="images/office.jpg">
     &lt;/div>
     &lt;div class="card-content">
-      &lt;span class="card-title activator grey-text text-darken-4">Card Title&lt;i class="material-icons right">more_vert</i>&lt;/i>&lt;/span>
+      &lt;span class="card-title activator grey-text text-darken-4">Card Title&lt;i class="material-icons right">more_vert&lt;/i>&lt;/span>
       &lt;p>&lt;a href="#">This is a link&lt;/a>&lt;/p>
     &lt;/div>
     &lt;div class="card-reveal">


### PR DESCRIPTION
## Proposed changes
**Changes Card page in Documentation:**
The close Button has to be in front of the title, so that a linebreak (due to long text) in the card title will not push the close button down.
Also fixed a superfluous closing `</i>.`
Thx for awesome library!
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
https://codepen.io/ShabanNaasso/pen/VrwaQW
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
