### PR TITLE
#4168 Adjust label of date and time input types

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1,7 +1,7 @@
 (function ($) {
   // Function to update labels of text fields
   M.updateTextFields = function() {
-    let input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
+    let input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], input[type=date], input[type=time], textarea';
     $(input_selector).each(function(element, index) {
       let $this = $(this);
       if (element.value.length > 0 || $(element).is(':focus') || element.autofocus || $this.attr('placeholder') !== null) {
@@ -124,7 +124,7 @@
 
   $(document).ready(function() {
     // Text based inputs
-    let input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], textarea';
+    let input_selector = 'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], input[type=date], input[type=time], textarea';
 
     // Add active if form auto complete
     $(document).on('change', input_selector, function () {

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -193,6 +193,12 @@ textarea.materialize-textarea {
     }
   }
 
+  & > input[type=date]:not(.browser-default) + label,
+  & > input[type=time]:not(.browser-default) + label {
+    transform: translateY(-14px) scale(.8);
+    transform-origin: 0 0;
+  }
+
   .helper-text {
     &::after {
       opacity: 1;


### PR DESCRIPTION
## Proposed changes
Adjust label of date and time input types. Described on issue [4168](https://github.com/Dogfalo/materialize/issues/4168).
Summary of changes:
- Adjust JS to add/remove `active` css class on labels on focus/blur
- Adjust SASS to keep labels in the same position even without focus

## Screenshots
Before changes (focused date field)
![selection_060](https://user-images.githubusercontent.com/5929781/36337346-5c5adb7c-137b-11e8-8271-93a4660addae.png)

After changes (focused and unfocused date field)
![selection_061](https://user-images.githubusercontent.com/5929781/36337350-7cb1f73e-137b-11e8-91d7-3b6648f71a0c.png)
![selection_062](https://user-images.githubusercontent.com/5929781/36337352-8252ceac-137b-11e8-8225-66cd04086dfe.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
