### PR TITLE
fix datepicker closing invoked by modal component

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -269,6 +269,9 @@
         },
         onCloseEnd: () => {
           this.isOpen = false;
+          if (typeof this.options.onClose === 'function') {
+            this.options.onClose.call(this);
+          }
         }
       });
     }
@@ -949,10 +952,6 @@
         return;
       }
 
-      this.isOpen = false;
-      if (typeof this.options.onClose === 'function') {
-        this.options.onClose.call(this);
-      }
       this.modal.close();
       return this;
     }

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -234,6 +234,17 @@
       }
     }
 
+    closeSelects() {
+      let oldYearSelect = this.calendarEl.querySelector('.orig-select-year');
+      if (oldYearSelect) {
+        M.FormSelect.getInstance(oldYearSelect).dropdown.close();
+      }
+      let oldMonthSelect = this.calendarEl.querySelector('.orig-select-month');
+      if (oldMonthSelect) {
+        M.FormSelect.getInstance(oldMonthSelect).dropdown.close();
+      }
+    }
+
     _insertHTMLIntoDOM() {
       if (this.options.showClearBtn) {
         $(this.clearBtn).css({ visibility: '' });
@@ -253,6 +264,9 @@
     _setupModal() {
       this.modalEl.id = 'modal-' + this.id;
       this.modal = M.Modal.init(this.modalEl, {
+        onCloseStart: () => {
+          this.closeSelects();
+        },
         onCloseEnd: () => {
           this.isOpen = false;
         }
@@ -513,9 +527,7 @@
       }
       return (
         `<td data-day="${opts.day}" class="${arr.join(' ')}" aria-selected="${ariaSelected}">` +
-        `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${
-          opts.month
-        }" data-day="${opts.day}">${opts.day}</button>` +
+        `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${opts.month}" data-day="${opts.day}">${opts.day}</button>` +
         '</td>'
       );
     }


### PR DESCRIPTION
## Proposed changes

Datepicker component is shown inside Modal component. Datepicker close method asks Modal component to close, but Modal doesn't informDatepicker that is is closed/hidden.

Main issue is with ESC keypress that is handled by Modal, but also programmatical closing of the Modal element will not correctly handle Datepicker closing.

Problems that is this causing:
* #6092 - if year/month dropdown is visible to user and ESC is pressed, it will close calendar, but the dropdown stays open
* #6500 - if ESC is pressed the Datepicker will not fire onClose event

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
