### PR TITLE
Fix of moving upwards, also fixes copy-paste issues

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -252,10 +252,7 @@
       M.textareaAutoResize($textarea);
     });
 
-    $(document).on('keyup', text_area_selector, function() {
-      M.textareaAutoResize($(this));
-    });
-    $(document).on('keydown', text_area_selector, function() {
+    $(document).on('input', text_area_selector, function() {
       M.textareaAutoResize($(this));
     });
 


### PR DESCRIPTION
## Proposed changes

When calculating the new size of the textarea the text moved upwards, before moving downwards again when setting the correct height. This fix eliminates this issue, it also fixes non-key related changed to the value of the textarea (paste, cut).

## Screenshots (if appropriate) or codepen:

See #5938

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
