### PR TITLE
Fix dropdown section in v1 upgrade guide documentation

### DIFF
--- a/v1-upgrade-guide.md
+++ b/v1-upgrade-guide.md
@@ -38,7 +38,7 @@
 ## Dropdown
 - Removed gutter option
 - Removed stopPropagation option
-- Call plugin on `.dropdown-content` instead of `.dropdown-button`
+- Call plugin on `.dropdown-trigger` instead of `.dropdown-button`
 - Change attribute `data-activates` to `data-target`
 - Rename classes `.dropdown-button` to `.dropdown-trigger`
 - Rename option `belowOrigin` to `coverTrigger`
@@ -116,7 +116,3 @@
 
 ## Transitions
 - JavaScript transitions removed
-
-
-
-


### PR DESCRIPTION
## Proposed changes
This PR fixes issue #6116 which is a simple change to this line in the Dropdown section:

> Call plugin on .dropdown-content instead of .dropdown-button

As the issue points out, it should be `.dropdown-trigger` and not `.dropdown-content`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
