### PR TITLE
Allow timepicker container to be an element

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -210,7 +210,8 @@
       this.modalEl.id = 'modal-' + this.id;
 
       // Append popover to input by default
-      let containerEl = document.querySelector(this.options.container);
+      const optEl = this.options.container;
+      let containerEl = (optEl instanceof HTMLElement?optEl:document.querySelector(optEl));
       if (this.options.container && !!containerEl) {
         this.$modalEl.appendTo(containerEl);
       } else {


### PR DESCRIPTION
## Proposed changes
The datepicker requires an element to be specified for the container, the time picker requires a selector string. This change allows an element to be specified while retaining the original method as a fallback

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
