### PR TITLE
datepicker font size now displays month correctly

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -29,6 +29,7 @@
       border-bottom: none;
       text-align: center;
       margin: 0;
+      font-size: 1.0rem;
     }
 
     .caret {

--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -30,6 +30,7 @@
       text-align: center;
       margin: 0;
       font-size: 1.0rem;
+      text-overflow: ellipsis;
     }
 
     .caret {
@@ -42,7 +43,7 @@
   }
 
   .select-month input {
-    width: 80px;
+    width: 120px;
   }
 }
 


### PR DESCRIPTION

## Proposed changes
Added changes to datepicker specifically when selecting a month because the size of the text was to big and now it shows with a correct size

## Pre-fix image
<img width="624" alt="Screen Shot 2019-11-26 at 12 25 07 PM" src="https://user-images.githubusercontent.com/10965484/69665563-dcb82700-1047-11ea-9b63-e91b18aa21b3.png">

## Fixed 
<img width="626" alt="Screen Shot 2019-11-26 at 12 26 37 PM" src="https://user-images.githubusercontent.com/10965484/69665654-0ec98900-1048-11ea-96eb-a71c5434abb6.png">

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
