### PR TITLE
Move calls to color() to _variables.scss

### DIFF
--- a/sass/components/_badges.scss
+++ b/sass/components/_badges.scss
@@ -7,7 +7,7 @@ span.badge {
   font-size: 1rem;
   line-height: $badge-height;
   height: $badge-height;
-  color: color('grey', 'darken-1');
+  color: $badge-text-color;
   float: right;
   box-sizing: border-box;
 

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -114,7 +114,7 @@ a {
 .divider {
   height: 1px;
   overflow: hidden;
-  background-color: color("grey", "lighten-2");
+  background-color: $divider-bg-color;
 }
 
 

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -47,6 +47,7 @@ $link-color: color("light-blue", "darken-1") !default;
 // 2. Badges
 // ==========================================================================
 
+$badge-text-color: color('grey', 'darken-1') !default;
 $badge-bg-color: $secondary-color !default;
 $badge-height: 22px !default;
 
@@ -346,3 +347,8 @@ $collection-line-height: 1.5rem !default;
 // ==========================================================================
 
 $progress-bar-color: $secondary-color !default;
+
+// 25. Dividers
+// ==========================================================================
+
+$divider-bg-color: color("grey", "lighten-2") !default;


### PR DESCRIPTION
Fix #5608

## Proposed changes
The divider color in _global.scss and the badge text color in
_badges.scss is using a direct call to color() function. By moving
these colors to _variables.scss, it allows for users to override
$colors and any color variables in _variables.scss before importing
those files.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (the tests for Optgroup Select do not currently pass for the v1-dev branch)

