### PR TITLE
Materialbox. Added option: "originSizeIfPossible"

### DIFF
--- a/jade/page-contents/media_content.html
+++ b/jade/page-contents/media_content.html
@@ -58,6 +58,12 @@
               <td>Transition out duration in milliseconds.</td>
             </tr>
             <tr>
+              <td>originSizeIfPossible</td>
+              <td>Boolean</td>
+              <td>false</td>
+              <td>Do not resize the image if the screen size allows.</td>
+            </tr>
+            <tr>
               <td>onOpenStart</td>
               <td>Function</td>
               <td>null</td>

--- a/js/materialbox.js
+++ b/js/materialbox.js
@@ -5,6 +5,7 @@
     inDuration: 275,
     outDuration: 200,
     onOpenStart: null,
+    originSizeIfPossible: false,
     onOpenEnd: null,
     onCloseStart: null,
     onCloseEnd: null
@@ -379,6 +380,15 @@
         ratio = this.originalWidth / this.originalHeight;
         this.newWidth = this.windowHeight * 0.9 * ratio;
         this.newHeight = this.windowHeight * 0.9;
+      }
+
+      if (
+        this.options.originSizeIfPossible && // if option true
+        //If the image dimensions need to be increased more than the original, we leave the original
+        (this.newWidth > this.el.naturalWidth || this.newHeight > this.el.naturalHeight)
+      ) {
+        this.newWidth = this.el.naturalWidth;
+        this.newHeight = this.el.naturalHeight;
       }
 
       this._animateImageIn();


### PR DESCRIPTION
This option allows you not to change the size of the image, which is less than the screen size.

## Proposed changes
Small images are stretched to the full screen, which sometimes looks awful. This option will not stretch such images.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
