### PR TITLE
Allow long elements such as dropdowns escape modals

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -10,7 +10,7 @@
   max-height: 70%;
   width: 55%;
   margin: auto;
-  overflow-y: auto;
+  overflow-y: visible;
 
   border-radius: 2px;
   will-change: top, opacity;


### PR DESCRIPTION
## Proposed changes
When including a long dropdown (select) in a modal, if the dropdown list is longer than the modal, it will be constrained inside the modal. The change allows such elements escape the modal.

## Screenshots:
Before:
<img width="457" alt="before" src="https://user-images.githubusercontent.com/7517745/39845887-78c3b05a-53c6-11e8-9ecc-b28291fb787e.PNG">

After:
<img width="458" alt="after" src="https://user-images.githubusercontent.com/7517745/39845891-7dcb3848-53c6-11e8-98ad-e2edea20cd4b.PNG">


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
