### PR TITLE
Update updateTextFields and add collapsible-irgnore class

### DIFF
--- a/js/collapsible.js
+++ b/js/collapsible.js
@@ -109,7 +109,7 @@
      */
     _handleCollapsibleClick(e) {
       let $header = $(e.target).closest('.collapsible-header');
-      if (e.target && $header.length) {
+      if (e.target && $header.length && (!$(e.target).hasClass('collapsible-ignore'))) {
         let $collapsible = $header.closest('.collapsible');
         if ($collapsible[0] === this.el) {
           let $collapsibleLi = $header.closest('li');

--- a/js/forms.js
+++ b/js/forms.js
@@ -1,6 +1,6 @@
 (function($) {
   // Function to update labels of text fields
-  M.updateTextFields = function() {
+  M.updateTextFields = function(withValidation=false) {
     let input_selector =
       'input[type=text], input[type=password], input[type=email], input[type=url], input[type=tel], input[type=number], input[type=search], input[type=date], input[type=time], textarea';
     $(input_selector).each(function(element, index) {
@@ -17,6 +17,8 @@
       } else {
         $this.siblings('label').removeClass('active');
       }
+      if(withValidation)
+        M.validate_field($(element))
     });
   };
 


### PR DESCRIPTION
Proposed changes
Added a class (collapsible-ignore) check to the onClick handler for the Collapsible Header. This class gives the possibility to add input elements in the header and to click them without triggering the collapse action.
Added an optional argument to the UpdateInputFields method to validate the Fields once updated. Default is false.

Types of changes
-Added class check for collapsible-ignore to prevent collapse action from collapsible header
-Added optional argument to UpdateInputFields to validate Fields