### PR TITLE
Fix issue #6669 - Remove the css implementation from the global HTML button element

### DIFF
--- a/sass/components/forms/_forms.scss
+++ b/sass/components/forms/_forms.scss
@@ -3,11 +3,6 @@ select:focus {
   outline: $select-focus;
 }
 
-button:focus {
-  outline: none;
-  background-color: $button-background-focus;
-}
-
 label {
   font-size: $label-font-size;
   color: $input-border-color;


### PR DESCRIPTION
1. The styling of the button should be in `_buttons.scss` not in `_forms.scss` .
2. `_button.scss` already have a `:focus` state.
3. The styling shouldn't be applied to the global HTML `button` element and should instead be applied to the `.btn` class.

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
