### PR TITLE
Footer Padding

### DIFF
--- a/jade/page-contents/footer_content.html
+++ b/jade/page-contents/footer_content.html
@@ -25,10 +25,10 @@
                 </ul>
               </div>
             </div>
-          </div>
-          <div class="footer-copyright">
-            © 2014 Copyright Text
-            <a class="grey-text text-lighten-4 right" href="#!">More Links</a>
+            <div class="footer-copyright">
+              © 2014 Copyright Text
+              <a class="grey-text text-lighten-4 right" href="#!">More Links</a>
+            </div>
           </div>
         </footer>
         <div class="row">

--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -1010,6 +1010,7 @@ body.parallax-demo footer {
   .footer-copyright {
     color: inherit;
     background-color: transparent;
+    padding: 10px 20px;
   }
 }
 

--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -1010,7 +1010,6 @@ body.parallax-demo footer {
   .footer-copyright {
     color: inherit;
     background-color: transparent;
-    padding: 10px 20px;
   }
 }
 


### PR DESCRIPTION
## Proposed changes
Added 20px left-right-padding to footer-copyright, so that whenever someone opens the footer section in the documentation, the copyright text will have some gap between the text and its borders.
It looks in a manner for the documentation readers.

## Screenshots (if appropriate) or codepen:
**Before:**
![footer-before](https://user-images.githubusercontent.com/45182517/66225483-f7c68480-e6f1-11e9-9f56-19b7637ba87d.PNG)

**After:**
![footer-after](https://user-images.githubusercontent.com/45182517/66225520-0ca31800-e6f2-11e9-9523-991f6dc75509.PNG)



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
