### PR TITLE
Fix incorrect resizing of sidenav

### DIFF
--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -358,10 +358,13 @@
     _handleWindowResize() {
       // Only handle horizontal resizes
       if (this.lastWindowWidth !== window.innerWidth) {
-        if (window.innerWidth > 992) {
-          this.open();
-        } else {
+        if (window.innerWidth <= 992) {
           this.close();
+        }
+
+        if (window.innerWidth > 992 && this.lastWindowWidth <= 992) {
+          this.close();
+          this.open();
         }
       }
 


### PR DESCRIPTION
## Proposed changes
This fixes issue #6350. When the sidenav is in non-fixed mode and opened, then the window is maximized making the window wider than it was previously, the darkening effect of the sidenav would stay. This has now been changed, so the darkening effect properly disappears.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
