### PR TITLE
Removed carousel methods on chips documentation

### DIFF
--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -186,15 +186,15 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin instance like this: </p>
           <pre><code class="language-javascript col s12">
-  var instance = M.Chips.getInstance(elem);
+    var instance = M.Chips.getInstance(elem);
 
-  /* jQuery Method Calls
-    You can still use the old jQuery plugin method calls.
-    But you won't be able to access instance properties.
+    /* jQuery Method Calls
+      You can still use the old jQuery plugin method calls.
+      But you won't be able to access instance properties.
 
-    $('.chips').chips('methodName');
-    $('.chips').chips('methodName', paramName);
-  */
+      $('.chips').chips('methodName');
+      $('.chips').chips('methodName', paramName);
+    */
           </code></pre>
         </blockquote>
 

--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -186,15 +186,15 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin instance like this: </p>
           <pre><code class="language-javascript col s12">
-            var instance = M.Chips.getInstance(elem);
+  var instance = M.Chips.getInstance(elem);
 
-            /* jQuery Method Calls
-              You can still use the old jQuery plugin method calls.
-              But you won't be able to access instance properties.
-        
-              $('.chips').chips('methodName');
-              $('.chips').chips('methodName', paramName);
-            */
+  /* jQuery Method Calls
+    You can still use the old jQuery plugin method calls.
+    But you won't be able to access instance properties.
+
+    $('.chips').chips('methodName');
+    $('.chips').chips('methodName', paramName);
+  */
           </code></pre>
         </blockquote>
 

--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -186,15 +186,15 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin instance like this: </p>
           <pre><code class="language-javascript col s12">
-    var instance = M.Carousel.getInstance(elem);
+            var instance = M.Chips.getInstance(elem);
 
-    /* jQuery Method Calls
-      You can still use the old jQuery plugin method calls.
-      But you won't be able to access instance properties.
-
-      $('.carousel').carousel('methodName');
-      $('.carousel').carousel('methodName', paramName);
-    */
+            /* jQuery Method Calls
+              You can still use the old jQuery plugin method calls.
+              But you won't be able to access instance properties.
+        
+              $('.chips').chips('methodName');
+              $('.chips').chips('methodName', paramName);
+            */
           </code></pre>
         </blockquote>
 


### PR DESCRIPTION
## Proposed changes
Updated the methods section of the Chips documentation to remove some old Carousel examples that aren't applicable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
