### PR TITLE
avoid wrong ending position due to animation if modal is displayed at…

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -58,6 +58,7 @@
       this.id = this.$el.attr('id');
       this._openingTrigger = undefined;
       this.$overlay = $('<div class="modal-overlay"></div>');
+      this.fixedX = !!(el.style.left || el.style.right);
 
       Modal._increment++;
       Modal._count++;
@@ -213,7 +214,7 @@
         $.extend(enterAnimOptions, {
           top: [this.options.startingTop, this.options.endingTop],
           opacity: 1,
-          scaleX: [.8, 1],
+          scaleX: this.fixedX ? 1 : [.8, 1],
           scaleY: [.8, 1]
         });
         anim(enterAnimOptions);
@@ -262,7 +263,7 @@
         $.extend(exitAnimOptions, {
           top: [this.options.endingTop, this.options.startingTop],
           opacity: 0,
-          scaleX: 0.8,
+          scaleX: this.fixedX ? 1 : 0.8,
           scaleY: 0.8
         });
         anim(exitAnimOptions);


### PR DESCRIPTION
… fixed x-position

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
This fixes part of my problems mentioned in #5471:
A `Modal` with a fixed x-Position ends up in the wrong place after the opening animation is finished.
Avoiding an animated `scaleX` in the animation fixes this.

For this the fixed position to work correctly, there also needs to be set `margin:0;` on the modal element.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
