### PR TITLE
Pass correct element reference to Autocomplete.init

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -337,7 +337,7 @@
         this.$input[0].focus();
       };
 
-      this.autocomplete = M.Autocomplete.init(this.$input, this.options.autocompleteOptions)[0];
+      this.autocomplete = M.Autocomplete.init(this.$input[0], this.options.autocompleteOptions)[0];
     }
 
     /**


### PR DESCRIPTION
## Proposed changes
[Chips](http://next.materializecss.com/chips.html) feature is broken in v1-dev (Throwing `TypeError:  .Autocomplete.init(...) is null @ chips.js:340:26`). This simple fix makes it work (passes the element itself to the .init call instead of the container jquery-like object.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
