### PR TITLE
Workaround race condition in some IE11 versions

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -132,6 +132,7 @@
           $(this.dropdownOptions).find('li').removeClass('active');
           $(option).toggleClass('active');
           this.input.value = option.textContent;
+          this.$el.prop('selected', false)
         }
 
         this._activateOption($(this.dropdownOptions), option);


### PR DESCRIPTION
On IE 11.0.9600.18977 there is a race condition that caused both
previous and current value to be displayed as selected in the selected.

_setValueToInput() indeed gets value from each el that is selected. And
with IE 11 it found two selected options at the time of execution.

This patch ensures that silly browsers who can't maintain a consistent
state for a select field will not fall in the trap.

Please release friend :)