### PR TITLE
Use custom format function on datepicker init if defined

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -141,7 +141,12 @@
       this._setupEventHandlers();
 
       if (!this.options.defaultDate) {
-        this.options.defaultDate = new Date(Date.parse(this.el.value));
+        // Check if there is a custom format function and use it to load the date from input
+        if (this.options.parse)
+          this.options.defaultDate = this.options.parse(this.el.value, this.options.format);
+        else
+          this.options.defaultDate = new Date(Date.parse(this.el.value));
+        }
       }
 
       let defDate = this.options.defaultDate;


### PR DESCRIPTION
## Proposed changes
When you define a custom format function for the datepicker, its not used on the init. The datepicker create the date object from the input value when no default date is defined, and uses the default format function from javascript that only accepts dates on the format "YYYY-MM-DD".

With these proposed change, on the init the datepicker will check if there is a custom format function defined and will use it insted of the default javascript one to load the date from the input value when no default date is defined.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
