### PR TITLE
Added function to allow duplicate chips to be added

### DIFF
--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -176,6 +176,12 @@
               <td>Callback for chip delete.</td>
             </tr>
             <tr>
+              <td>allowDuplicates</td>
+              <td>Boolean</td>
+              <td>false</td>
+              <td>Allow duplicate chips to be added.</td>
+            </tr>
+            <tr>
           </tbody>
         </table>
       </div>

--- a/js/chips.js
+++ b/js/chips.js
@@ -9,7 +9,8 @@
     limit: Infinity,
     onChipAdd: null,
     onChipSelect: null,
-    onChipDelete: null
+    onChipDelete: null,
+    allowDuplicates: false
   };
 
   /**
@@ -41,6 +42,7 @@
        * @prop {String} placeholder
        * @prop {String} secondaryPlaceholder
        * @prop {Object} autocompleteOptions
+       * @prop {Boolean}  [allowDuplicates=false]
        */
       this.options = $.extend({}, Chips.defaults, options);
 
@@ -384,12 +386,15 @@
      * @param {chip} chip
      */
     _isValid(chip) {
-      if (chip.hasOwnProperty('tag') && chip.tag !== '') {
-        let exists = false;
-        for (let i = 0; i < this.chipsData.length; i++) {
-          if (this.chipsData[i].tag === chip.tag) {
-            exists = true;
-            break;
+      
+        if (chip.hasOwnProperty('tag') && chip.tag !== '') {
+          let exists = false;
+          for (let i = 0; i < this.chipsData.length; i++) {
+            
+            if (this.options.allowDuplicates === false && this.chipsData[i].tag === chip.tag) {
+              exists = true;
+              break;
+            }
           }
         }
         return !exists;

--- a/js/chips.js
+++ b/js/chips.js
@@ -386,15 +386,12 @@
      * @param {chip} chip
      */
     _isValid(chip) {
-      
-        if (chip.hasOwnProperty('tag') && chip.tag !== '') {
-          let exists = false;
-          for (let i = 0; i < this.chipsData.length; i++) {
-            
-            if (this.options.allowDuplicates === false && this.chipsData[i].tag === chip.tag) {
-              exists = true;
-              break;
-            }
+      if (chip.hasOwnProperty('tag') && chip.tag !== '') {
+        let exists = false;
+        for (let i = 0; i < this.chipsData.length; i++) {
+          if (this.options.allowDuplicates === false && this.chipsData[i].tag === chip.tag) {
+            exists = true;
+            break;
           }
         }
         return !exists;


### PR DESCRIPTION
 ## Proposed changes

Current functionality: When a duplicate chip is added, it immediately disappears as it is meant to check to see if the chip already exists. If it exists, it is not added. 

However, there are some situations where adding duplicate chips would actually be useful such as if you wish to do sentence forming in conjunction with the Auto complete on chips. 

I propose to add a boolean option to allow duplicates. The default is set to false, meaning no duplicates are allowed so this change will not affect any current users of the library. 

Only users that wish to use this will be able to explicitly state they wish to have duplicates.

The check is done in the _isValid(chip) function in `chip.js`. 

 ## Screenshots (if appropriate) or codepen:

In the code, it can be specified like so: 
```
var instances = M.Chips.init(elems, {
  allowDuplicates: true
});
```

 ## Types of changes
- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
 
 ## Checklist:
 
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Please let me know if there's anything I would need to do in order for this to be accepted.  
 
 #6403 

EDIT: I've updated the documentation
