### PR TITLE
Fix typo for hovered dropdown destroy

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -148,9 +148,9 @@
       this.dropdownEl.removeEventListener('click', this._handleDropdownClickBound);
 
       if (this.options.hover) {
-        this.el.removeEventHandlers('mouseenter', this._handleMouseEnterBound);
-        this.el.removeEventHandlers('mouseleave', this._handleMouseLeaveBound);
-        this.dropdownEl.removeEventHandlers('mouseleave', this._handleMouseLeaveBound);
+        this.el.removeEventListener('mouseenter', this._handleMouseEnterBound);
+        this.el.removeEventListener('mouseleave', this._handleMouseLeaveBound);
+        this.dropdownEl.removeEventListener('mouseleave', this._handleMouseLeaveBound);
       } else {
         this.el.removeEventListener('click', this._handleClickBound);
       }

--- a/tests/spec/dropdown/dropdownFixture.html
+++ b/tests/spec/dropdown/dropdownFixture.html
@@ -24,5 +24,19 @@
       <li class="divider"></li>
       <li><a href="#!">three</a></li>
     </ul>
+
+    <!-- Dropdown Trigger -->
+    <a id="dropdownDestroyTrigger" class='dropdown-trigger btn' href='#' data-target='dropdownDestroy'>
+      <i class="material-icons left">arrow_drop_down</i>
+      <span>Drop Me!</span>
+    </a>
+
+    <!-- Dropdown Destroy  -->
+    <ul id='dropdownDestroy' class='dropdown-content'>
+      <li><a href="#!">one</a></li>
+      <li><a href="#!">two</a></li>
+      <li class="divider"></li>
+      <li><a href="#!">three</a></li>
+    </ul>
   </div>
 </div>

--- a/tests/spec/dropdown/dropdownSpec.js
+++ b/tests/spec/dropdown/dropdownSpec.js
@@ -66,5 +66,19 @@ describe("Dropdown Plugin", function () {
         }, 400);
       }, 400);
     });
+
+    it("hovered should destroy itself", function (done) {
+      var dropdownTrigger = $('#dropdownDestroyTrigger');
+      $(dropdownTrigger).dropdown('destroy');
+      $(dropdownTrigger).dropdown({ hover: true });
+
+      expect(function() {
+        $(dropdownTrigger).dropdown('destroy');
+      }).not.toThrow();
+
+      setTimeout(function() {
+        done();
+      }, 400);
+  });
   });
 });


### PR DESCRIPTION
There was obviously a typo `removeEventHandlers` instead of `removeEventListener`

## Proposed changes
Replace with the correct calls

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
