### PR TITLE
Fix datepicker modal-content display

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
+  margin-bottom: 0;
 }
 
 .datepicker-controls {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This fixes a **very** minor issue in the display of the datepicker component.  Currently, the component looks like this:

![datepicker_issue](https://user-images.githubusercontent.com/20972961/40114796-2a06f844-58dc-11e8-91b4-573c00ffd4fc.png)

As you can see, there is a 4px margin at the bottom which causes a blank space in the background of the date display.  With this update, the datepicker modal looks like this:

![datepicker_fixed](https://user-images.githubusercontent.com/20972961/40114840-571bd4da-58dc-11e8-9f5e-f8708a98f75e.png)

This is how it looked in the previous version of Materialize.

Thanks for a great library!
