### PR TITLE
add context parameter to M.updateTextFields

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1,8 +1,8 @@
 (function ($) {
   // Function to update labels of text fields
-  M.updateTextFields = function() {
+  M.updateTextFields = function(ctx) {
     let input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
-    $(input_selector).each(function(element, index) {
+    $(input_selector, ctx).each(function(element, index) {
       let $this = $(this);
       if (element.value.length > 0 || $(element).is(':focus') || element.autofocus || $this.attr('placeholder') !== null) {
         $this.siblings('label').addClass('active');


### PR DESCRIPTION
## Proposed changes
`M.updateTextFields` could use an optional `context` parameter, so it doesn't iterate over the whole HTML DOM all the time.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
