### PR TITLE
Fix logic error that prevents tabbing through autocomplete

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -201,7 +201,7 @@
 
       // Check if the input isn't empty
       // Check if focus triggered by tab
-      if (this.oldVal !== val && (M.tabPressed || e.type !== 'focus')) {
+      if (this.oldVal !== val && (!M.tabPressed || e.type !== 'focus')) {
         this.open();
       }
 


### PR DESCRIPTION
## Proposed changes
When I realized that I could not tab through autocomplete component, I started looking into the code. I was able to find where the tabbing went awry. When user tabs into the autocomplete input element, we don't want to open the dropdown, yet. The code was testing for that condition, but it needed a slight change. It should open if the tab is not pressed.

## Screenshots (if appropriate) or codepen:
https://github.com/Dogfalo/materialize/blob/ca9beaf1591f9e5fa4536a4f6d8dabd6136406fb/js/autocomplete.js#L204 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
