### PR TITLE
Make Autocomplete sort optional

### DIFF
--- a/jade/page-contents/autocomplete_content.html
+++ b/jade/page-contents/autocomplete_content.html
@@ -119,6 +119,7 @@
     return a.indexOf(inputString) - b.indexOf(inputString);
   }
         </code></pre>
+        <p>To disable sorting and use the values as they appear in the data object, use a falsy value.</p>
       </div>
 
 

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -370,14 +370,16 @@
       }
 
       // Sort
-      let sortFunctionBound = (a, b) => {
-        return this.options.sortFunction(
-          a.key.toLowerCase(),
-          b.key.toLowerCase(),
-          val.toLowerCase()
-        );
-      };
-      matchingData.sort(sortFunctionBound);
+      if (this.options.sortFunction) {
+        let sortFunctionBound = (a, b) => {
+          return this.options.sortFunction(
+            a.key.toLowerCase(),
+            b.key.toLowerCase(),
+            val.toLowerCase()
+          );
+        };
+        matchingData.sort(sortFunctionBound);
+      }
 
       // Render
       for (let i = 0; i < matchingData.length; i++) {


### PR DESCRIPTION
When sortFunction is falsy, do not sort.

## Proposed changes
Autocomplete item sorting should not be required.

This is helpful to users that pass in already-sorted data in the first place. Processing thus far (in `_renderDropdown`) respects the initial ordering from `options.data`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
