### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Before opening an issue here make sure, that you have read the template completly through -->
+<!-- Before opening an issue here make sure, that you have read the template completely through -->
 
 When asking general "how to" questions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bolded styling surrounded by emojis indicates a breaking change.
   - Now correctly removes all event listeners on destroy
 
 - Materialbox
-  - Destroy now removed wrapper element added during intialization
+  - Destroy now removed wrapper element added during initialization
 
 - Pushpin
   - Fixed bug on IE11 where class was not removed properly
@@ -176,7 +176,7 @@ Bolded styling surrounded by emojis indicates a breaking change.
 
 - Datepicker
   - Fixed date format option
-  - Scrollbar no longer unecessarily appears when using datepicker
+  - Scrollbar no longer unnecessarily appears when using datepicker
   - Fixed bug where using month and year selectors didn't change date
 
 - Dropdown
@@ -443,7 +443,7 @@ Bolded styling surrounded by emojis indicates a breaking change.
 - JavaScript Initialization no longer needed for many components
 - HTML options through data-attributes
 - Site colors can be defined through Primary and Secondary color in Sass
-- Tables no longer resonsive by default
+- Tables no longer responsive by default
 
 
 ## v0.95.0 (Jan 17, 2015)

--- a/v1-changelog.md
+++ b/v1-changelog.md
@@ -1,6 +1,6 @@
 ## Auto Init
-- Componenets are no longer initialized automatically on document load by Materialize
-- Added function `M.AutoInit()` that initializes all componenets
+- Components are no longer initialized automatically on document load by Materialize
+- Added function `M.AutoInit()` that initializes all components
 
 ## Autocomplete
 - Added sort function to order completion results


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.