### PR TITLE
remove table row borders

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -427,10 +427,6 @@ table {
   }
 }
 
-tr {
-  border-bottom: 1px solid $table-border-color;
-}
-
 td, th{
   padding: 15px 5px;
   display: table-cell;


### PR DESCRIPTION
It should be either `thead` or the line should be removed.

Our new docs say
> Tables are borderless by default.

http://next.materializecss.com/table.html