### PR TITLE
Adds support for modal options in datepicker

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -102,7 +102,10 @@
     onSelect: null,
     onOpen: null,
     onClose: null,
-    onDraw: null
+    onDraw: null,
+
+    // modal options
+    modalOptions: {}
   };
 
   /**
@@ -252,11 +255,10 @@
 
     _setupModal() {
       this.modalEl.id = 'modal-' + this.id;
-      this.modal = M.Modal.init(this.modalEl, {
-        onCloseEnd: () => {
+      this.options.modalOptions['onCloseEnd'] = () => {
           this.isOpen = false;
         }
-      });
+      this.modal = M.Modal.init(this.modalEl, this.options.modalOptions);
     }
 
     toString(format) {


### PR DESCRIPTION
## Proposed changes
### Allow users to set modal options for datepicker

All modals in my use case had a custom `startingTop` and  `endingTop` property. There was no way to set this property in the same way while initializing datepickers. 

Adding modals options support for datepicker would make it more customisable and hence I propose this change.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
