### PR TITLE
Fix a bug in timepicker about clock hand

### DIFF
--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -104,6 +104,7 @@
 }
 .timepicker-dial {
 	transition: transform 350ms, opacity 350ms;
+	touch-action: manipulation;
 }
 .timepicker-dial-out {
   &.timepicker-hours {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Problem is when changing clock handles, This error occurs : 

`Unable to preventDefault inside passive event listener due to target being treated as passive.`

Adding `touch-action: manipulation;` to `timepicker-dial` class can fix the problem. 
[https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action)
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
