### PR TITLE
Typos in upgrade guide

### DIFF
--- a/v1-upgrade-guide.md
+++ b/v1-upgrade-guide.md
@@ -56,7 +56,7 @@
 
 ## Modal
 - Change attribute `data-activates` to `data-target`
-- Removed ready and complete callback, use onOpenEnd and onOpenEnd callback instead
+- Removed ready and complete callbacks, use onOpenEnd and onCloseEnd callbacks instead
 
 
 ## Scrollfire
@@ -77,7 +77,7 @@
 - Rename plugin call `.sideNav()` to `.sidenav()`
 - Sidenav option `closeOnClick` no longer exists
   - Instead apply the class `.sidenav-close` to any item in the Sidenav that you wish to trigger a close.
-- Removed onOpen and onClose callback, use onOpenEnd and onCloseEnd callback instead
+- Removed onOpen and onClose callbacks, use onOpenEnd and onCloseEnd callbacks instead
 - Rename `fixed` class to `sidenav-fixed`
 - Rename methods `show` and `hide` to `open` and `close` respectively
 


### PR DESCRIPTION
## Proposed changes

Typos in upgrade guide: the Modal's `complete` callback was renamed `onCloseEnd`, not `onOpenEnd`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
