### PR TITLE
Deleting redundant code for autocomplete enter

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -261,11 +261,6 @@
 
       // enter
       if (e.keyCode === 13) {
-        // Override enter if autocompleting.
-        if (this.hasAutocomplete && this.autocomplete && this.autocomplete.isOpen) {
-          return;
-        }
-
         e.preventDefault();
         this.addChip({
           tag: this.$input[0].value


### PR DESCRIPTION
## Proposed changes
We should not overwrite autocomplete enter click.
For example if we have in autocomplete list: "tag1", then it was impossible to add just "tag".
And without this code it is possible to add tag which is actually a substring of a different tag.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
