### PR TITLE
Aligned helper-text with inputs when using prefix

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -222,6 +222,7 @@ textarea.materialize-textarea {
   .prefix ~ textarea,
   .prefix ~ label,
   .prefix ~ .validate ~ label,
+  .prefix ~ .helper-text,
   .prefix ~ .autocomplete-content {
     margin-left: 3rem;
     width: 92%;


### PR DESCRIPTION
## Proposed changes
Horizontally aligns the helper-text with input, labels etc. when using a prefix.

## Screenshots (if appropriate) or codepen:
Misaligned
![misaligned](https://user-images.githubusercontent.com/11448375/34694121-4056ad30-f4c6-11e7-89e0-495c2c47a514.png)

Aligned
![aligned](https://user-images.githubusercontent.com/11448375/34694238-a524c562-f4c6-11e7-9409-b134673fc774.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

  