### PR TITLE
Enforce black text in input fields

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -25,6 +25,7 @@ textarea.materialize-textarea {
 
   // General Styles
   background-color: transparent;
+  color: black;
   border: none;
   border-bottom: $input-border;
   border-radius: 0;


### PR DESCRIPTION
## Proposed changes
When using custom themes at the desktop environment (e.g. _Adwaita-dark_, a GTK theme), sometimes the themes overrides some CSS variables. In this case, _Adwaita-dark_ set the colors of the text fields in forms as `white` if the website doesn't make it, making the text at the same color as the field. This changes reinforce the browser to set the text to `black` at user input fields, fixing this bug.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
