### PR TITLE
Update Scrollspy documentation example for native javascript

### DIFF
--- a/jade/page-contents/scrollspy_content.html
+++ b/jade/page-contents/scrollspy_content.html
@@ -38,8 +38,8 @@
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
         <pre><code class="language-javascript">
-  var elem = document.querySelector('.scrollspy');
-  var instance = M.ScrollSpy.init(elem, options);
+  var elements = document.querySelectorAll('.scrollspy');
+  var instance = M.ScrollSpy.init(elements, options);
 
   // Or with jQuery
 


### PR DESCRIPTION
The documentation shows both native javascript and jQuery way to initialize the Scrollspy plugin, the native javascript example uses document.querySelector, which only returns the first element found matching the selector, resulting in only initializing one element, this needs update  so it uses document.querySelectorAll, which returns the whole NodeList before calling the M.ScrollSpy.init method.

Solves https://github.com/Dogfalo/materialize/issues/5569

## Proposed changes
Just a simple update to the `jade` template for that particular example

## Screenshots (if appropriate) or codepen:
![image](https://user-images.githubusercontent.com/6183307/36458050-8f16d774-1672-11e8-9c88-ba82033ac087.png)


## Types of changes
- Jade template updated for the documentation.
