### PR TITLE
Remove webkit-appearence from buttons

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -75,6 +75,9 @@
     background-color: $button-raised-background-hover;
     @extend .z-depth-1-half;
   }
+  &[type=button] {
+    -webkit-appearance: none; // Gets rid of the outlined rectangle default in Chrome
+  }
 }
 
 // Floating button


### PR DESCRIPTION
set the webkit-appearence to none on .btn objects that have the type of
"button" since Chrome overrides border styles applied to buttons.

Signed-off-by: Malcolm VanOrder <mvanorder1390@gmail.com>

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

buttons created with .btn and type="button" worked in browsers other than Chrome, however chrome overrides the borders set by materialize. This is less noticeable with a normal button, but with floating buttons the shadow was round and the button wasn't. Simply by setting the -webkit-appearance to none with the .btn[type=button] selector, this is corrected and the buttons show up the same as if the type was not set or if the page was loaded in another browser.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
