### PR TITLE
Remove button:focus styles from _forms.scss

### DIFF
--- a/sass/components/forms/_forms.scss
+++ b/sass/components/forms/_forms.scss
@@ -3,11 +3,6 @@ select:focus {
   outline: $select-focus;
 }
 
-button:focus {
-  outline: none;
-  background-color: $button-background-focus;
-}
-
 label {
   font-size: $label-font-size;
   color: $input-border-color;


### PR DESCRIPTION
## Proposed changes
Remove styling global `button` element in `_forms.scss`
```
button:focus {
  outline: none;
  background-color: $button-background-focus;
}
```
Now button styles are applied within `.btn` class

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
