### PR TITLE
fixed range input selector

### DIFF
--- a/js/range.js
+++ b/js/range.js
@@ -259,5 +259,5 @@
     M.initializeJqueryWrapper(Range, 'range', 'M_Range');
   }
 
-  Range.init($('input[type=range'));
+  Range.init($('input[type=range]'));
 }( cash, M.Vel ));


### PR DESCRIPTION
## Proposed changes
fixed #5388.
selector of `range` changed from`input[type=range` to `input[type=range]` to support safari browser env.

## Screenshots (if appropriate) or codepen:
<img width="504" alt="2017-11-21 6 46 30" src="https://user-images.githubusercontent.com/10153090/33065539-7f77c54e-ceec-11e7-9dc9-be57d3ff6665.png">


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
