### PR TITLE
add callback onDragStart for sidenav

### DIFF
--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -188,13 +188,13 @@
       this._startingXpos = clientX;
       this._xPos = this._startingXpos;
       this._time = Date.now();
+      if (this.options.onDragStart) {
+        this.options.onDragStart(!this.isOpen);
+      }
       this._width = this.el.getBoundingClientRect().width;
       this._overlay.style.display = 'block';
       anim.remove(this.el);
       anim.remove(this._overlay);
-      if (this.options.onDragStart) {
-        this.options.onDragStart(!this.isOpen);
-      }
     }
 
 

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -6,6 +6,7 @@
     draggable: true,
     inDuration: 250,
     outDuration: 200,
+    onDragStart: null,
     onOpenStart: null,
     onOpenEnd: null,
     onCloseStart: null,
@@ -191,6 +192,9 @@
       this._overlay.style.display = 'block';
       anim.remove(this.el);
       anim.remove(this._overlay);
+      if (this.options.onDragStart) {
+        this.options.onDragStart(!this.isOpen);
+      }
     }
 
 


### PR DESCRIPTION
## Proposed changes
Add a callback for starting to drag the sidenav, so it can be used to change its content.
Fixes #5619 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
