### PR TITLE
Fix bug by adding missing classes in img element in select component

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -317,8 +317,9 @@
 
       // add icons
       let iconUrl = option.getAttribute('data-icon');
+      let classes = option.getAttribute('class');
       if (!!iconUrl) {
-        let imgEl = $(`<img alt="" src="${iconUrl}">`);
+        let imgEl = $(`<img alt="" class="${classes}" src="${iconUrl}">`);
         liEl.prepend(imgEl);
       }
 


### PR DESCRIPTION
## Proposed changes

It fixes the #5797 issue.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).


## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
