### PR TITLE
Autocomplete respect dropdownOptions. Fix placement when container is…

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -50,7 +50,7 @@
       this.$inputField = this.$el.closest('.input-field');
       this.$active = $();
       this._mousedown = false;
-      this._setupDropdown();
+      this._setupDropdown(options.dropdownOptions);
 
       this._setupEventHandlers();
     }
@@ -145,7 +145,7 @@
     /**
      * Setup dropdown
      */
-    _setupDropdown() {
+    _setupDropdown(dropdownOptions) {
       this.container = document.createElement('ul');
       this.container.id = `autocomplete-options-${M.guid()}`;
       $(this.container).addClass('autocomplete-content dropdown-content');
@@ -158,7 +158,8 @@
         coverTrigger: false,
         onItemClick: (itemEl) => {
           this.selectOption($(itemEl));
-        }
+        },
+        ...dropdownOptions
       });
 
       // Sketchy removal of dropdown click handler

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -398,8 +398,8 @@
       if (this.options.container == document.body) {
         idealHeight = dropdownBRect.height;
         idealWidth = triggerBRect.width;
-        idealXPos = triggerBRect.left;
-        idealYPos = triggerBRect.top;
+        idealXPos = triggerBRect.left + window.scrollX;
+        idealYPos = triggerBRect.top + window.scrollY;
       } else {
         idealHeight = dropdownBRect.height;
         idealWidth = dropdownBRect.width;

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -390,10 +390,22 @@
       let triggerBRect = this.el.getBoundingClientRect();
       let dropdownBRect = this.dropdownEl.getBoundingClientRect();
 
-      let idealHeight = dropdownBRect.height;
-      let idealWidth = dropdownBRect.width;
-      let idealXPos = triggerBRect.left - dropdownBRect.left;
-      let idealYPos = triggerBRect.top - dropdownBRect.top;
+      let idealHeight;
+      let idealWidth;
+      let idealXPos;
+      let idealYPos;
+
+      if (this.options.container == document.body) {
+        idealHeight = dropdownBRect.height;
+        idealWidth = triggerBRect.width;
+        idealXPos = triggerBRect.left;
+        idealYPos = triggerBRect.top;
+      } else {
+        idealHeight = dropdownBRect.height;
+        idealWidth = dropdownBRect.width;
+        idealXPos = triggerBRect.left - dropdownBRect.left;
+        idealYPos = triggerBRect.top - dropdownBRect.top;
+      }
 
       let dropdownBounds = {
         left: idealXPos,


### PR DESCRIPTION
… document.body

## Proposed changes
Autocomplete should pass dropdownOptions to the dropdown. As described in https://github.com/Dogfalo/materialize/issues/1385, Dropdown options can be used to customize the container used by Dropdown. Autocomplete is built on Dropdown, so should pass Dropdown options.

Our specific need for this is so that Autocomplete options don't get cut off within a modal. 

## Screenshots (if appropriate) or codepen:
Current v1.0.0 behavior:
![Screen Shot 2020-09-21 at 4 24 28 PM](https://user-images.githubusercontent.com/844258/93823236-1be2e480-fc27-11ea-9a53-96c78e7bc714.png)

With these changes, we can specify `dropdownOptions: { container: document.body },` and get:
![Screen Shot 2020-09-21 at 4 18 35 PM](https://user-images.githubusercontent.com/844258/93823282-2d2bf100-fc27-11ea-90c4-a0a0e5eba4ab.png)


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
