### PR TITLE
Auto Complete assuming imagefix

### DIFF
--- a/jade/page-contents/forms_content.html
+++ b/jade/page-contents/forms_content.html
@@ -896,7 +896,7 @@
         </code></pre>
 
         <h4>Initialization</h4>
-        <p>The data is a json object where the key is the matching string and the value is an optional image url.</p>
+        <p>The data is a json object where the key is the matching string and the value is an optional image url. If the value is not a string, ie null or an object, i will not be considered an image url.</p>
         <pre><code class="language-javascript">
   $('input.autocomplete').autocomplete({
     data: {

--- a/js/forms.js
+++ b/js/forms.js
@@ -404,7 +404,8 @@
                     }
 
                     var autocompleteOption = $('<li></li>');
-                    if (!!data[key]) {
+                    if (!!data[key] && (typeof data[key] === "string" || data[key] instanceof String) ) {
+                      // Add image if and only if the data[key] is a string and present
                       autocompleteOption.append('<img src="'+ data[key] +'" class="right circle"><span>'+ key +'</span>');
                     } else {
                       autocompleteOption.append('<span>'+ key +'</span>');


### PR DESCRIPTION
## Proposed changes
The auto complete always assumes that a key of a result (data[key]) is a url to an image, this is an odd behaviour and therefore it should be changed to at least only assume that strings are a url and other things are not (objects, numbers etc).

Proposed in #3584 originally

## Types of changes
When the key is no longer a string it will not be considered an image anymore.
This should not be a breaking change for anyone unless they do something really crazy with objects or numbers etc.

- [  ] Bug fix (non-breaking change which fixes an issue).
- [**X**] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [**X**] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [**X**] My change requires a change to the documentation.
- [**X**] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
