### PR TITLE
Added border and label colors for Select

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -384,3 +384,18 @@
     M.initializeJqueryWrapper(Select, 'select', 'M_Select');
   }
 }(cash));
+
+ /**
+  * Set color for label and input bottom border on select
+  */
+  var color = '#009688';
+  $(document).on('change', 'select', function() {
+    if($(this).val() !== "") {
+      $($(this).parent()).next('label').css('color', color); // Not required though
+        $($(this).parent()).children('input.select-dropdown').css({
+          "border-bottom": "1px solid "+ color, 
+          "-webkit-box-shadow": "0 1px 0 0 "+ color, 
+          "box-shadow": "0 1px 0 0 "+ color
+        });
+      }
+  });


### PR DESCRIPTION
## Proposed changes

When an option is selected which have a value in it, proposed js will add colors for label and input bottom border of Select. This is just for an idea and this can be improved. This is done for the uniformity of other Form elements, to match with the colors. Select menu is always reverting to grey (default) color after the user leaves ":focus" on it. This will fix the issue. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] All new and existing tests passed.
