### PR TITLE
Refine the documentation of the `container` attributes of some components

### DIFF
--- a/jade/page-contents/dropdown_content.html
+++ b/jade/page-contents/dropdown_content.html
@@ -95,9 +95,9 @@
             </tr>
             <tr>
               <td>container</td>
-              <td>Element</td>
+              <td>Element || String</td>
               <td>null</td>
-              <td>Provide an element that will be the bounding container of the dropdown.</td>
+              <td>Provide an element or a selector for an element that will be the bounding container of the dropdown.</td>
             </tr>
             <tr>
               <td>coverTrigger</td>

--- a/jade/page-contents/pickers_content.html
+++ b/jade/page-contents/pickers_content.html
@@ -131,9 +131,9 @@
               </tr>
               <tr>
                 <td>container</td>
-                <td>Element</td>
+                <td>Element || String</td>
                 <td>null</td>
-                <td>Specify a DOM element to render the calendar in, by default it will be placed before the input.</td>
+                <td>Specify a DOM element or a selector for an element to render the calendar in, by default it will be placed before the input.</td>
               </tr>
               <tr>
                 <td>showClearBtn</td>
@@ -531,9 +531,9 @@ instance.destroy();
               </tr>
               <tr>
                 <td>container</td>
-                <td>String</td>
+                <td>Element || String</td>
                 <td>null</td>
-                <td>Specify a selector for a DOM element to render the calendar in, by default it will be placed before the input.</td>
+                <td>Specify a DOM element or a selector for an element to render the calendar in, by default it will be placed before the input.</td>
               </tr>
               <tr>
                 <td>showClearBtn</td>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -38,7 +38,7 @@
        * @prop {String} [alignment='left'] - Edge which the dropdown is aligned to
        * @prop {Boolean} [autoFocus=true] - Automatically focus dropdown el for keyboard
        * @prop {Boolean} [constrainWidth=true] - Constrain width to width of the button
-       * @prop {Element} container - Container element to attach dropdown to (optional)
+       * @prop {(Element|string)} container - Container element or element selector to attach dropdown to (optional)
        * @prop {Boolean} [coverTrigger=true] - Place dropdown over trigger
        * @prop {Boolean} [closeOnClick=true] - Close on click of dropdown item
        * @prop {Boolean} [hover=false] - Open dropdown on hover


### PR DESCRIPTION
## Proposed changes

There are multiple components that allow the user to specify a HTML element, that should be uses as a container for the rendering of their dynamically added child HTML components.
Those components are: Date-Picker, Time-Picker and Dropdown.

Unfortunately this container attributes are not documented fully/consistently, so I updated the documentation to improve that.

## Types of changes

- [x] Documentation improvement
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Contains only the non-breaking documentation changes, originally submitted in #6044 