### PR TITLE
datepicker: add yearRangeReverse property sort year in reverse order

### DIFF
--- a/jade/page-contents/pickers_content.html
+++ b/jade/page-contents/pickers_content.html
@@ -112,6 +112,12 @@
                 <td>Number of years either side, or array of upper/lower range.</td>
               </tr>
               <tr>
+                <td>yearRangeReverse</td>
+                <td>Boolean</td>
+                <td>false</td>
+                <td>Sort year range in reverse order</td>
+              </tr>
+              <tr>
                 <td>isRTL</td>
                 <td>Boolean</td>
                 <td>false</td>

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -513,9 +513,7 @@
       }
       return (
         `<td data-day="${opts.day}" class="${arr.join(' ')}" aria-selected="${ariaSelected}">` +
-        `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${
-          opts.month
-        }" data-day="${opts.day}">${opts.day}</button>` +
+        `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${opts.month}" data-day="${opts.day}">${opts.day}</button>` +
         '</td>'
       );
     }
@@ -604,11 +602,15 @@
         j = 1 + year + opts.yearRange;
       }
 
+      let years = [];
       for (arr = []; i < j && i <= opts.maxYear; i++) {
         if (i >= opts.minYear) {
-          arr.push(`<option value="${i}" ${i === year ? 'selected="selected"' : ''}>${i}</option>`);
+          years.push(
+            `<option value="${i}" ${i === year ? 'selected="selected"' : ''}>${i}</option>`
+          );
         }
       }
+      arr = arr.concat(opts.yearRangeReverse ? years.reverse() : years);
 
       yearHtml = `<select class="datepicker-select orig-select-year" tabindex="-1">${arr.join(
         ''

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -602,15 +602,14 @@
         j = 1 + year + opts.yearRange;
       }
 
-      let years = [];
       for (arr = []; i < j && i <= opts.maxYear; i++) {
         if (i >= opts.minYear) {
-          years.push(
-            `<option value="${i}" ${i === year ? 'selected="selected"' : ''}>${i}</option>`
-          );
+          arr.push(`<option value="${i}" ${i === year ? 'selected="selected"' : ''}>${i}</option>`);
         }
       }
-      arr = arr.concat(opts.yearRangeReverse ? years.reverse() : years);
+      if (opts.yearRangeReverse) {
+        arr.reverse();
+      }
 
       yearHtml = `<select class="datepicker-select orig-select-year" tabindex="-1">${arr.join(
         ''


### PR DESCRIPTION
This add yearRangeReverse property to date picker to sort year range in reverse order

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
