### PR TITLE
removed font-weight declaration from flow text

### DIFF
--- a/sass/components/_typography.scss
+++ b/sass/components/_typography.scss
@@ -45,7 +45,6 @@ small { font-size: 75%; }
 
 
 .flow-text{
-  font-weight: 300;
   $i: 0;
   @while $i <= $intervals {
     @media only screen and (min-width : 360 + ($i * $interval-size)) {


### PR DESCRIPTION
The user should determine the font-weight in their own stylesheet, not the framework. Mainly because a user may want to use flow-text where h1-h6 tags occur, which effectively removes the bold from all h1-h6 tags. This forces setting font weight on them using !important which is not a good practice, or override it by explicitly setting