### PR TITLE
Update CSS to prevent dropdowns from spilling over modal edges

### DIFF
--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -83,3 +83,8 @@ body.keyboard-focused {
 .dropdown-trigger {
   cursor: pointer;
 }
+
+// Do not spill over the edge of a modal
+.modal-content .dropdown-content.select-dropdown {
+	max-height: 60vh !important; // important needed to override JS' calculations
+}

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -86,5 +86,5 @@ body.keyboard-focused {
 
 // Do not spill over the edge of a modal
 .modal-content .dropdown-content.select-dropdown {
-	max-height: 60vh !important; // important needed to override JS' calculations
+	max-height: calc(60vh - 56px) !important; // important needed to override JS' calculations
 }


### PR DESCRIPTION
## Proposed changes
In applications I am working on, I have found the need to place dropdowns into modals quite common.  However, large dropdowns would always spill over and force the modal to have overflow.  This fixes this by forcing dropdowns to be no larger than 60vh (the modal itself will always be no longer than 70vh).

It may be more appropriate to add this into the JS itself or another CSS file, I just thought I'd share my fix.

## Screenshots (if appropriate) or codepen:
You can see the issue before and after my patch:
https://codepen.io/anon/pen/EzrOjE

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.