### PR TITLE
Fix #6312 chrome 73 workaround for date picker and dropdowns

### DIFF
--- a/js/date_picker/picker.js
+++ b/js/date_picker/picker.js
@@ -220,7 +220,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     P.$root.addClass( CLASSES.opened )
                     aria( P.$root[0], 'hidden', false )
 
-                }, 0 )
+                }, 100 )
 
                 // If we have to give focus, bind the element and doc events.
                 if ( dontGiveFocus !== false ) {
@@ -242,21 +242,25 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
                     // Bind the document events.
                     $document.on( 'click.' + STATE.id + ' focusin.' + STATE.id, function( event ) {
 
-                        var target = event.target
+                        setTimeout(function(event){
 
-                        // If the target of the event is not the element, close the picker picker.
-                        // * Don’t worry about clicks or focusins on the root because those don’t bubble up.
-                        //   Also, for Firefox, a click on an `option` element bubbles up directly
-                        //   to the doc. So make sure the target wasn't the doc.
-                        // * In Firefox stopPropagation() doesn’t prevent right-click events from bubbling,
-                        //   which causes the picker to unexpectedly close when right-clicking it. So make
-                        //   sure the event wasn’t a right-click.
-                        if ( target != ELEMENT && target != document && event.which != 3 ) {
+                            var target = event.target
 
-                            // If the target was the holder that covers the screen,
-                            // keep the element focused to maintain tabindex.
-                            P.close( target === P.$root.children()[0] )
-                        }
+                            // If the target of the event is not the element, close the picker picker.
+                            // * Don’t worry about clicks or focusins on the root because those don’t bubble up.
+                            //   Also, for Firefox, a click on an `option` element bubbles up directly
+                            //   to the doc. So make sure the target wasn't the doc.
+                            // * In Firefox stopPropagation() doesn’t prevent right-click events from bubbling,
+                            //   which causes the picker to unexpectedly close when right-clicking it. So make
+                            //   sure the event wasn’t a right-click.
+                            if ( target != ELEMENT && target != document && event.which != 3 ) {
+
+                                // If the target was the holder that covers the screen,
+                                // keep the element focused to maintain tabindex.
+                                P.close( target === P.$root.children()[0] )
+                            }
+
+                        }, 0, event);
 
                     }).on( 'keydown.' + STATE.id, function( event ) {
 

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -190,7 +190,7 @@
             hideDropdown();
             $(document).off('click.'+ activates.attr('id'));
           });
-        }, 0);
+        }, 100);
       }
 
       function hideDropdown() {


### PR DESCRIPTION
## Proposed changes
Fix for issue #6312 to allow chrome 73 compatibility for date/time pickers and dropdowns

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
