### PR TITLE
Workaround race condition in some IE11 versions

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -358,6 +358,10 @@
         }
       }
 
+      if (!this.isMultiple) {
+        values = values.slice(values.length - 1)
+      }
+
       this.input.value = values.join(', ');
     }
 


### PR DESCRIPTION
## Proposed changes

On IE 11.0.9600.18977 there is a race condition that caused both
previous and current value to be displayed as selected in a non-multiple
select.

_setValueToInput() indeed gets value from each el that is selected. And
with IE 11 it found two selected options at the time of execution.

This patch ensures that silly browsers who can't maintain a consistent
state for a select field will not fall in the trap.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
