### PR TITLE
Fixed inline input field in documentation

### DIFF
--- a/jade/page-contents/text_inputs_content.html
+++ b/jade/page-contents/text_inputs_content.html
@@ -46,8 +46,8 @@
               <div class="col s12">
                 This is an inline input field:
                 <div class="input-field inline">
-                  <input id="email" type="email" class="validate">
-                  <label for="email">Email</label>
+                  <input id="email_inline" type="email" class="validate">
+                  <label for="email_inline">Email</label>
                   <span class="helper-text" data-error="wrong" data-success="right"></span>
                 </div>
               </div>
@@ -88,8 +88,8 @@
         &lt;div class="col s12">
           This is an inline input field:
           &lt;div class="input-field inline">
-            &lt;input id="email" type="email" class="validate">
-            &lt;label for="email">Email&lt;/label>
+            &lt;input id="email_inline" type="email" class="validate">
+            &lt;label for="email_inline">Email&lt;/label>
             &lt;span class="helper-text" data-error="wrong" data-success="right">Helper text&lt;/span>
           &lt;/div>
         &lt;/div>


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

In the documentation (in Forms > Text Inputs), after clicking on the full-column "Email" field, clicking on the inline "Email" field re-opens the full-column email input field instead of the inline field, because they have the same id. I changed the inline input field's id from email to email_inline, and changed the code snippet to reflect that change.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.