### PR TITLE
Fix #6306 Tooltip positions shifted in horizontally scrolling table.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -217,6 +217,10 @@ M.checkWithinContainer = function(container, bounding, offset) {
     container === document.body
       ? Math.max(containerRect.bottom, window.innerHeight)
       : containerRect.bottom;
+  let containerRight = 
+    container === document.body 
+      ? Math.max(containerRect.right, window.innerWidth) 
+      : containerRect.right;
 
   let scrollLeft = container.scrollLeft;
   let scrollTop = container.scrollTop;
@@ -230,7 +234,7 @@ M.checkWithinContainer = function(container, bounding, offset) {
   }
 
   if (
-    scrolledX + bounding.width > containerRect.right - offset ||
+    scrolledX + bounding.width > containerRight - offset ||
     scrolledX + bounding.width > window.innerWidth - offset
   ) {
     edges.right = true;


### PR DESCRIPTION
## Proposed changes
Issue #6306 
This fix resolves a bug with tooltip position horizontally. 
**The current behavior of tooltips:** When a page is loaded will display at the far right side of the viewport regardless of the position of its trigger and tooltips are initially outside of the viewport. I think is important to accept this fix because this bug affects how is the data display in the view. 


## Screenshots (if appropriate) or codepen:
Bug behavior: 
![PRMAterialize](https://user-images.githubusercontent.com/26575531/57431327-49242380-71e7-11e9-94e2-a518a18fb277.gif)

Here's a codepen example: https://codepen.io/akemd/pen/GeOMvj

<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

The resolved bug is interacting in this way:
![PRMAT](https://user-images.githubusercontent.com/26575531/57431612-32ca9780-71e8-11e9-832b-c8f9c89cb1e4.gif)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
