### PR TITLE
fix css (minor changes: add mask-image, add backface-visibility, float / display warning, remove empty checkbox)

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -218,6 +218,7 @@ video.responsive-video {
 }
 
 // Breadcrumbs
+/* when float is not 'none',display is treated as 'block'*/
 .breadcrumb {
   display: inline-block;
   font-size: 18px;
@@ -227,10 +228,12 @@ video.responsive-video {
   [class^="mdi-"], [class*="mdi-"],
   i.material-icons {
     display: inline-block;
+    /* display: block, see the note above */
     float: left;
     font-size: 24px;
   }
 
+  // see note above for float
   &:before {
     content: '\E5CC';
     color: rgba(255,255,255, .7);
@@ -243,6 +246,7 @@ video.responsive-video {
     margin: 0 10px 0 8px;
     -webkit-font-smoothing: antialiased;
     float: left;
+    /* display is now 'block' see the note above */
   }
 
   &:first-child:before {
@@ -506,10 +510,10 @@ td, th{
       padding: 0 10px;
     }
 
-    /* sort out borders */
     thead {
       border: 0;
       border-right: 1px solid $table-border-color;
+      /* sort out borders */
     }
   }
 

--- a/sass/components/_materialbox.scss
+++ b/sass/components/_materialbox.scss
@@ -9,7 +9,7 @@
   cursor: zoom-in;
   position: relative;
   transition: opacity .4s;
-  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 
   &.active {
     cursor: zoom-out;

--- a/sass/components/_waves.scss
+++ b/sass/components/_waves.scss
@@ -80,7 +80,7 @@
 
 .waves-circle {
   transform: translateZ(0);
-  -webkit-mask-image: -webkit-radial-gradient(circle, white 100%, black 100%);
+  mask-image: -webkit-radial-gradient(circle, white 100%, black 100%);
 }
 
 .waves-input-wrapper {
@@ -101,7 +101,7 @@
   height: 2.5em;
   line-height: 2.5em;
   border-radius: 50%;
-  -webkit-mask-image: none;
+  mask-image: none;
 }
 
 .waves-block {

--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -23,7 +23,7 @@
     user-select: none;
   }
 
-  /* checkbox aspect */
+  // checkbox aspect
   + span:not(.lever):before,
   &:not(.filled-in) + span:not(.lever):after {
     content: '';


### PR DESCRIPTION
Fix minor CSS issues

## Proposed changes
 - mask-image and backface-visibility were hardcoded for -webkit causing their standard counterparts to be skipped.  webkit tags are replace with standard ones, so postcss is allowed to add webkit versions  
 - warning (for display: inline-block) is added for float:left
 - /* checkbox aspect*/ comment was causing an empty ruleset, replaced with proper comment line definition

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
