### PR TITLE
Adding margin before the first breadcrumb

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -249,6 +249,10 @@ video.responsive-video {
     display: none;
   }
 
+  &:first-child {
+    margin-left: 15px;
+  }
+  
   &:last-child {
     color: #fff;
   }


### PR DESCRIPTION
Because the first item doesn't have a arrow before it, it was sticked to the left border. For the global spacing, it needs a margin at the beginning of the line

## Proposed changes
Just added a 15px margin-left on the first-child of the breadcrumbs item to have the same spacing as next breadcrumbs

## Screenshots (if appropriate) or codepen:
Here is the [CodePen](https://codepen.io/tchekda/pen/qwzPLg) to show the added element

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
