### PR TITLE
Fix undeclared variable

### DIFF
--- a/js/slider.js
+++ b/js/slider.js
@@ -19,7 +19,7 @@
         var $slider = $this.find('ul.slides').first();
         var $slides = $slider.find('> li');
         var $active_index = $slider.find('.active').index();
-        var $active, $indicators, $interval;
+        var $active, $indicators, $interval, $caption;
         if ($active_index != -1) { $active = $slides.eq($active_index); }
 
         // Transitions the caption depending on alignment


### PR DESCRIPTION
## Proposed changes
The slider component does not work if "strict mode" is enabled as $caption variable is not declared.

## Screenshots (if appropriate) or codepen:
![selection_120](https://user-images.githubusercontent.com/720487/32315847-8da4c45e-bfb6-11e7-8b03-03b15ac0c118.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
