### PR TITLE
add vanilla JS init example for CharacterCounter

### DIFF
--- a/jade/page-contents/modals_content.html
+++ b/jade/page-contents/modals_content.html
@@ -127,7 +127,6 @@
 
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
-        <p>To open a modal using a trigger:</p>
         <pre><code class="language-javascript">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.modal');

--- a/jade/page-contents/navbar_content.html
+++ b/jade/page-contents/navbar_content.html
@@ -641,9 +641,6 @@ $(".dropdown-trigger").dropdown();
 
         <br>
         <h5>Initialization</h5>
-        <p>After including the sidenav-trigger line into your navbar, all you have to do now initialize the plugin. This example
-          below assumes you have not modified the classes in the above example. In the case that you have, just change the
-          selector in the line below to match it.</p>
         <pre><code class="language-javascript">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.sidenav');

--- a/jade/page-contents/tabs_content.html
+++ b/jade/page-contents/tabs_content.html
@@ -72,7 +72,10 @@
       <div id="initialization" class="section scrollspy">
         <h3 class="header">Initialization</h3>
         <pre><code class="language-javascript">
-  var instance = M.Tabs.init(el, options);
+  document.addEventListener('DOMContentLoaded', function() {
+    var elems = document.querySelectorAll('.tabs');
+    var instances = M.Tabs.init(elems, options);
+  });
 
   // Or with jQuery
 

--- a/jade/page-contents/text_inputs_content.html
+++ b/jade/page-contents/text_inputs_content.html
@@ -348,7 +348,7 @@
 
       <div id="character-counter" class="section scrollspy">
         <h3 class="header">Character Counter</h3>
-        <p class="caption">Use a character counter in fields where a character restriction is in place.</p>
+        <p class="caption">Use a character counter in fields where a length restriction is in place. The field will be marked invalid when the length of the input exceeds the maximum.</p>
         <div class="row">
           <form class="col s12">
             <div class="row">
@@ -387,8 +387,15 @@
         <br>
 
         <h5>Initialization</h5>
-        <p>There are no options for this plugin, but if you are adding these dynamically, you can use this to initialize them.</p>
+        <p>There are currently no options available for this plugin. To dynamically initialize the plugin, use the following example:</p>
         <pre><code class="language-javascript">
+  document.addEventListener('DOMContentLoaded', function() {
+    var elems = document.querySelectorAll('[data-length]');
+    M.CharacterCounter.init(elems);
+  });
+
+  // Or with jQuery
+
   $(document).ready(function() {
     $('input#input_text, textarea#textarea2').characterCounter();
   });


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
This PR accomplishes 3 things:
1. add a vanilla javascript initialization example for the CharacterCounter plugin.
2. normalize the "initialization" examples everywhere.
3. clarify any help text where necessary, or remove any help text that is redundant.


Open to discuss.