### PR TITLE
Fix bug of hidden select caret inside card-panel

### DIFF
--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -87,6 +87,7 @@ select {
     padding: 0;
     display: block;
     user-select:none;
+    z-index: 1;
   }
 
   .caret {
@@ -95,7 +96,7 @@ select {
     top: 0;
     bottom: 0;
     margin: auto 0;
-    z-index: -1;
+    z-index: 0;
     fill: rgba(0,0,0,.87);
   }
 


### PR DESCRIPTION
# Proposed changes
Select caret is hidden when the container of the select element has a background color. One example is the card-panel. Changing the z-index of input and svg fixes the issue.

Related issue: #5435

## Codepen:
https://codepen.io/anon/pen/KybJZK

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
