### PR TITLE
Update modal.js to properly call onOpenStart

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -279,6 +279,9 @@
 
       this.isOpen = true;
 
+      // Set opening trigger, undefined indicates modal was opened by javascript
+      this._openingTrigger = !!$trigger ? $trigger[0] : undefined;
+  
       // onOpenStart callback
       if (typeof(this.options.onOpenStart) === 'function') {
         this.options.onOpenStart.call(this, this.el, this._openingTrigger);
@@ -288,9 +291,6 @@
       body.style.overflow = 'hidden';
       this.el.classList.add('open');
       this.el.insertAdjacentElement('afterend', this.$overlay[0]);
-
-      // Set opening trigger, undefined indicates modal was opened by javascript
-      this._openingTrigger = !!$trigger ? $trigger[0] : undefined;
 
       if (this.options.dismissible) {
         this._handleKeydownBound = this._handleKeydown.bind(this);


### PR DESCRIPTION

## Proposed changes
the initialization of this._openingTrigger happens AFTER the onOpenStart callback; this means the callback receives "undefined" the very first time it's called and in the subsequent calls
it receives the element that triggered the previous modal open
 
by moving the initialization before the onOpenStart call, the callback receives the correct information 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
