### PR TITLE
sidenav/modal - fix on iOS when user can scroll if preventScroll = true

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -163,6 +163,14 @@
     }
 
     /**
+     * Handle touch
+     * @param {Event} e
+     */
+    _handleTouch(e) {
+      e.preventDefault();
+    }
+
+    /**
      * Handle Focus
      * @param {Event} e
      */
@@ -304,6 +312,8 @@
 
       if (this.options.preventScrolling) {
         document.body.style.overflow = 'hidden';
+        this._handleTouchMove = this._handleTouch.bind(this);
+        this.$overlay[0].addEventListener('touchmove', this._handleTouchMove);
       }
 
       this.el.classList.add('open');
@@ -346,8 +356,9 @@
       this.el.classList.remove('open');
 
       // Enable body scrolling only if there are no more modals open.
-      if (Modal._modalsOpen === 0) {
+      if (Modal._modalsOpen === 0 && this.options.preventScrolling) {
         document.body.style.overflow = '';
+        this.$overlay[0].removeEventListener('touchmove', this._handleTouchMove);
       }
 
       if (this.options.dismissible) {

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -353,6 +353,14 @@
     }
 
     /**
+     * Handle touch
+     * @param {Event} e
+     */
+    _handleTouch(e) {
+      e.preventDefault();
+    }
+
+    /**
      * Handle Window Resize
      */
     _handleWindowResize() {
@@ -401,11 +409,14 @@
     _preventBodyScrolling() {
       let body = document.body;
       body.style.overflow = 'hidden';
+      this._handleTouchMove = this._handleTouch.bind(this);
+      this._overlay.addEventListener('touchmove', this._handleTouchMove);
     }
 
     _enableBodyScrolling() {
       let body = document.body;
       body.style.overflow = '';
+      this._overlay.removeEventListener('touchmove', this._handleTouchMove);
     }
 
     open() {


### PR DESCRIPTION
## Proposed changes
For Modal and Sidenav components. Even if the param preventScrolling is set to true, user is still able to scroll on iOS devices.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).


## Checklist:t hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
