### PR TITLE
fix dropdown position when coverTrigger is false

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -427,7 +427,7 @@
           if (alignments.spaceOnTop > alignments.spaceOnBottom) {
             verticalAlignment = 'bottom';
             idealHeight += alignments.spaceOnTop;
-            idealYPos -= alignments.spaceOnTop - 20; // add back padding space
+            idealYPos -= this.options.coverTrigger ? alignments.spaceOnTop - 20 : alignments.spaceOnTop - 20 + triggerBRect.height;
           } else {
             idealHeight += alignments.spaceOnBottom;
           }


### PR DESCRIPTION
## Proposed changes
Correction of the calculation of the position of the dropdown when the coverTrigger option is false and the dropdown is near the bottom of the window. 
This PR fixes issue #6279, related to the position of the dropdown of the autocomplete component.

## Screenshots (if appropriate) or codepen:
![autocomplete](https://user-images.githubusercontent.com/7862054/71850102-25c4b780-3099-11ea-93b6-91b9fd99bf5f.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
