### PR TITLE
Update input width in _chips.scss sass component

### DIFF
--- a/sass/components/_chips.scss
+++ b/sass/components/_chips.scss
@@ -62,6 +62,7 @@
     outline: 0;
     margin: 0;
     padding: 0 !important;
+    width: 120px !important;
     width: fit-content !important;
     min-width: 100px;
     max-width: 200px;

--- a/sass/components/_chips.scss
+++ b/sass/components/_chips.scss
@@ -62,7 +62,9 @@
     outline: 0;
     margin: 0;
     padding: 0 !important;
-    width: 120px !important;
+    width: fit-content !important;
+    min-width: 100px;
+    max-width: 200px;
   }
 
   .input:focus {


### PR DESCRIPTION
This is a minor but suitable change which updates the width of input field (for adding new chips) from fixed 120px to fit-content, with same !important weight. Also, the min-width and max-width properties are set to limit its size between 100px and 200px. With this change, the input placeholder (if limited to under 200px) will not get cropped, and it will also have a better fit into the input field, thereby offering it more flexibility to adapt the content.

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Basically, this change fixes the issue that I had encountered recently with the placeholder or text of the input before pressing enter to convert it to a chip. Please have a look at how this small change affects the chips input (Screenshot from Google Chrome):

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->
![Capture-ChangePropose](https://user-images.githubusercontent.com/57865187/83871438-ac1b1d80-a74d-11ea-97ca-673b94d78ad7.PNG)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
