### PR TITLE
FAB: allow open\hide animation for the plain "btn"

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -65,12 +65,12 @@
       }
 
       $this.addClass('active');
-      $this.find('ul .btn-floating').velocity(
+      $this.find('ul .btn-floating, ul .btn').velocity(
         { scaleY: ".4", scaleX: ".4", translateY: offsetY + 'px', translateX: offsetX + 'px'},
         { duration: 0 });
 
       var time = 0;
-      $this.find('ul .btn-floating').reverse().each( function () {
+      $this.find('ul .btn-floating, ul .btn').reverse().each( function () {
         $(this).velocity(
           { opacity: "1", scaleX: "1", scaleY: "1", translateY: "0", translateX: '0'},
           { duration: 80, delay: time });
@@ -93,8 +93,8 @@
 
     $this.removeClass('active');
     var time = 0;
-    $this.find('ul .btn-floating').velocity("stop", true);
-    $this.find('ul .btn-floating').velocity(
+    $this.find('ul .btn-floating, ul .btn').velocity("stop", true);
+    $this.find('ul .btn-floating, ul .btn').velocity(
       { opacity: "0", scaleX: ".4", scaleY: ".4", translateY: offsetY + 'px', translateX: offsetX + 'px'},
       { duration: 80 }
     );


### PR DESCRIPTION
## Proposed changes
In case when I want to work with customized FAB Menu where all buttons does not have "btn-floating", then open/hide animation does not reached. So, by current PR open/hide animation will by reached also

## Screenshots (if appropriate) or codepen:
### Before:
![before](https://user-images.githubusercontent.com/4967813/32654045-efa9e57a-c61a-11e7-9fd9-82ba8a2f81db.gif)
### After:
![after](https://user-images.githubusercontent.com/4967813/32654044-ef751d5e-c61a-11e7-9382-44b95e2e305b.gif)
