### PR TITLE
Fix collapsible-body height 0

### DIFF
--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -174,7 +174,7 @@
               overflow: '',
               paddingTop: '',
               paddingBottom: '',
-              height: ''
+              height: $body[0].height == 0 ? finalHeight : ''
             });
 
             // onOpenEnd callback


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
In specific cases the height of a `active` collapsible is not correct after `_animateIn`.
If the collapsible-body height is equal to 0 it uses the outerHeight.
With these changes it should be correct.

## Codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->
Version 1.0.0: https://codepen.io/anon/pen/NJVoRo
Fixed: https://codepen.io/KillTrot/pen/PLvVJx (fixed with onOpenEnd event and jQuery, in the pull request it's fixed in the code directly)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
