### PR TITLE
Fix chips focus

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -191,6 +191,8 @@
 
         if (currChips.chipsData.length) {
           currChips.selectChip(selectIndex);
+        } else {
+          currChips.$input[0].focus();
         }
 
         // left arrow key

--- a/js/chips.js
+++ b/js/chips.js
@@ -175,6 +175,15 @@
 
       let currChips = $chips[0].M_Chips;
 
+      // Revert blur from window unfocus
+      if (!currChips._selectedChip) {
+        for (var i = 0; i < $chips[0].childNodes.length; i++) {
+          if (document.activeElement === $chips[0].childNodes[i]) {
+            currChips.selectChip(i);
+          }
+        }
+      }
+
       // backspace and delete
       if (e.keyCode === 8 || e.keyCode === 46) {
         e.preventDefault();


### PR DESCRIPTION
## Proposed changes

The problem: If you have focused on a chip and then un-focus the entire browser window (not focusing on another element) the _handleChipsBlur function is executed. This sets null in _selectedChip but when you return to the window the chip retains its focus. If you try to hit the left, right and delete keys nothing is executed (in delete an exception is thrown).

This fix checks if the document.activeElement is one of the chips and selects it prior to executing any of the key down code.

Also a minor update is introduced in order to focus on the input element when deleting the last chip.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
