### PR TITLE
Allow touch events to be disabled in carousel

### DIFF
--- a/jade/page-contents/carousel_content.html
+++ b/jade/page-contents/carousel_content.html
@@ -98,6 +98,12 @@
             <td>Don't wrap around and cycle through items.</td>
           </tr>
           <tr>
+            <td>enableTouch</td>
+            <td>Boolean</td>
+            <td>true</td>
+            <td>Enable scriolling by touch.</td>
+          </tr>
+          <tr>
             <td>onCycleTo</td>
             <td>Function</td>
             <td>null</td>

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -9,6 +9,7 @@
     fullWidth: false, // Change to full width styles
     indicators: false, // Toggle indicators
     noWrap: false, // Don't wrap around and cycle through items.
+    enableTouch: true, // Enable dragging and touch events.
     onCycleTo: null // Callback for when a new slide is cycled to.
   };
 
@@ -46,6 +47,7 @@
        * @prop {Boolean} fullWidth
        * @prop {Boolean} indicators
        * @prop {Boolean} noWrap
+       * @prop {Boolean} enableTouch
        * @prop {Function} onCycleTo
        */
       this.options = $.extend({}, Carousel.defaults, options);
@@ -53,6 +55,7 @@
       // Setup
       this.hasMultipleSlides = this.$el.find('.carousel-item').length > 1;
       this.showIndicators = this.options.indicators && this.hasMultipleSlides;
+      this.enableTouch = this.options.enableTouch;
       this.noWrap = this.options.noWrap || !this.hasMultipleSlides;
       this.pressed = false;
       this.dragged = false;
@@ -147,7 +150,7 @@
       this._handleCarouselReleaseBound = this._handleCarouselRelease.bind(this);
       this._handleCarouselClickBound = this._handleCarouselClick.bind(this);
 
-      if (typeof window.ontouchstart !== 'undefined') {
+      if (typeof window.ontouchstart !== 'undefined' && this.enableTouch) {
         this.el.addEventListener('touchstart', this._handleCarouselTapBound);
         this.el.addEventListener('touchmove', this._handleCarouselDragBound);
         this.el.addEventListener('touchend', this._handleCarouselReleaseBound);
@@ -177,7 +180,7 @@
      * Remove Event Handlers
      */
     _removeEventHandlers() {
-      if (typeof window.ontouchstart !== 'undefined') {
+      if (typeof window.ontouchstart !== 'undefined' && this.enableTouch) {
         this.el.removeEventListener('touchstart', this._handleCarouselTapBound);
         this.el.removeEventListener('touchmove', this._handleCarouselDragBound);
         this.el.removeEventListener('touchend', this._handleCarouselReleaseBound);


### PR DESCRIPTION
## Proposed changes
Sometimes, touching is a no-no. This PR adds a flag to Materialize called `enableTouch` which allows the user to optionally disable the touch event binding.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
