### PR TITLE
Added logo image class in the navbar issue #5310

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -68,6 +68,10 @@ nav {
       left: 50%;
       transform: translateX(-50%);
     }
+    .logo-image {
+      height: $navbar-logo-image-height;
+      width:auto;
+    }
 
     @media #{$medium-and-down} {
       left: 50%;


### PR DESCRIPTION
It would be great to be able to add the logo in the navigation bar as an image rather than a text. It is not the same as adding a (small) icon on the left of the logo text as the idea is that it is placed like the logo and can be bigger than the icon. 
issue #5310 