### PR TITLE
change z-index in navbar-fixed class

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -188,7 +188,7 @@ nav {
 .navbar-fixed {
   position: relative;
   height: $navbar-height-mobile;
-  z-index: 997;
+  z-index: 998;
 
   nav {
     position: fixed;


### PR DESCRIPTION
when we use "navbar-fixed" in nav menu, it's behind the "sidenav-overlay" element.

## Proposed changes
change z-index 997 to 998 in navbar-fixed class.

## Screenshots (if appropriate) or codepen:
[before fixed](https://jsfiddle.net/MR_Mostafa/8hrmq36k/)
[after fixed](https://jsfiddle.net/MR_Mostafa/8hrmq36k/16/)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
