### PR TITLE
Fix .brand-logo.left with .sidebar-trigger

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -79,6 +79,11 @@ nav {
       }
 
       &.left { left: 0.5rem; }
+      
+      .sidenav-trigger~&.left{
+          left:unset;
+      }
+      
       &.right {
         right: 0.5rem;
         left: auto;


### PR DESCRIPTION
Add rule so that applying the left class to a brand logo no longer causes it to overlap with the sidebar trigger, if present. If not, keep original behavior.

## Proposed changes
For both aesthetic and functional reasons, I've had a number of projects where it would be preferable to have the brand logo left aligned, even on smaller screen sizes. This can be accomplished with the `.left` class, but if a `sidebar-trigger`, such as a hamburger icon, is present, they overlap. My update fixes the spacing when a `.sidenav-trigger` is present, but preserves it when it isn't. It also works with mobile collapse buttons. However, it doesn't work if the trigger is not a sibling, or if the `.brand-logo` is specified first in the HTML.



## Screenshots (if appropriate) or codepen:
https://codepen.io/fogoplayer/pen/pZzqOB

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
