### PR TITLE
Re-add background-color property of card action class

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -161,7 +161,7 @@
       border-radius: 0 0 2px 2px;
     }
     position: relative;
-    background-color: inherit;
+    background-color: #fff;
     border-top: 1px solid rgba(160,160,160,.2);
     padding: 16px $card-padding;
 

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -161,6 +161,7 @@
       border-radius: 0 0 2px 2px;
     }
     position: relative;
+    background-color: inherit;
     border-top: 1px solid rgba(160,160,160,.2);
     padding: 16px $card-padding;
 


### PR DESCRIPTION
## Proposed changes
PR raised to fix issue detailed at #5691 

## Screenshots (if appropriate) or codepen:
Screenshot of the Materialize "next" site on the left with the current styling and modified content to showcase overflow issue with the card action class, and on the right, a local build of the same documentation and content modification with below fix applied:

![image](https://user-images.githubusercontent.com/1449455/36615703-ce201d8c-18a6-11e8-8216-bcacb1b936fb.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
