### PR TITLE
useless float: left

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -226,7 +226,6 @@ video.responsive-video {
   [class^="mdi-"], [class*="mdi-"],
   i.material-icons {
     display: inline-block;
-    float: left;
     font-size: 24px;
   }
 


### PR DESCRIPTION
float: left;
is ignored on a 
display: inline-block;

## Proposed changes
float: left removed because we have a display: inline-block and float is ignored with this display

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
