### PR TITLE
Fix 6375 - Add seperate class for timepicker cancel and ok buttons

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -275,7 +275,7 @@
         .appendTo(confirmationBtnsContainer)
         .on('click', this.close.bind(this));
       $(
-        '<button class="btn-flat timepicker-close waves-effect" type="button" tabindex="' +
+        '<button class="btn-flat timepicker-done waves-effect" type="button" tabindex="' +
           (this.options.twelveHour ? '3' : '1') +
           '">' +
           this.options.i18n.done +

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -154,8 +154,13 @@
   color: $secondary-color;
 }
 
+.timepicker-done {
+  color: $secondary-color;
+}
+
 .timepicker-clear,
-.timepicker-close {
+.timepicker-close,
+.timepicker-done {
   padding: 0 20px;
 }
 


### PR DESCRIPTION
## Proposed changes
Fix #6375 by adding a new class for the `OK` button, `timepicker-done`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
