### PR TITLE
Autocomplete - Allow end user to modify autocomplete filter

### DIFF
--- a/jade/page-contents/autocomplete_content.html
+++ b/jade/page-contents/autocomplete_content.html
@@ -104,6 +104,12 @@
               <td></td>
               <td>Sort function that defines the order of the list of autocomplete options.</td>
             </tr>
+            <tr>
+              <td>filterFunction</td>
+              <td>Function</td>
+              <td></td>
+              <td>filter function that defines what is filtered based on the users input.</td>
+            </tr>
           </tbody>
         </table>
 
@@ -121,6 +127,20 @@
         </code></pre>
         <p>To disable sorting and use the values as they appear in the data object, use a falsy value.</p>
       </div>
+
+        <h5 class="method-header">
+          filterFunction
+        </h5>
+        <p>This is the default filter function. You can write your own filter function by passing in a function with the same
+          parameters.
+        <pre><code class="language-javascript col s12">
+  function(key, inputString) {                                                                                                      
+    return key.toLowerCase().indexOf(inputString) !== -1;                                                                                           
+  }
+        </code></pre>
+        <p>To disable sorting and use the values as they appear in the data object, use a falsy value.</p>
+      </div>
+
 
 
       <div id="methods" class="scrollspy section">

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -9,6 +9,9 @@
     sortFunction: function(a, b, inputString) {
       // Sort function for sorting autocomplete results
       return a.indexOf(inputString) - b.indexOf(inputString);
+    },
+    filterFunction: function(key, inputString) {
+      return key.toLowerCase().indexOf(inputString) !== -1;
     }
   };
 
@@ -348,7 +351,7 @@
 
       // Gather all matching data
       for (let key in data) {
-        if (data.hasOwnProperty(key) && key.toLowerCase().indexOf(val) !== -1) {
+        if (data.hasOwnProperty(key) && this.options.filterFunction(key, val)) {
           // Break if past limit
           if (this.count >= this.options.limit) {
             break;

--- a/tests/spec/autocomplete/autocompleteSpec.js
+++ b/tests/spec/autocomplete/autocompleteSpec.js
@@ -66,6 +66,71 @@ describe("Autocomplete Plugin", function () {
       }, 200);
 
     });
+    it("should filter results", function (done) {
+      var $normal = $('#normal-autocomplete');
+      var $parent = $normal.parent();
+      var $autocompleteEl = $normal.parent().find('.autocomplete-content');
+
+      $normal.focus();
+      $normal.val('e');
+      keyup($normal[0], 69);
+
+      setTimeout(function() {
+        expect($autocompleteEl.children().length).toEqual(2, 'Results containing e should return.');
+        done();
+      }, 200);
+    });
+
+    it("should allow for custom filtered results", function (done) {
+      var $normal = $('#normal-autocomplete');
+      var $parent = $normal.parent();
+      $normal.autocomplete({     
+        data: {
+          "Apple": null,
+          "Microsoft": null,
+          "Google": 'http://placehold.it/250x250'
+        },
+        // don't filter anything.
+        filterFunction: function(key_string,filter_string) {
+          // each record is passed through this function
+          // if false record is not displayed.
+          return true
+        }
+      });
+      var $autocompleteEl = $normal.parent().find('.autocomplete-content');
+
+      $normal.focus();
+      $normal.val('foo');
+      keyup($normal[0], 69);
+
+      setTimeout(function() {
+        expect($autocompleteEl.children().length).toEqual(3, 'All rows should return.');
+        done();
+      }, 200);
+    });
+
+    it("Should update data to be processed.", function (done) {
+      var $normal = $('#normal-autocomplete');
+      var $instance = M.Autocomplete.getInstance($normal)
+      var $parent = $normal.parent();
+
+      $instance.updateData({
+        "Apple": null,
+        "Microsoft": null,
+        "Google": 'https://placehold.it/250x250',
+        "Oracle": null
+        }); 
+      var $autocompleteEl = $normal.parent().find('.autocomplete-content');
+
+      $normal.focus();
+      $normal.val('e');
+      keyup($normal[0], 69);
+
+      setTimeout(function() {
+        expect($autocompleteEl.children().length).toEqual(3, 'should return updated result set.');
+        done();
+      }, 200);
+    });
 
     it("should open correctly from typing", function (done) {
       var $normal = $('#normal-autocomplete');


### PR DESCRIPTION
## Proposed changes
Move autocomplete filter to a configuration item. Useful for the following reasons:
- Allow the developer to make custom filter.
- Reduce amount of new features to be introduced into the code base.
- Other libraries (Awesomplete) already do this.
- Change is low risk.
- 66 lines of unit tests for 4 lines of code change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
