### PR TITLE
Fix for https://github.com/Dogfalo/materialize/issues/5663

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -93,8 +93,8 @@
 
       this.options = $.extend({}, Datepicker.defaults, options);
       
-      // make sure i18n defaults are not lost when single i18n options are passed
-      if(options.hasOwnProperty('i18n')) {
+      // make sure i18n defaults are not lost when only few i18n option properties are passed
+      if(options.hasOwnProperty('i18n') && typeof options.i18n === 'object') {
          this.options.i18n = $.extend({}, Datepicker.defaults.i18n, options.i18n);
       }
 

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -92,6 +92,11 @@
       this.el.M_Datepicker = this;
 
       this.options = $.extend({}, Datepicker.defaults, options);
+      
+      // make sure i18n defaults are not lost when single i18n options are passed
+      if(options.hasOwnProperty('i18n') {
+         this.options.i18n = $.extend({}, Datepicker.defaults.i18n, options.i18n);
+      }
 
       // Remove time component from minDate and maxDate options
       if (this.options.minDate) this.options.minDate.setHours(0, 0, 0, 0);

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -94,7 +94,7 @@
       this.options = $.extend({}, Datepicker.defaults, options);
       
       // make sure i18n defaults are not lost when single i18n options are passed
-      if(options.hasOwnProperty('i18n') {
+      if(options.hasOwnProperty('i18n')) {
          this.options.i18n = $.extend({}, Datepicker.defaults.i18n, options.i18n);
       }
 


### PR DESCRIPTION
make sure i18n defaults are not lost when single i18n options are passed

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change replaces an otherwise necessary change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
