### PR TITLE
change chips init to material_chips()

### DIFF
--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -81,8 +81,8 @@
 
   // Or with jQuery
 
-  $('.chips').chips();
-  $('.chips-initial').chips({
+  $('.chips').material_chips();
+  $('.chips-initial').material_chips({
     data: [{
       tag: 'Apple',
     }, {
@@ -91,11 +91,11 @@
       tag: 'Google',
     }],
   });
-  $('.chips-placeholder').chips({
+  $('.chips-placeholder').material_chips({
     placeholder: 'Enter a tag',
     secondaryPlaceholder: '+Tag',
   });
-  $('.chips-autocomplete').chips({
+  $('.chips-autocomplete').material_chips({
     autocompleteOptions: {
       data: {
         'Apple': null,


### PR DESCRIPTION
the current docs suggesting to initialize chips with .chips() don't work
and have to be initialized with .material_chips()

## Proposed changes
update docs with proper initializing function for `chips`

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
