### PR TITLE
Add userDismissible option for toasts

### DIFF
--- a/jade/page-contents/toasts_content.html
+++ b/jade/page-contents/toasts_content.html
@@ -72,6 +72,12 @@
               <td>0.8</td>
               <td>The percentage of the toast's width it takes for a drag to dismiss a Toast.</td>
             </tr>
+            <tr>
+              <td>userDismissible</td>
+              <td>Boolean</td>
+              <td>true</td>
+              <td>If true, the user is allowed to dismiss the Toast by dragging it, otherwise it is only possible to dismiss the Toast programmatically as described below.</td>
+            </tr>
           </tbody>
         </table>
         <br>

--- a/js/toasts.js
+++ b/js/toasts.js
@@ -8,7 +8,8 @@
     outDuration: 375,
     classes: '',
     completeCallback: null,
-    activationPercent: 0.8
+    activationPercent: 0.8,
+    userDismissible: true
   };
 
   class Toast {
@@ -97,13 +98,15 @@
       if (e.target && $(e.target).closest('.toast').length) {
         let $toast = $(e.target).closest('.toast');
         let toast = $toast[0].M_Toast;
-        toast.panning = true;
-        Toast._draggedToast = toast;
-        toast.el.classList.add('panning');
-        toast.el.style.transition = '';
-        toast.startingXPos = Toast._xPos(e);
-        toast.time = Date.now();
-        toast.xPos = Toast._xPos(e);
+        if (toast.options.userDismissible) {
+          toast.panning = true;
+          Toast._draggedToast = toast;
+          toast.el.classList.add('panning');
+          toast.el.style.transition = '';
+          toast.startingXPos = Toast._xPos(e);
+          toast.time = Date.now();
+          toast.xPos = Toast._xPos(e);
+        }
       }
     }
 


### PR DESCRIPTION
## Proposed changes
Introduced an additional option for toasts to allow them only to be dismissed programmatically and not by swiping. However, this option defaults to true, so there are no behaviour changes regarding the current version in case this option is omitted in M.toast({...}). 

This can be useful for several cases:
- when a preloader bar is included in a toast to show the progress of an async file upload.
- when the user is offline. The toast can then be dismissed as soon as connectivity is restored.
...


## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
