### PR TITLE
Button margin

### DIFF
--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -9,7 +9,7 @@
   padding: $button-padding;
   text-transform: uppercase;
   vertical-align: middle;
-  margin: 1%;
+  margin-bottom: 1%;
   -webkit-tap-highlight-color: transparent; // Gets rid of tap active state
 }
 

--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -9,6 +9,7 @@
   padding: $button-padding;
   text-transform: uppercase;
   vertical-align: middle;
+  margin: 1%;
   -webkit-tap-highlight-color: transparent; // Gets rid of tap active state
 }
 


### PR DESCRIPTION
## Proposed changes
Added 1% bottom-margin to buttons, so that when a button is displayed as a block element there will be spaces between them and other elements

## Screenshots (if appropriate) or codepen:
Before: 
![image](https://user-images.githubusercontent.com/18077352/63215678-0d9ace80-c0df-11e9-9a79-1888bce4c798.png)

After:
![image](https://user-images.githubusercontent.com/18077352/63215667-ed6b0f80-c0de-11e9-9ae1-510bd10d0896.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
