### PR TITLE
fix: update tooltip delay info to correct increments

### DIFF
--- a/jade/page-contents/tooltips_content.html
+++ b/jade/page-contents/tooltips_content.html
@@ -57,13 +57,13 @@
             <tr>
               <td>exitDelay</td>
               <td>Number</td>
-              <td>0</td>
+              <td>200</td>
               <td>Delay time before tooltip disappears.</td>
             </tr>
             <tr>
               <td>enterDelay</td>
               <td>Number</td>
-              <td>200</td>
+              <td>0</td>
               <td>Delay time before tooltip appears.</td>
             </tr>
             <tr>


### PR DESCRIPTION
## Proposed changes
This fixes issue #6468 where the `exitDelay` and `enterDelay` times are reversed.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
