### PR TITLE
Fix input prefix alignment

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -214,6 +214,7 @@ textarea.materialize-textarea {
     width: $input-height;
     font-size: 2rem;
     transition: color .2s;
+    top: .5rem;
 
     &.active { color: $input-focus-color; }
   }


### PR DESCRIPTION
## Proposed changes
This PR fixes Dogfalo/materialize#4822 (the vertical alignment of prefix icons)

## Screenshots (if appropriate) or codepen:
Before:
![Before](https://user-images.githubusercontent.com/6892681/30249465-8954a920-963d-11e7-8cab-b5a4fefbeb1d.png)

After:
![After](https://user-images.githubusercontent.com/6892681/30249477-a67cd11c-963d-11e7-96e0-f7d03e9d7753.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. *(does not affect test)*
- [x] All new and existing tests passed.
