### PR TITLE
Add option autofocusFirstSuggestion to Autocomplete

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -6,6 +6,7 @@
     limit: Infinity, // Limit of results the autocomplete shows
     onAutocomplete: null, // Callback for when autocompleted
     minLength: 1, // Min characters before autocomplete starts
+    autofocusFirstSuggestion: false, // If true the first suggestion is immediately focused
     sortFunction: function(a, b, inputString) { // Sort function for sorting autocomplete results
       return a.indexOf(inputString) - b.indexOf(inputString);
     }
@@ -330,6 +331,13 @@
 
         $(this.container).append($autocompleteOption);
         this._highlight(val, $autocompleteOption);
+      }
+
+      // Give focus to the first suggestion if required
+      if (this.options.autofocusFirstSuggestion && this.count > 0) {
+        this.activeIndex = 0;
+        this.$active = $(this.container).children('li').eq(this.activeIndex);
+        this.$active.addClass('active');
       }
     }
 


### PR DESCRIPTION
## Proposed changes
The autocomplete is not giving focus to the first element (as stated here https://github.com/Dogfalo/materialize/issues/4508). 
Obviously the answer given in the linked issue is correct (in fact in a scenario where there is "Apple" in the suggestions list but the user would like to type "App" the feature can be really annoying).
I think that providing flexibility could be a good choice and so i've added the "autofocusFirstSuggestion" option to Autocomplete (defaulted to false).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
