### PR TITLE
Make v0.100.2 date picker and dropdown play nice with Chrome 73

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -514,6 +514,12 @@
       var uniqueID = Materialize.guid();
       $select.attr('data-select-id', uniqueID);
       var wrapper = $('<div class="select-wrapper"></div>');
+
+      // to fix Chrome 73 bug
+      wrapper.click(function (e) {
+        e.stopPropagation();
+      });
+
       wrapper.addClass($select.attr('class'));
       if ($select.is(':disabled'))
         wrapper.addClass('disabled');


### PR DESCRIPTION
## Proposed changes
Chrome 73 changes broke v0.100.2 date picker and dropdown, among other things. 

1. Datepicker - was being closed as soon as it is opened. I just ported over pickadate v.3.6.3 picker constructor prepareElement function contents (https://github.com/amsul/pickadate.js/blob/master/lib/picker.js). This made my project happy, for now. For some reason the debounce interval of 100 was not enough to win the race in our case, therefore it is 150. This introduces a (barely) noticeable lag between the click event and the rendering of the picker. There is an edge case of the user clicking and holding the mouse for too long which will close the date picker.

2. Dropdown - was being collapsed as soon as it was clicked and dropped. I understand that dist/materialize.js shoud not be updated directly as they are automatically generated. So it made sense to update the form.js instead, which should have been reflected in materialize.js at some point. However, in our project, that did not fix the dropdown. I had to manually update materialize.js to fix it. I can either refactor this commit or remove it completely. 

The branch was checked out off of master at the commit that released v0.100.2 back in the day. I will change that if it is wrong.

Although this patch seem like a good thing, it is probably evil! All of us using v0.100.2  should upgrade ASAP!

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

#6336