### PR TITLE
Added plain JavaScript sample to initialize the dropdown menu.

### DIFF
--- a/jade/page-contents/navbar_content.html
+++ b/jade/page-contents/navbar_content.html
@@ -342,10 +342,17 @@
   &lt;/div>
 &lt;/nav>
         </code></pre>
-        <p>To activate the dropdown menu, insert this line of code into your JavaScript file, within the
-          <code class="language-javascript">$( document ).ready(function)</code> block</p>
+        <p>To activate the dropdown menu, insert this lines of code into your JavaScript file:
         <pre><code class="language-javascript">
-$(".dropdown-trigger").dropdown();
+// Plain JavaScript
+document.addEventListener('DOMContentLoaded', function() {
+    M.Dropdown.init(document.querySelectorAll('.dropdown-trigger'));
+});
+		
+// or jQuery
+$(document).ready(function () {
+    $(".dropdown-trigger").dropdown();
+});
         </code></pre>
         <h5>Trigger dropdown menu on click</h5>
         <p>


### PR DESCRIPTION
## Proposed changes
In https://materializecss.com/navbar.html#navbar-dropdown it states you have to execute some jQuery based JavaScript in your page to initialize the dropdown menu in the navbar. Since it wouldn't work without it, I added jQuery to my project.

A little later I found out that materialize can work completely without jQuery, and the documentation of the Dropdown box itself (https://materializecss.com/dropdown.html#initialization) shows how to do it in plain JavaScript too. So I thought I'd add it to the navbar page too. 

## Types of changes
- [x] Documentation fix.

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [not applicable] I have added tests to cover my changes.
- [x] All new and existing tests passed.
