### PR TITLE
Prevents the content panels of disabled tabs from being added to the …

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 (function($, anim) {
   'use strict';
 
@@ -7,6 +8,47 @@
     swipeable: false,
     responsiveThreshold: Infinity // breakpoint for swipeable
   };
+=======
+(function ($) {
+
+  var methods = {
+    init : function(options) {
+      var defaults = {
+        onShow: null,
+        swipeable: false,
+        responsiveThreshold: Infinity, // breakpoint for swipeable
+      };
+      options = $.extend(defaults, options);
+      var namespace = Materialize.objectSelectorString($(this));
+
+      return this.each(function(i) {
+
+      var uniqueNamespace = namespace+i;
+
+      // For each set of tabs, we want to keep track of
+      // which tab is active and its associated content
+      var $this = $(this),
+          window_width = $(window).width();
+
+      var $active, $content, $links = $this.find('li.tab a'),
+          $tabs_width = $this.width(),
+          $tabs_content = $(),
+          $tabs_wrapper,
+          $tab_width = Math.max($tabs_width, $this[0].scrollWidth) / $links.length,
+          $indicator,
+          index = 0,
+          prev_index = 0,
+          clicked = false,
+          clickedTimeout,
+          transition = 300;
+
+
+      // Finds right attribute for indicator based on active tab.
+      // el: jQuery Object
+        var calcRightPos = function(el) {
+          return Math.ceil($tabs_width - el.position().left - el[0].getBoundingClientRect().width - $this.scrollLeft());
+      };
+>>>>>>> b94dd3c7eb37cf51acf6398cd710f7984f62e9e2
 
   /**
    * @class
@@ -245,10 +287,12 @@
       }
 
       let $tabsContent = $();
-      this.$tabLinks.each((link) => {
-        let $currContent = $(M.escapeHash(link.hash));
-        $currContent.addClass('carousel-item');
-        $tabsContent = $tabsContent.add($currContent);
+          this.$tabLinks.each((link) => {
+          if(!$(link).parent('li.tab').hasClass('disabled')){
+            let $currContent = $(M.escapeHash(link.hash));
+            $currContent.addClass('carousel-item');
+            $tabsContent = $tabsContent.add($currContent);
+          }
       });
 
       let $tabsWrapper = $('<div class="tabs-content carousel carousel-slider"></div>');


### PR DESCRIPTION
## Proposed changes
Prevent the content panels of disabled tabs from being added to the tab carousel if the associated tab has the class 'disabled'


- [ ] Bug fix (non-breaking change which fixes an issue).


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
