### PR TITLE
Replace copyright symbol with &copy;

### DIFF
--- a/jade/_footer.html
+++ b/jade/_footer.html
@@ -118,7 +118,7 @@
             </div>
 
             <div class="footer-copyright">
-              © 2014-<noscript>2018</noscript><script type="text/javascript">document.write(new Date().getFullYear());</script> Materialize, All rights reserved.
+              &copy; 2014-<noscript>2018</noscript><script type="text/javascript">document.write(new Date().getFullYear());</script> Materialize, All rights reserved.
               <a class="grey-text text-darken-1 right" href="https://github.com/Dogfalo/materialize/blob/master/LICENSE">MIT License</a>
             </div>
 

--- a/jade/page-contents/footer_content.html
+++ b/jade/page-contents/footer_content.html
@@ -55,7 +55,7 @@
           &lt;/div>
           &lt;div class="footer-copyright">
             &lt;div class="container">
-            © 2014 Copyright Text
+            &copy; 2014 Copyright Text
             &lt;a class="grey-text text-lighten-4 right" href="#!">More Links&lt;/a>
             &lt;/div>
           &lt;/div>


### PR DESCRIPTION
## Proposed changes
Just wanted to swap out the Unicode copyright symbol for the HTML character entity.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
