### PR TITLE
Fix for tabs breaking when there's no associated content to a tab

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -179,7 +179,7 @@
           });
         }
       } else {
-        if (this.$content !== undefined) {
+        if (this.$content[0]) {
           this.$content[0].style.display = 'block';
           this.$content.addClass('active');
           if (typeof(this.options.onShow) === 'function') {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Tabs currently break if there's not a matching content div found by [this line](https://github.com/Dogfalo/materialize/compare/v1-dev...abradley2:fix/tabs-without-content?expand=1#diff-3dd5119e1daf5898ff764a06ac0aca24R164) because the check here is looking against `undefined`, whereas an empty jquery-like wrapper is returned when it can't find anything.

I propose changing the check so it no longer fails with a "cannot read property `style` of undefined" error by properly checking if the selector is empty or now.

This is useful when you want to use the tabs component but aren't relying on the tabs themselves to manage showing/hiding the content- which I'm doing in another app that wraps Materialize in Preact.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
