### PR TITLE
Remove ugly collapsible-header blue focus box

### DIFF
--- a/sass/components/_collapsible.scss
+++ b/sass/components/_collapsible.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.collapsible-header:focus {
+  outline: 0
+}
+
 .collapsible-body {
   display: none;
   border-bottom: 1px solid $collapsible-border-color;


### PR DESCRIPTION
## Proposed changes
Just added an outline rule to the collapsible-header. This way, it won't show the blue box on focus, which is kind of ugly.
## Screenshots (if appropriate) or codepen:
<img width="800" alt="screen shot 2018-03-30 at 18 15 24" src="https://user-images.githubusercontent.com/16862997/38144835-bb5c7c66-3446-11e8-8b90-7fd0f1ec0c89.png">

**Without the rule**


<img width="800" alt="screen shot 2018-03-30 at 18 17 43" src="https://user-images.githubusercontent.com/16862997/38144836-bb7efbc4-3446-11e8-9517-9fcce53bc819.png">

**With the rule**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
