### PR TITLE
Allow user to disable autocomplete filtering

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -6,6 +6,7 @@
     limit: Infinity, // Limit of results the autocomplete shows
     onAutocomplete: null, // Callback for when autocompleted
     minLength: 1, // Min characters before autocomplete starts
+    filterResults: true, // whether to filter the results based on the keyword
     sortFunction: function(a, b, inputString) {
       // Sort function for sorting autocomplete results
       return a.indexOf(inputString) - b.indexOf(inputString);
@@ -348,7 +349,9 @@
 
       // Gather all matching data
       for (let key in data) {
-        if (data.hasOwnProperty(key) && key.toLowerCase().indexOf(val) !== -1) {
+          if (this.options.filterResults && (!data.hasOwnProperty(key) || key.toLowerCase().indexOf(val) === -1)) {
+            continue;
+          }
           // Break if past limit
           if (this.count >= this.options.limit) {
             break;
@@ -361,7 +364,6 @@
           matchingData.push(entry);
 
           this.count++;
-        }
       }
 
       // Sort


### PR DESCRIPTION
## Proposed changes
Allow user to disable autocomplete filtering by modifying the option filterResults = false

I only put this for reference but I prefer the solution from https://github.com/Dogfalo/materialize/pull/6245 so you can discard this PR in case you merge the other.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [ x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


