### PR TITLE
Updating select docs initialization

### DIFF
--- a/jade/page-contents/select_content.html
+++ b/jade/page-contents/select_content.html
@@ -209,8 +209,8 @@
     You can still use the old jQuery plugin method calls.
     But you won't be able to access instance properties.
 
-    $('select').formSelect('methodName');
-    $('select').formSelect('methodName', paramName);
+    $('select').select('methodName');
+    $('select').select('methodName', paramName);
   */
         </code></pre>
       </blockquote>


### PR DESCRIPTION
Jquery init is not a function. Working solution is .select() instead of .formSelect()

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
