### PR TITLE
Fix inconsistent padding between sidenav and collapsible

### DIFF
--- a/sass/components/_sideNav.scss
+++ b/sass/components/_sideNav.scss
@@ -45,7 +45,8 @@
     font-weight: 500;
     height: $sidenav-item-height;
     line-height: $sidenav-line-height;
-    padding: 0 ($sidenav-padding * 2);
+    // Keep padding consistent with collapsible
+    padding: 0 ($sidenav-padding);
 
     &:hover { background-color: rgba(0,0,0,.05);}
 


### PR DESCRIPTION
## Proposed changes

A sidenav collapsible item was not indented the same way a sidenav standard item, resulting in a strange rendering of the sidenav: misaligned items, dropdown menu (collapsible) items aligned with standard items of the sidenav making  difficult to identify the menu hierarchy...

Fixes #928

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
