### PR TITLE
Better fix for chip label bug

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -361,7 +361,7 @@
     _setupLabel() {
       this.$label = this.$el.find('label');
       if (this.$label.length) {
-        this.$label[0].setAttribute('for', this.$input.attr('id'));
+        this.$label.attr('for', this.$input.attr('id'));
       }
     }
 


### PR DESCRIPTION
## Proposed changes
I think, that this is a better fix for #6124. It does not assume number of elements and sets `for` atribute for all of them. Not only the first one.

Side note - It would be nice to release a new version. At least as a patch version, so we won't be forced to use development branch and be able to use actual release.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
