### PR TITLE
Add stopPropagation to the Dropdown class

### DIFF
--- a/jade/page-contents/dropdown_content.html
+++ b/jade/page-contents/dropdown_content.html
@@ -153,6 +153,12 @@
               <td>null</td>
               <td>Function called when dropdown finishes exiting.</td>
             </tr>
+            <tr>
+              <td>stopPropagation</td>
+              <td>Boolean</td>
+              <td>false</td>
+              <td>Stop the propagation of a click event for the dropdown trigger</td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -15,7 +15,8 @@
     onOpenEnd: null,
     onCloseStart: null,
     onCloseEnd: null,
-    onItemClick: null
+    onItemClick: null,
+    stopPropagation: false
   };
 
   /**
@@ -48,6 +49,7 @@
        * @prop {Function} onOpenEnd - Function called when dropdown finishes opening
        * @prop {Function} onCloseStart - Function called when dropdown starts closing
        * @prop {Function} onCloseEnd - Function called when dropdown finishes closing
+       * @prop {Boolean} [stopPropagation=false] - Constrain width to width of the button
        */
       this.options = $.extend({}, Dropdown.defaults, options);
 
@@ -170,6 +172,11 @@
 
     _handleClick(e) {
       e.preventDefault();
+
+      if (stopPropagation) {
+        e.stopPropagation();
+      }
+
       this.open();
     }
 


### PR DESCRIPTION
This commit re-adds the stopPropagation property to a dropdown for the dropdown trigger

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Adding the stopPropagation property allows an html element that contains a dropdown trigger to have a click event that does not get triggered when selecting the dropdown trigger.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

In [this](https://codepen.io/brendanbehr/pen/xxOjvWW) example I have two chips with an ellipsis icon as the dropdown trigger, The left chip fires the chip event when you click on the chip and anything related to the dropdown trigger.  The right chip contains the click event on the text which is not ideal because there is un-clickable space on the chip and if I want to add an icon to the left of the text I would need to wrap the icon and text in a span that has a click event.  

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
