### PR TITLE
Add javascript initialization hint

### DIFF
--- a/jade/page-contents/range_content.html
+++ b/jade/page-contents/range_content.html
@@ -52,8 +52,14 @@
         <p>Initialize to display the value above the slider when dragging. Initialization is only needed for elements created after the page loads.</p>
         <pre><code class="language-javascript">
   document.addEventListener('DOMContentLoaded', function() {
-    var elems = document.querySelectorAll("input[type=range]");
+    var elems = document.querySelectorAll('input[type=range]');
     M.Range.init(elems);
+  });
+  
+  // Or with jQuery
+
+  $(document).ready(function(){
+    $('input[type=range]').range();
   });
         </code></pre>
       </div>


### PR DESCRIPTION
This hint is for the creation of range elements after materialize.js has loaded. HTML5 ranges loaded onto the page after materialize.js loads do not display thumbs indicating the value of the range by default. This is problematic when using javascript frameworks like vue and react. See [Issue 6036](https://github.com/Dogfalo/materialize/issues/6036)

## Proposed changes
Add a snippet of javascript on the ranges page in the documentation showing how to initialize a range after materialize.js has loaded.

## Type of change
Documentation Change

## Checklist:
- [x] I have read the **[CONTRIBUTING document]
It only specifies what to do for documentation changes to version 0.100.2