### PR TITLE
fix(sideNav): remove resize event when destroyed

### DIFF
--- a/js/sideNav.js
+++ b/js/sideNav.js
@@ -1,5 +1,6 @@
 (function ($) {
 
+  var sideNavFixedResizer;
   var methods = {
     init : function(options) {
       var defaults = {
@@ -55,7 +56,7 @@
 
         // Window resize to reset on large screens fixed
         if (menu.hasClass('fixed')) {
-          $(window).resize( function() {
+          $(window).resize(sideNavFixedResizer = function () {
             if (window.innerWidth > 992) {
               // Close menu if window is resized bigger than 992 and user has fixed sidenav
               if ($('#sidenav-overlay').length !== 0 && menuOut) {
@@ -75,7 +76,6 @@
               }
 
             }
-
           });
         }
 
@@ -391,6 +391,7 @@
       $dragTarget.remove();
       $(this).off('click');
       $overlay.remove();
+      $(window).off('resize', sideNavFixedResizer);
     },
     show : function() {
       this.trigger('click');


### PR DESCRIPTION
Remove resize event when calling destroy, else it will still be active.

## Proposed changes
Remove resize event when destroying sideNav

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
