### PR TITLE
Fixed letter-spacing by adding px at end

### DIFF
--- a/sass/components/_table_of_contents.scss
+++ b/sass/components/_table_of_contents.scss
@@ -16,7 +16,7 @@
     padding-left: 20px;
     height: 1.5rem;
     line-height: 1.5rem;
-    letter-spacing: .4;
+    letter-spacing: .4px;
     display: inline-block;
 
     &:hover {

--- a/sass/components/date_picker/_default.date.scss
+++ b/sass/components/date_picker/_default.date.scss
@@ -152,7 +152,7 @@
 .picker__day--today {
   position: relative;
   color: #595959;
-  letter-spacing: -.3;
+  letter-spacing: -.3px;
   padding: .75rem 0;
   font-weight: 400;
   border: 1px solid transparent;


### PR DESCRIPTION
## Proposed changes
Resolves #6492 - letter-spacing property requires a unit at the end, so added px 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
