### PR TITLE
Fix docs for collapsible preselected section

### DIFF
--- a/jade/page-contents/collapsible_content.html
+++ b/jade/page-contents/collapsible_content.html
@@ -80,7 +80,7 @@
         <br>
         <h5>Preselected Section</h5>
         <span>If you want a collapsible with a preopened section just add the
-          <code class="language-markup">active</code> class to the collapsible-header. </span>
+          <code class="language-markup">active</code> class to the respective collapsible item's <code class="language-markup"><li></code>. </span>
         <ul class="collapsible collapsible-accordion">
           <li>
             <div class="collapsible-header">


### PR DESCRIPTION
## Proposed changes
The current docs state:

> If you want a collapsible with a preopened section just add the  active class to the collapsible-header.

It should say, that the `active` class has to be added to the `<li>` instead the collapsible-header.

## Types of changes

- [x] Documentation fix

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
