### PR TITLE
Fix issue with function definition

### DIFF
--- a/js/date_picker/picker.date.js
+++ b/js/date_picker/picker.date.js
@@ -1165,12 +1165,13 @@ DatePicker.prototype.nodes = function( isOpen ) {
 
 
         // Materialize modified
-        createDayLabel = function() {
-                if (selectedObject != null)
-                    return selectedObject.date
-                else return nowObject.date
-            }
-        createWeekdayLabel = function() {
+        var createDayLabel = function() {
+            if (selectedObject != null)
+                return selectedObject.date
+            else return nowObject.date
+        }
+
+        var createWeekdayLabel = function() {
             var display_day;
 
             if (selectedObject != null)


### PR DESCRIPTION
In `string mode`, the defining vars without `var` cause ReferenceError. `strict mode` can be added by some bundler

## Proposed changes
Define function properly.

## Screenshots (if appropriate) or codepen:
![image](https://user-images.githubusercontent.com/1037995/32338636-a9fe1e2c-bff5-11e7-83a4-856433d7d63f.png)


## Types of changes
- [+] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [+] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [-] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
- [-] I have added tests to cover my changes.
- [+] All new and existing tests passed.
