### PR TITLE
Fix select multiple behavior

### DIFF
--- a/tests/spec/select/selectSpec.js
+++ b/tests/spec/select/selectSpec.js
@@ -106,7 +106,6 @@ describe("Select Plugin", function () {
         click(thirdOption[0]);
         click(document.body);
 
-
         setTimeout(function() {
           expect(multipleDropdown).toBeHidden('Should be hidden after choosing item.');
           expect(browserSelect.val()).toEqual([], 'Actual select element should be empty because none chosen.');
@@ -123,6 +122,45 @@ describe("Select Plugin", function () {
       var secondOption = browserSelect.find('option[selected]').eq(0);
       var thirdOption = browserSelect.find('option[selected]').eq(1);
       expect(multipleInput.val()).toEqual(secondOption.text() + ', ' + thirdOption.text(), 'Value should be equal to preselected option.');
+    });
+
+    it("should re-select and re-deselect the placeholder option", function (done) {
+      multipleInput = browserSelect.parent().find('input.select-dropdown');
+      multipleDropdown = browserSelect.parent().find('ul.select-dropdown');
+
+      // will open dropdown
+      click(multipleInput[0]);
+
+      setTimeout(function() {
+        // did open dropdown
+        
+        var placeholderOption = browserSelect.find('option').eq(0);
+        expect(placeholderOption[0].selected).toEqual(false, 'Value is equal to false firstly');
+        // deselect second option
+        var secondOption = multipleDropdown.find('li').eq(2);
+        click(secondOption[0]);
+
+        setTimeout(function() {
+
+          expect(placeholderOption[0].selected).toEqual(false, 'Value is equal to false because third option is selected');
+
+          var thirdOption = multipleDropdown.find('li').eq(3);
+          click(thirdOption[0]);
+
+          setTimeout(function() {
+            // did deselect all options
+            
+            expect(placeholderOption[0].selected).toEqual(true, 'Value is equal to true because other options are not selected');
+
+            click(secondOption[0]);
+
+            setTimeout(function() {
+              expect(placeholderOption[0].selected).toEqual(false, 'Value is equal to false because second option is selected');
+              done();
+            }, 400);
+          }, 400);
+        }, 400)
+      }, 400);
     });
   });
 


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
I think `<select multiple>` behavior is wrong.
Currentry it is as follows: 

|no| screenshoot| operation|
|:--|:-------------:|:-----------|
|1| ![select - materialize - google chrome 2018_07_01 15_53_34](https://user-images.githubusercontent.com/11131732/42131886-52d4e6e8-7d47-11e8-9b24-44dbaf74d68a.png)| initial view |
|2|![select - materialize - google chrome 2018_07_01 15_54_22](https://user-images.githubusercontent.com/11131732/42131890-68989a92-7d47-11e8-984c-34c2a6c28164.png)| Opened dropdown options |
|3|![select - materialize - google chrome 2018_07_01 15_54_33](https://user-images.githubusercontent.com/11131732/42131896-818021b0-7d47-11e8-9519-5bfb4936db31.png)|  Clicked option1 and then deselected placeholder option.|
|4|![select - materialize - google chrome 2018_07_01 15_54_40](https://user-images.githubusercontent.com/11131732/42131898-b34f8f0a-7d47-11e8-923a-7446a87e1567.png)| Closed dropdown options. But the placeholder option is inputed. I think this is wrong. |
|5| ![select - materialize - google chrome 2018_07_01 15_54_47](https://user-images.githubusercontent.com/11131732/42131942-776dc302-7d48-11e8-9a73-d37d94bbe48b.png) | Opened dropwon options again. But the placeholder option is selected again... |
|6| ![select - materialize - google chrome 2018_07_01 15_55_21](https://user-images.githubusercontent.com/11131732/42131963-004fdbce-7d49-11e8-8120-78799bafddd5.png) | Deselected option1, but the placeholder option is not selected. However the placeholder option is inputted after closing dropdown options.|

### The fixed behavior

So I fixed it as follows:

The operation 1 ~ 3 are the same as above.

|no| screenshoot| operation|
|:--|:-------------:|:-----------|
|4|![select - materialize - google chrome 2018_07_01 16_23_44](https://user-images.githubusercontent.com/11131732/42132052-24b0150e-7d4b-11e8-88e0-5129a5924d83.png)|Selected option1 and then deselect placeholder and closed dropdwon option.  In the fixed version, he placeholder option is not inputted.|
|5| ![select - materialize - google chrome 2018_07_01 16_24_51](https://user-images.githubusercontent.com/11131732/42132062-4cda9112-7d4b-11e8-81fe-4215d324a23a.png)| Deselected option1 and then the placeholder option is selected. |
|6|![select - materialize - google chrome 2018_07_01 16_26_00](https://user-images.githubusercontent.com/11131732/42132068-74cc3fc2-7d4b-11e8-8575-f4e37b098930.png)| Closed dropdown option. the placeholder option is inputed. |

### About he definition of placeholder option

This fixed changes also the definition of placeholder option.
In fixed version, the definition of placeholder option is as follows:

* the attribute of value is `""`.
* the attribute of disabled is `true`.

```select.html
<select id="select" multiple>
    <option value="" disabled>This is placeholder option</option>
    <option value="1"> Option1 </option>
    <option value="2"> Option2 </option>
    <option value="3" selected> Option3 </option>
</select>
```

The above is as follows:

|no| screenshoot| operation|
|:--|:-------------:|:-----------|
|1|![select - materialize - google chrome 2018_07_01 16_40_31](https://user-images.githubusercontent.com/11131732/42132166-b66358ce-7d4d-11e8-8bbf-2741c303826b.png)| initial view|
|2|![select - materialize - google chrome 2018_07_01 16_43_06](https://user-images.githubusercontent.com/11131732/42132173-d9a2a92a-7d4d-11e8-98a4-d1f6ed5ac9df.png)| Deselected option3 and then the placeholder option is selected. |

That's all.

This framework is great.
Thanks.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
