### PR TITLE
 Correctly set chipsInstance.autocomplete, plus docs!

### DIFF
--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -279,6 +279,11 @@
               <td>Boolean</td>
               <td>If the chips has autocomplete enabled.</td>
             </tr>
+            <tr>
+              <td>autocomplete</td>
+              <td>Object</td>
+              <td><a href="autocomplete.html">Autocomplete</a> instance, if any.</td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/js/chips.js
+++ b/js/chips.js
@@ -337,7 +337,7 @@
         this.$input[0].focus();
       };
 
-      this.autocomplete = M.Autocomplete.init(this.$input[0], this.options.autocompleteOptions)[0];
+      this.autocomplete = M.Autocomplete.init(this.$input[0], this.options.autocompleteOptions);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes
chips instance `.autocomplete` was being set to `undefined`, now the underlying autocomplete instance is correctly exposed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation: Added it to the bottom of [Chips Properties table](http://next.materializecss.com/chips.html#properties).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
