### PR TITLE
Ref. 4736 Chips autocomplete should have option to prevent user own input 

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -6,6 +6,7 @@
     placeholder: '',
     secondaryPlaceholder: '',
     autocompleteOptions: {},
+    autocompleteOnly: false,
     limit: Infinity,
     onChipAdd: null,
     onChipSelect: null,
@@ -271,9 +272,11 @@
         }
 
         e.preventDefault();
-        this.addChip({
-          tag: this.$input[0].value
-        });
+        if (!this.hasAutocomplete || (this.hasAutocomplete && !this.options.autocompleteOnly) ) {
+          this.addChip({
+            tag: this.$input[0].value
+          });
+        }
         this.$input[0].value = '';
 
         // delete or left


### PR DESCRIPTION
Chips autocomplete should have option to prevent user own input 
----
- added boolean option autoCompleteOnly to chips defaults options
- when pressing enter to add a chip, the chip is only added if M.Chips.options.autocompleteOnly==false (or if hasAutcomplete == false)