### PR TITLE
add option to use browsers native selects for month and year dropdown

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -53,6 +53,9 @@
     // Show clear button
     showClearBtn: false,
 
+    // use browsers select
+    nativeSelects: false,
+
     // internationalization
     i18n: {
       cancel: 'Cancel',
@@ -194,7 +197,8 @@
       this._removeEventHandlers();
       this.modal.destroy();
       $(this.modalEl).remove();
-      this.destroySelects();
+      if (!this.options.nativeSelects)
+        this.destroySelects();
       this.el.M_Datepicker = undefined;
     }
 
@@ -627,15 +631,21 @@
           this.render(this.calendars[c].year, this.calendars[c].month, randId);
       }
 
-      this.destroySelects();
+      if (!this.options.nativeSelects)
+        this.destroySelects();
 
       this.calendarEl.innerHTML = html;
 
       // Init Materialize Select
       let yearSelect = this.calendarEl.querySelector('.pika-select-year');
       let monthSelect = this.calendarEl.querySelector('.pika-select-month');
-      M.FormSelect.init(yearSelect, {classes: 'select-year', dropdownOptions: {container: document.body, constrainWidth: false}});
-      M.FormSelect.init(monthSelect, {classes: 'select-month', dropdownOptions: {container: document.body, constrainWidth: false}});
+      if (this.options.nativeSelects) {
+        yearSelect.classList.add('browser-default');
+        monthSelect.classList.add('browser-default');
+      } else {
+        M.FormSelect.init(yearSelect, {classes: 'select-year', dropdownOptions: {container: document.body, constrainWidth: false}});
+        M.FormSelect.init(monthSelect, {classes: 'select-month', dropdownOptions: {container: document.body, constrainWidth: false}});
+      }
 
       // Add change handlers for select
       yearSelect.addEventListener('change', this._handleYearChange.bind(this));


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
New option for date picker to use browser-default selects for month and year dropdown.
This helps me avoid the issue in #5723 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
