### PR TITLE
fix(dropdown): allow anchor navigation for real href links

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -243,7 +243,18 @@
      * @param {Event} e
      */
     _handleDropdownClick(e) {
-      // onItemClick callback
+      const anchor = e.target.closest('a');
+      if (anchor) {
+        const href = anchor.getAttribute('href') || '';
+
+        // If href is NOT an in-page hash AND NOT javascript:
+        if (href && href.charAt(0) !== '#' && !href.startsWith('javascript:')) {
+          // Allow browser navigation
+          return;
+        }
+      }
+
+      // onItemClick callback 
       if (typeof this.options.onItemClick === 'function') {
         let itemEl = $(e.target).closest('li')[0];
         this.options.onItemClick.call(this, itemEl);


### PR DESCRIPTION

This PR fixes the issue where clicking a dropdown item containing a normal
`<a href="...">` link does not navigate to its target page.

Materialize’s dropdown click logic currently prevents the default click behavior
for all items, which unintentionally blocks navigation for legitimate links.

This change adds a safe early-return in `_handleDropdownClick()`:

* If the clicked element is an `<a>`
* **AND** the `href` is not a hash link (`#something`)
* **AND** not a `javascript:` pseudo-protocol

…then the browser is allowed to perform normal navigation.

This preserves all existing behavior for:

* `href="#"` (in-page navigation)
* `href="javascript:void(0)"` (JS-only actions)
* `onItemClick` callbacks
* keyboard-based selection behavior

Fixes: **#6683**

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist

* [x] I have read the **CONTRIBUTING** document.
* [ ] My change requires documentation updates.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes. *(Not required for this UI fix.)*
* [x] All existing tests pass (build completed successfully).

---




