### PR TITLE
fix(datepicker): increase month selector width

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -41,7 +41,7 @@
   }
 
   .select-month input {
-    width: 70px;
+    width: 80px;
   }
 }
 


### PR DESCRIPTION
## Proposed changes
Increase the month selector width because it is too small to accommodate "September", "November", and "December".

## Screenshots (if appropriate) or codepen:
![image](https://user-images.githubusercontent.com/3712700/40471622-8fe72f72-5f7a-11e8-9974-374ea166a291.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
