### PR TITLE
Include unit of measure for number

### DIFF
--- a/sass/components/_table_of_contents.scss
+++ b/sass/components/_table_of_contents.scss
@@ -16,7 +16,7 @@
     padding-left: 20px;
     height: 1.5rem;
     line-height: 1.5rem;
-    letter-spacing: .4;
+    letter-spacing: .4px;
     display: inline-block;
 
     &:hover {

--- a/sass/components/date_picker/_default.date.scss
+++ b/sass/components/date_picker/_default.date.scss
@@ -152,7 +152,7 @@
 .picker__day--today {
   position: relative;
   color: #595959;
-  letter-spacing: -.3;
+  letter-spacing: -.3px;
   padding: .75rem 0;
   font-weight: 400;
   border: 1px solid transparent;

--- a/sass/components/date_picker/_default.time.scss
+++ b/sass/components/date_picker/_default.time.scss
@@ -261,7 +261,7 @@
 }
 .clockpicker-canvas line {
 	stroke: $secondary-color;
-	stroke-width: 4;
+	stroke-width: 4px;
 	stroke-linecap: round;
 	/*shape-rendering: crispEdges;*/
 }


### PR DESCRIPTION
## Proposed changes
I needed to make these adjustments to improve the score of my site on the website of the Brazilian Federal Government. There is a law in Brazil that certain websites (including ours) that must have a score above 95%. I performed the necessary tests here: http://jigsaw.w3.org/css-validator/validator?uri=52.3.243.252%2F&profile=css3svg&lang=en and got the errors below:

12 | .table-of-contents a | Value Error : letter-spacing only 0 can be a unit. You must put a unit after your number : 0.4
37 | .picker__day--today | Value Error : letter-spacing only 0 can be a unit. You must put a unit after your number : -0.3
37 | .clockpicker-canvas line | only 0 can be a unit. You must put a unit after your number : 4

My pull request solves the 3 errors above.
Thank you.


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [ x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
