### PR TITLE
Initial stab at future Ajax support

### DIFF
--- a/jade/page-contents/autocomplete_content.html
+++ b/jade/page-contents/autocomplete_content.html
@@ -89,6 +89,12 @@
               <td>Callback for when autocompleted.</td>
             </tr>
             <tr>
+              <td>onValueChange</td>
+              <td>Function</td>
+              <td>null</td>
+              <td>Callback for when the user typed something. This is just before Autocomplete consults it's data object and is a hook for AJAX calls to be made. Handling fast typers is left as an exercise for the user.</td>
+            </tr>
+            <tr>
               <td>minLength</td>
               <td>Number</td>
               <td>1</td>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -4,6 +4,7 @@
   let _defaults = {
     data: {}, // Autocomplete data set
     limit: Infinity, // Limit of results the autocomplete shows
+    onValueChange: null, // Callback for when the value of the input changes
     onAutocomplete: null, // Callback for when autocompleted
     minLength: 1, // Min characters before autocomplete starts
     sortFunction: function (a, b, inputString) { // Sort function for sorting autocomplete results
@@ -46,7 +47,7 @@
       this.isOpen = false;
       this.count = 0;
       this.activeIndex = -1;
-      this.oldVal;
+      this.oldVal = null;
       this.$inputField = this.$el.closest('.input-field');
       this.$active = $();
       this._mousedown = false;
@@ -185,6 +186,10 @@
 
         if (val.length >= this.options.minLength) {
           this.isOpen = true;
+          // Handle value change in the element ("User typed something")
+          if (typeof(this.options.onValueChange) === 'function') {
+            this.options.onValueChange.call(this, val);
+          }
           this._renderDropdown(this.options.data, val);
         }
 

--- a/js/init.js
+++ b/js/init.js
@@ -193,6 +193,10 @@
     $('.tap-target').tapTarget();
     $('input.autocomplete').autocomplete({
       data: {"Apple": null, "Microsoft": null, "Google": 'http://placehold.it/250x250'},
+      onValueChange: function (val) {
+        // PoC for working callback, without being intrusive of the functionality.
+        console.log('value = ' + val);
+      }
     });
     $('input[data-length], textarea[data-length]').characterCounter();
 


### PR DESCRIPTION
## Proposed changes
Add a callback hook just before data is consulted, leveraging
the logic that is already there (irrelevant keys, minlength, etc).

This needs more work to deal with requests that typically take longer
than the time it takes for a user to type multiple keys, but the API
for the callback is very unlikely to change as all that logic can
be encapsulated in the callback itself.

I'm not well-versed in JS unit tests, but will add them if the proposed
implementation is accepted.

Contributes to #4086 .

## Screenshots (if appropriate) or codepen:
A (working) AJAX implementation is in [this branch](https://github.com/melvyn-sopacua/materialize/blob/poc-komoot-photon/js/init.js).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
