### PR TITLE
Avoid setAttribute for CSP compliance

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -51,6 +51,15 @@
         return style;
     }
 
+    function setStyle(obj, style) {
+      if (M.jQueryLoaded) {
+        $( obj ).css(style);
+      }
+      else {
+        obj.setAttribute('style', convertStyle(style));
+      }
+    }
+
     var Effect = {
 
         // Effect delay
@@ -95,7 +104,7 @@
             };
 
             ripple.className = ripple.className + ' waves-notransition';
-            ripple.setAttribute('style', convertStyle(rippleStyle));
+            setStyle(ripple, rippleStyle);
             ripple.className = ripple.className.replace('waves-notransition', '');
 
             // Scale the ripple
@@ -116,7 +125,7 @@
             rippleStyle['-o-transition-timing-function']      = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
             rippleStyle['transition-timing-function']         = 'cubic-bezier(0.250, 0.460, 0.450, 0.940)';
 
-            ripple.setAttribute('style', convertStyle(rippleStyle));
+            setStyle(ripple, rippleStyle);
         },
 
         hide: function(e) {
@@ -165,7 +174,7 @@
                     'transform': scale,
                 };
 
-                ripple.setAttribute('style', convertStyle(style));
+                setStyle(ripple, style);
 
                 setTimeout(function() {
                     try {
@@ -200,7 +209,7 @@
                         elementStyle = '';
                     }
 
-                    wrapper.setAttribute('style', elementStyle);
+                    setStyle(wrapper, elementStyle);
 
                     el.className = 'waves-button-input';
                     el.removeAttribute('style');


### PR DESCRIPTION
## Proposed changes

Under some circumstances (we experienced this issue with a recent rails and appropriately strict CSP policies, see mkhairi/materialize-sass#186), materialize causes CSP violations.

Using `setAttribute('style', style)` causes issues with the style policy. `element.style = ...` is CSP compliant and could be used instead. jQuery offers `.css()`, which uses the aforementioned `.style`.
This PR changes the problematic `setAttribute` calls to using a `setStyle()` function which checks if jQuery is loaded and uses `.css()` if possible or falls back to `setAttribute`.
It might be possible to enhance the function to fall back to looping through the styles and directly applying them with `.style = `, but I didn't look into that yet.
I "played it safe" with regards to the jQuery check, but maybe `.css()` is already implemented by whichever way materialize chose to replace/deprecate jQuery, so it might not even be necessary.

## Screenshots (if appropriate) or codepen:

/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
